### PR TITLE
pkvm: x86: hide EPT A/D support from pKVM high

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/nested.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/nested.c
@@ -65,6 +65,9 @@ int read_vmx_msr(struct kvm_vcpu *vcpu, unsigned long msr, u64 *val)
 			/* not support vmfunc */
 			low = high = 0;
 			break;
+		case MSR_IA32_VMX_EPT_VPID_CAP:
+			low &= ~VMX_EPT_AD_BIT;
+			break;
 		default:
 			err = -EACCES;
 			break;

--- a/arch/x86/kvm/vmx/pkvm/hyp/nested.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/nested.h
@@ -23,6 +23,7 @@ void pkvm_init_nest(void);
 #define LIST_OF_VMX_MSRS        		\
 	MSR_IA32_VMX_MISC,                      \
 	MSR_IA32_VMX_PROCBASED_CTLS2,           \
+	MSR_IA32_VMX_EPT_VPID_CAP,              \
 	MSR_IA32_VMX_VMFUNC
 
 bool is_vmx_msr(unsigned long msr);


### PR DESCRIPTION
The Accessed and Dirty bits in virtual EPT which is maintained by L1 KVM high don't reflect the actual access status of L2 GPAs.  If KVM uses these bits as indications of whether a GFN can be swapped out, it could cause problems.

If we hide the A/D bits from KVM, it may correctly emulate the EPT A/D bits with the access tracking faults facility.

Signed-off-by: Zide Chen <zide.chen@intel.com>