### PR TITLE
pkvm: x86: Pass iommu ecap value to sync_data

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
@@ -126,6 +126,8 @@ do {									\
 #define QI_DESC_PC_DID(qw)		((qw & GENMASK_ULL(31, 16)) >> 16)
 #define QI_DESC_PC_PASID(qw)		((qw & GENMASK_ULL(51, 32)) >> 32)
 
+#define pgt_to_pkvm_iommu(pgt) container_of(pgt, struct pkvm_iommu, pgt)
+
 struct pasid_dir_entry {
 	u64 val;
 };


### PR DESCRIPTION
The sync_data object is used for passing information for shadowing page tables. Since the legacy mode has been supported, when doing shadowing, the info in sdata->iommu_ecap field is needed to identify which mode the iommu is working in.

This patch also changes the function name iommu_sm_id_sync_entry() to iommu_id_sync_entry(), since this function works for both legacy mode and scalable mode.

Signed-off-by: Tina Zhang <tina.zhang@intel.com>