### PR TITLE
Passthrough device support for protected VM with SM IOMMU

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -183,7 +183,12 @@ static inline unsigned long pkvm_shadow_ept_pgtable_pages(int nr_vm)
 	/* Allow 1 GiB for MMIO mappings for each VM */
 	 res += __pkvm_pgtable_max_pages(SZ_1G >> PAGE_SHIFT) * nr_vm;
 
-	return res;
+	 /*
+	  * Each shadow VM has two page tables. One is used to manage page state
+	  * and reused as IOMMU second-level pagetable for passthrough device in
+	  * protected VM. Another one is used as shadow EPT.
+	  */
+	return (res * 2);
 }
 
 u64 pkvm_total_reserve_pages(void);

--- a/arch/x86/include/asm/pkvm.h
+++ b/arch/x86/include/asm/pkvm.h
@@ -18,6 +18,7 @@
 #define PKVM_HC_ACTIVATE_IOMMU		7
 #define PKVM_HC_TLB_REMOTE_FLUSH_RANGE	8
 #define PKVM_HC_SET_MMIO_VE		9
+#define PKVM_HC_ADD_PTDEV		10
 
 /*
  * 15bits for PASID, DO NOT change it, based on it,

--- a/arch/x86/kvm/vmx/pkvm/hyp/Makefile
+++ b/arch/x86/kvm/vmx/pkvm/hyp/Makefile
@@ -18,6 +18,7 @@ pkvm-hyp-obj	:= $(obj)/vmx_asm.o $(obj)/vmexit.o \
 		   $(obj)/vmx.o $(obj)/vmsr.o \
 		   $(obj)/iommu.o $(obj)/iommu_debug.o \
 		   $(obj)/mem_protect.o $(obj)/lapic.o \
+		   $(obj)/ptdev.o \
 		   $(obj)/trace.o
 
 virt-dir	:= $(objtree)/$(KVM_PKVM)

--- a/arch/x86/kvm/vmx/pkvm/hyp/cpu.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/cpu.h
@@ -28,10 +28,10 @@ static inline void pkvm_msr_write(u32 reg, u64 msr_val)
 	asm volatile (" wrmsr " : : "c" (reg), "a" ((u32)msr_val), "d" ((u32)(msr_val >> 32U)));
 }
 
-#define pkvm_wrmsr(msr, low, high)              \
-do {                                            \
-	u64 __val = (u64)high << 32 | (u64)low; \
-	pkvm_msr_write(msr, __val);             \
+#define pkvm_wrmsr(msr, low, high)                      \
+do {                                                    \
+	u64 __val = (u64)(high) << 32 | (u64)(low);     \
+	pkvm_msr_write(msr, __val);                     \
 } while (0)
 
 #define pkvm_wrmsrl(msr, val)   pkvm_msr_write(msr, val)

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -218,7 +218,7 @@ struct pkvm_pgtable_ops ept_ops = {
 	.default_prot = EPT_PROT_DEF,
 };
 
-static bool is_pgt_ops_ept(struct pkvm_pgtable *pgt)
+bool is_pgt_ops_ept(struct pkvm_pgtable *pgt)
 {
 	return pgt && (pgt->pgt_ops == &ept_ops);
 }

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -27,6 +27,7 @@
 
 static struct pkvm_pool host_ept_pool;
 static struct pkvm_pgtable host_ept;
+static struct pkvm_pgtable host_ept_notlbflush;
 static pkvm_spinlock_t _host_ept_lock = __PKVM_SPINLOCK_UNLOCKED;
 
 static struct pkvm_pool shadow_ept_pool;
@@ -114,6 +115,17 @@ struct pkvm_mm_ops host_ept_mm_ops = {
 	.put_page = host_ept_put_page,
 	.page_count = pkvm_page_count,
 	.flush_tlb = host_ept_flush_tlb,
+	.flush_cache = host_ept_flush_cache,
+};
+
+static struct pkvm_mm_ops host_ept_mm_ops_no_tlbflush = {
+	.phys_to_virt = pkvm_phys_to_virt,
+	.virt_to_phys = pkvm_virt_to_phys,
+	.zalloc_page = host_ept_zalloc_page,
+	.get_page = host_ept_get_page,
+	.put_page = host_ept_put_page,
+	.page_count = pkvm_page_count,
+	.flush_tlb = flush_tlb_noop,
 	.flush_cache = host_ept_flush_cache,
 };
 
@@ -316,7 +328,23 @@ int pkvm_host_ept_init(struct pkvm_pgtable_cap *cap,
 				  fls(cap->allowed_pgsz) - 1);
 
 	pkvm_hyp->host_vm.ept = &host_ept;
-	return pkvm_pgtable_init(&host_ept, &host_ept_mm_ops, &ept_ops, cap, true);
+	ret = pkvm_pgtable_init(&host_ept, &host_ept_mm_ops, &ept_ops, cap, true);
+	if (ret)
+		return ret;
+
+	/*
+	 * Prepare an instance for host EPT without doing TLB flushing.
+	 * This is used for some fastpath code which wants to avoid
+	 * doing TLB flushing for each host EPT modifications. It doesn't
+	 * mean TLB flushing is not needed. The user still needs to do
+	 * TLB flushing explicitly after finishing all the host EPT
+	 * modifications.
+	 */
+	host_ept_notlbflush = host_ept;
+	host_ept_notlbflush.mm_ops = &host_ept_mm_ops_no_tlbflush;
+	pkvm_hyp->host_vm.ept_notlbflush = &host_ept_notlbflush;
+
+	return 0;
 }
 
 int handle_host_ept_violation(unsigned long gpa)
@@ -504,7 +532,21 @@ static int pkvm_pgstate_pgt_map_leaf(struct pkvm_pgtable *pgt, unsigned long vad
 		ret = __pkvm_host_share_guest(map_phys, pgt, vaddr, level_size, data->prot);
 		break;
 	case KVM_X86_PROTECTED_VM:
-		ret = __pkvm_host_donate_guest(map_phys, pgt, vaddr, level_size, data->prot);
+		if (vm->need_prepopulation)
+			/*
+			 * As pgstate pgt is the source of the shadow EPT, only after pgstate
+			 * pgt is set up, shadow EPT can be set up. So protected VM will not be
+			 * able to use the memory donated in pgstate pgt before its shadow EPT
+			 * is setting up. So it is safe to use the fastpath to donate all the
+			 * pages to improve the pre-population performance. TLB flushing
+			 * can be done in the caller after the pre-population is done but before
+			 * setting up its shadow EPT.
+			 */
+			ret = __pkvm_host_donate_guest_fastpath(map_phys, pgt, vaddr,
+								level_size, data->prot);
+		else
+			ret = __pkvm_host_donate_guest(map_phys, pgt, vaddr,
+						       level_size, data->prot);
 		break;
 	default:
 		ret = -EINVAL;
@@ -812,6 +854,17 @@ static bool allow_shadow_ept_mapping(struct pkvm_shadow_vm *vm,
 	if (vm->need_prepopulation) {
 		if (populate_pgstate_pgt(pgstate_pgt))
 			return false;
+		/*
+		 * Explicitly flush TLB of the host EPT after populating the page
+		 * state pgt.
+		 *
+		 * During the population, some pages are donated from primary VM to
+		 * this VM with the fastpath interface to avoid doing TLB flushing
+		 * during each iteration of the page donation so that to have a fast
+		 * population performance. So still need to do TLB flushing in the
+		 * end after finishing all the donations.
+		 */
+		host_ept_flush_tlb(&host_ept);
 		vm->need_prepopulation = false;
 	}
 

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -31,6 +31,8 @@ static pkvm_spinlock_t _host_ept_lock = __PKVM_SPINLOCK_UNLOCKED;
 static struct pkvm_pool shadow_ept_pool;
 static struct rsvd_bits_validate ept_zero_check;
 
+static void flush_tlb_noop(struct pkvm_pgtable *pgt) { };
+
 static inline void pkvm_init_ept_page(void *page)
 {
 	/*
@@ -479,6 +481,25 @@ static struct pkvm_mm_ops shadow_ept_mm_ops = {
 	.flush_tlb = shadow_ept_flush_tlb,
 };
 
+/*
+ * pgstate_pgt_mm_ops is similar to the shadow_ept_mm_ops as its
+ * memory is reserved together with shadow EPT pages. The
+ * difference is that it doesn't have the flush_tlb callback as
+ * pgstate_pgt only works as IOMMU second-level page table for
+ * protected VM when there are passthrough devices, and in this
+ * case the memory is pinned, and the mapping is not allowed to
+ * be removed from pgstate_pgt.
+ */
+static struct pkvm_mm_ops pgstate_pgt_mm_ops = {
+	.phys_to_virt = pkvm_phys_to_virt,
+	.virt_to_phys = pkvm_virt_to_phys,
+	.zalloc_page = shadow_ept_zalloc_page,
+	.get_page = shadow_ept_get_page,
+	.put_page = shadow_ept_put_page,
+	.page_count = pkvm_page_count,
+	.flush_tlb = flush_tlb_noop,
+};
+
 static int pkvm_shadow_ept_map_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr, int level,
 				    void *ptep, struct pgt_flush_data *flush_data, void *arg)
 {
@@ -747,6 +768,27 @@ int pkvm_shadow_ept_init(struct shadow_ept_desc *desc)
 	flush_ept(desc->shadow_eptp);
 
 	return 0;
+}
+
+void pkvm_pgstate_pgt_deinit(struct pkvm_shadow_vm *vm)
+{
+	pkvm_spin_lock(&vm->lock);
+
+	pkvm_pgtable_destroy(&vm->pgstate_pgt, NULL);
+
+	pkvm_spin_unlock(&vm->lock);
+}
+
+int pkvm_pgstate_pgt_init(struct pkvm_shadow_vm *vm)
+{
+	struct pkvm_pgtable *pgt = &vm->pgstate_pgt;
+	struct pkvm_pgtable_cap cap = {
+		.level = pkvm_hyp->ept_iommu_pgt_level,
+		.allowed_pgsz = pkvm_hyp->ept_iommu_pgsz_mask,
+		.table_prot = VMX_EPT_RWX_MASK,
+	};
+
+	return pkvm_pgtable_init(pgt, &pgstate_pgt_mm_ops, &ept_ops, &cap, true);
 }
 
 /*

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -218,6 +218,11 @@ struct pkvm_pgtable_ops ept_ops = {
 	.default_prot = EPT_PROT_DEF,
 };
 
+static bool is_pgt_ops_ept(struct pkvm_pgtable *pgt)
+{
+	return pgt && (pgt->pgt_ops == &ept_ops);
+}
+
 int pkvm_host_ept_map(unsigned long vaddr_start, unsigned long phys_start,
 		unsigned long size, int pgsz_mask, u64 prot)
 {
@@ -271,28 +276,6 @@ void pkvm_flush_host_ept(void)
 	u64 eptp = pkvm_construct_eptp(host_ept.root_pa, host_ept.level);
 
 	flush_ept(eptp);
-}
-
-static void ept_mk_nopresent(struct pkvm_pgtable *pgt, void *ptep)
-{
-	u64 val;
-
-	val = READ_ONCE(*(u64 *)ptep) & ~VMX_EPT_RWX_MASK;
-	pgt->pgt_ops->pgt_set_entry(ptep, val);
-}
-
-static void ept_remap_with_newprot(struct pkvm_pgtable *pgt, int level, void *ptep, u64 new_prot)
-{
-	u64 old_pte = READ_ONCE(*(u64 *)ptep);
-	u64 new_pte;
-
-	if ((old_pte & EPT_PROT_MASK) == new_prot)
-		return;
-
-	new_pte = (old_pte & ~EPT_PROT_MASK) | new_prot;
-	if (level != PG_LEVEL_4K)
-		pgt->pgt_ops->pgt_entry_mkhuge(&new_pte);
-	pgt->pgt_ops->pgt_set_entry(ptep, new_pte);
 }
 
 static void reset_rsvds_bits_mask_ept(struct rsvd_bits_validate *rsvd_check,
@@ -500,14 +483,14 @@ static struct pkvm_mm_ops pgstate_pgt_mm_ops = {
 	.flush_tlb = flush_tlb_noop,
 };
 
-static int pkvm_shadow_ept_map_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr, int level,
-				    void *ptep, struct pgt_flush_data *flush_data, void *arg)
+static int pkvm_pgstate_pgt_map_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr, int level,
+				     void *ptep, struct pgt_flush_data *flush_data, void *arg)
 {
 	struct pkvm_pgtable_map_data *data = arg;
 	struct pkvm_pgtable_ops *pgt_ops = pgt->pgt_ops;
 	unsigned long level_size = pgt_ops->pgt_level_to_size(level);
 	unsigned long map_phys = data->phys & PAGE_MASK;
-	struct pkvm_shadow_vm *vm = sept_to_shadow_vm(pgt);
+	struct pkvm_shadow_vm *vm = pgstate_pgt_to_shadow_vm(pgt);
 	int ret;
 
 	/*
@@ -515,11 +498,23 @@ static int pkvm_shadow_ept_map_leaf(struct pkvm_pgtable *pgt, unsigned long vadd
 	 * multiple EPT violations happen on different CPUs.
 	 */
 	if (pgt_ops->pgt_entry_present(ptep)) {
+		unsigned long phys = pgt_ops->pgt_entry_to_phys(ptep);
+
 		/*
-		 * Update the present entry with the newprot as a mismatching
-		 * property bits can also cause EPT violation.
+		 * Check if the existing mapping is the same as the wanted one.
+		 * If not the same, report an error so that the map_leaf caller
+		 * will not map the different addresses in its shadow EPT.
 		 */
-		ept_remap_with_newprot(pgt, level, ptep, data->prot);
+		if (phys != map_phys) {
+			pkvm_err("%s: gpa 0x%lx @level%d old_phys 0x%lx != new_phys 0x%lx\n",
+				 __func__, vaddr, level, phys, map_phys);
+			return -EPERM;
+		}
+
+		/*
+		 * The pgstate_pgt now is EPT format with fixed property bits. No
+		 * need to check and update property bits for pgstate_pgt.
+		 */
 		goto out;
 	}
 
@@ -528,33 +523,7 @@ static int pkvm_shadow_ept_map_leaf(struct pkvm_pgtable *pgt, unsigned long vadd
 		ret = __pkvm_host_share_guest(map_phys, pgt, vaddr, level_size, data->prot);
 		break;
 	case KVM_X86_PROTECTED_VM:
-		if (owned_this_page(ptep)) {
-			unsigned long phys = pgt_ops->pgt_entry_to_phys(ptep);
-
-			/*
-			 * pkvm doesn't allow changing the final page mapping
-			 * in shadow EPT if this page has been used by protected
-			 * VM. This is due to security concern. So before reusing
-			 * the mapping, do a sanity check and report an error if
-			 * not the same.
-			 */
-			if (phys != map_phys) {
-				pkvm_err("%s: gpa 0x%lx @level%d old_phys 0x%lx != new_phys 0x%lx\n",
-						__func__, vaddr, level, phys, map_phys);
-				ret = -EPERM;
-			} else {
-				/*
-				 * Invept has invalid this entry for protected VM but keep
-				 * the phys address remained. Re-use this phys address and
-				 * its page state to create the mapping with new property
-				 * bits.
-				 */
-				ept_remap_with_newprot(pgt, level, ptep, data->prot);
-				ret = 0;
-			}
-		} else {
-			ret = __pkvm_host_donate_guest(map_phys, pgt, vaddr, level_size, data->prot);
-		}
+		ret = __pkvm_host_donate_guest(map_phys, pgt, vaddr, level_size, data->prot);
 		break;
 	default:
 		ret = -EINVAL;
@@ -574,13 +543,16 @@ out:
 	return 0;
 }
 
-static int pkvm_shadow_ept_free_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr, int level,
-				     void *ptep, struct pgt_flush_data *flush_data, void *arg)
+static int pkvm_pgstate_pgt_free_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr, int level,
+				      void *ptep, struct pgt_flush_data *flush_data, void *arg)
 {
 	unsigned long phys = pgt->pgt_ops->pgt_entry_to_phys(ptep);
 	unsigned long size = pgt->pgt_ops->pgt_level_to_size(level);
-	struct pkvm_shadow_vm *vm = sept_to_shadow_vm(pgt);
-	int ret = 0;
+	struct pkvm_shadow_vm *vm = pgstate_pgt_to_shadow_vm(pgt);
+	int ret;
+
+	if (!pgt->pgt_ops->pgt_entry_present(ptep))
+		return 0;
 
 	/*
 	 * For normal VM, call __pkvm_host_unshare_guest() to unshare all previous
@@ -589,89 +561,14 @@ static int pkvm_shadow_ept_free_leaf(struct pkvm_pgtable *pgt, unsigned long vad
 	 *
 	 * For protected VM, call __pkvm_host_undonate_guest() to undonate all
 	 * previous donated pages, the donated pages are indicated by their page
-	 * table entry whose page state show it owned this page - check by API
-	 * owned_this_page(). The reason to check page state is because for
-	 * invalidation operation(below) of a protected VM, we will make the page
-	 * table entry non-present while still keep its page state information in
-	 * the page table entry. So either a donated page is invalidated or not,
-	 * it's kept in donated state.
+	 * table entry which is present.
 	 *
 	 * And the pgtable_free_cb in this current page walker is still walking
-	 * the shadow EPT so cannot allow the  __pkvm_host_unshare_guest()
-	 * or __pkvm_host_undonate_guest() release shadow EPT table pages. So
-	 * we shall get_page befor these APIs called, then put_page to allow
+	 * the page state table so cannot allow the  __pkvm_host_unshare_guest()
+	 * or __pkvm_host_undonate_guest() release page state table pages. So
+	 * we shall get_page before these APIs called, then put_page to allow
 	 * pgtable_free_cb free table pages with correct refcount.
 	 *
-	 */
-	switch (vm->vm_type) {
-	case KVM_X86_DEFAULT_VM:
-		if (pgt->pgt_ops->pgt_entry_present(ptep)) {
-			pgt->mm_ops->get_page(ptep);
-			ret = __pkvm_host_unshare_guest(phys, pgt, vaddr, size);
-			pgt->mm_ops->put_page(ptep);
-			flush_data->flushtlb |= true;
-		}
-		break;
-	case KVM_X86_PROTECTED_VM:
-		if (owned_this_page(ptep)) {
-			void *virt = pgt->mm_ops->phys_to_virt(phys);
-
-			/*
-			 * before return to host, the page previously owned by
-			 * protected VM shall be memset to 0 to avoid secret leakage.
-			 */
-			memset(virt, 0, size);
-
-			pgt->mm_ops->get_page(ptep);
-			ret = __pkvm_host_undonate_guest(phys, pgt, vaddr, size);
-			pgt->mm_ops->put_page(ptep);
-			flush_data->flushtlb |= true;
-		} else if (*(u64 *)ptep == SHADOW_EPT_MMIO_ENTRY) {
-			pgt->pgt_ops->pgt_set_entry(ptep, pgt->pgt_ops->default_prot);
-			pgt->mm_ops->put_page(ptep);
-		}
-		break;
-	default:
-		ret = -EINVAL;
-		break;
-	}
-
-	if (ret)
-		pkvm_err("%s failed: ret %d vm_type %ld phys 0x%lx GPA 0x%lx size 0x%lx\n",
-			 __func__, ret, vm->vm_type, phys, vaddr, size);
-
-	return ret;
-}
-
-static int pkvm_shadow_ept_invalidate_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr,
-					   int level, void *ptep, struct pgt_flush_data *flush_data,
-					   void *arg)
-{
-	unsigned long phys = pgt->pgt_ops->pgt_entry_to_phys(ptep);
-	unsigned long size = pgt->pgt_ops->pgt_level_to_size(level);
-	struct pkvm_shadow_vm *vm = sept_to_shadow_vm(pgt);
-	int ret = 0;
-
-	if (!pgt->pgt_ops->pgt_entry_present(ptep)) {
-		if (*(u64 *)ptep == SHADOW_EPT_MMIO_ENTRY) {
-			pgt->pgt_ops->pgt_set_entry(ptep, pgt->pgt_ops->default_prot);
-			pgt->mm_ops->put_page(ptep);
-		}
-		return 0;
-	}
-
-	/*
-	 * We need do invalidation for all present page table entry.
-	 *
-	 * For normal VM, do same as free_leaf, unshare the page from guest,
-	 * and do not allow the __pkvm_host_unshare_guest() release shadow
-	 * EPT table pages.
-	 *
-	 * For protected VM, from security consideration, we shall not allow a
-	 * donated page to be undonated back to host during ept invalidation,
-	 * as it will cause secret leakage during runtime; so we just make the
-	 * page table entry not present and keep all the other page entry information
-	 * like page state, ADDR, PAGE_SIZE etc.
 	 */
 	switch(vm->vm_type) {
 	case KVM_X86_DEFAULT_VM:
@@ -680,10 +577,20 @@ static int pkvm_shadow_ept_invalidate_leaf(struct pkvm_pgtable *pgt, unsigned lo
 		pgt->mm_ops->put_page(ptep);
 		flush_data->flushtlb |= true;
 		break;
-	case KVM_X86_PROTECTED_VM:
-		ept_mk_nopresent(pgt, ptep);
+	case KVM_X86_PROTECTED_VM: {
+		void *virt = pgt->mm_ops->phys_to_virt(phys);
+
+		/*
+		 * before returning to host, the page previously owned by
+		 * protected VM shall be memset to 0 to avoid secret leakage.
+		 */
+		memset(virt, 0, size);
+		pgt->mm_ops->get_page(ptep);
+		ret = __pkvm_host_undonate_guest(phys, pgt, vaddr, size);
+		pgt->mm_ops->put_page(ptep);
 		flush_data->flushtlb |= true;
 		break;
+	}
 	default:
 		ret = -EINVAL;
 		break;
@@ -709,7 +616,19 @@ static void __invalidate_shadow_ept_with_range(struct shadow_ept_desc *desc,
 	if (!is_valid_eptp(desc->shadow_eptp))
 		goto out;
 
-	pkvm_pgtable_unmap_nosplit(sept, vaddr, size, pkvm_shadow_ept_invalidate_leaf);
+	pkvm_pgtable_unmap_nosplit(sept, vaddr, size, NULL);
+
+	/*
+	 * As for normal VM, its memory might need to be swapped out
+	 * or other kinds of management from primary VM thus should
+	 * unmap from pgstate pgt as well.
+	 *
+	 * As for protected VM, its memory is pinned thus no need to
+	 * unmap from pgstate pgt.
+	 */
+	if (vm->vm_type == KVM_X86_DEFAULT_VM)
+		pkvm_pgtable_unmap_nosplit(&vm->pgstate_pgt, vaddr, size,
+					   pkvm_pgstate_pgt_free_leaf);
 out:
 	pkvm_spin_unlock(&vm->lock);
 }
@@ -730,16 +649,14 @@ void pkvm_invalidate_shadow_ept_with_range(struct shadow_ept_desc *desc,
 
 void pkvm_shadow_ept_deinit(struct shadow_ept_desc *desc)
 {
-	struct pkvm_pgtable *sept = &desc->sept;
 	struct pkvm_shadow_vm *vm = sept_desc_to_shadow_vm(desc);
 
 	pkvm_spin_lock(&vm->lock);
 
-	if (desc->shadow_eptp) {
-		pkvm_pgtable_destroy(sept, pkvm_shadow_ept_free_leaf);
-		memset(sept, 0, sizeof(struct pkvm_pgtable));
-		desc->shadow_eptp = 0;
-	}
+	if (desc->shadow_eptp)
+		pkvm_pgtable_destroy(&desc->sept, NULL);
+
+	memset(desc, 0, sizeof(struct shadow_ept_desc));
 
 	pkvm_spin_unlock(&vm->lock);
 }
@@ -774,7 +691,7 @@ void pkvm_pgstate_pgt_deinit(struct pkvm_shadow_vm *vm)
 {
 	pkvm_spin_lock(&vm->lock);
 
-	pkvm_pgtable_destroy(&vm->pgstate_pgt, NULL);
+	pkvm_pgtable_destroy(&vm->pgstate_pgt, pkvm_pgstate_pgt_free_leaf);
 
 	pkvm_spin_unlock(&vm->lock);
 }
@@ -847,6 +764,58 @@ static bool is_access_violation(u64 ept_entry, u64 exit_qual)
 	return access_violation;
 }
 
+static bool allow_shadow_ept_mapping(struct pkvm_shadow_vm *vm,
+				     u64 gpa, unsigned long hpa,
+				     unsigned long size)
+{
+	struct pkvm_pgtable *pgstate_pgt = &vm->pgstate_pgt;
+	unsigned long mapped_hpa;
+	int level;
+
+	/*
+	 * Lookup the page state pgt to check if the mapping is already created
+	 * or not.
+	 */
+	pkvm_pgtable_lookup(pgstate_pgt, gpa, &mapped_hpa, NULL, &level);
+
+	if ((pgstate_pgt->pgt_ops->pgt_level_to_size(level) < size) ||
+	    mapped_hpa == INVALID_ADDR) {
+		u64 prot;
+		/*
+		 * Page state pgt doesn't have mapping yet, or it has mapping
+		 * but with a smaller size, so try to map with the desired size
+		 * in page state pgt first. Although page state pgt may already
+		 * have all the desired mappings with smaller size, map_leaf
+		 * can help to check if the mapped phys matches with the desired
+		 * hpa to guarantee shadow EPT maps GPA to the right HPA.
+		 */
+		if (is_pgt_ops_ept(pgstate_pgt)) {
+			prot = VMX_EPT_RWX_MASK;
+		} else {
+			pkvm_err("%s: pgstate_pgt format not supported\n", __func__);
+			return false;
+		}
+
+		if (pkvm_pgtable_map(pgstate_pgt, gpa, hpa, size,
+				     0, prot, pkvm_pgstate_pgt_map_leaf)) {
+			pkvm_err("%s: pgstate_pgt map gpa 0x%llx hpa 0x%lx size 0x%lx failed\n",
+				 __func__, gpa, hpa, size);
+			return false;
+		}
+	} else if (mapped_hpa != hpa) {
+		/*
+		 * Page state pgt has mapping already, so check if the mapped
+		 * phys matches with the hpa, and report an error if doesn't
+		 * match.
+		 */
+		pkvm_err("pgstate_pgt not match: mapped_hpa 0x%lx != 0x%lx for gpa 0x%llx\n",
+			 mapped_hpa, hpa, gpa);
+		return false;
+	}
+
+	return true;
+}
+
 enum sept_handle_ret
 pkvm_handle_shadow_ept_violation(struct shadow_vcpu_state *shadow_vcpu, u64 l2_gpa, u64 exit_quali)
 {
@@ -889,8 +858,8 @@ pkvm_handle_shadow_ept_violation(struct shadow_vcpu_state *shadow_vcpu, u64 l2_g
 		 */
 		u64 prot = (gprot & EPT_PROT_MASK) | EPT_PROT_DEF;
 
-		if (!pkvm_pgtable_map(sept, gpa, hpa, level_size, 0,
-					prot, pkvm_shadow_ept_map_leaf))
+		if (allow_shadow_ept_mapping(vm, gpa, hpa, level_size) &&
+		    !pkvm_pgtable_map(sept, gpa, hpa, level_size, 0, prot, NULL))
 			ret = PKVM_HANDLED;
 	}
 out:

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -23,6 +23,7 @@
 #include "vmx.h"
 #include "mem_protect.h"
 #include "debug.h"
+#include "ptdev.h"
 
 static struct pkvm_pool host_ept_pool;
 static struct pkvm_pgtable host_ept;
@@ -764,6 +765,56 @@ static bool is_access_violation(u64 ept_entry, u64 exit_qual)
 	return access_violation;
 }
 
+static int populate_pgstate_pgt(struct pkvm_pgtable *pgt)
+{
+	struct pkvm_shadow_vm *vm = pgstate_pgt_to_shadow_vm(pgt);
+	struct list_head *ptdev_head = &vm->ptdev_head;
+	struct pkvm_ptdev *ptdev, *tmp;
+	u64 *prot_override;
+	bool populated;
+	u64 prot;
+	int ret;
+
+	list_for_each_entry(ptdev, ptdev_head, vm_node) {
+		/* No need to populate if vpgt.root_pa doesn't exist */
+		if (!ptdev->vpgt.root_pa)
+			continue;
+
+		populated = false;
+		list_for_each_entry(tmp, ptdev_head, vm_node) {
+			if (tmp == ptdev)
+				break;
+			if (tmp->vpgt.root_pa == ptdev->vpgt.root_pa) {
+				populated = true;
+				break;
+			}
+		}
+
+		if (populated)
+			continue;
+
+		if (ptdev->vpgt.pgt_ops != pgt->pgt_ops) {
+			/* Populate with EPT format */
+			if (is_pgt_ops_ept(pgt)) {
+				prot = VMX_EPT_RWX_MASK;
+			} else {
+				pkvm_err("pkvm: not supported populating\n");
+				return -EOPNOTSUPP;
+			}
+			prot_override = &prot;
+		} else {
+			prot_override = NULL;
+		}
+
+		ret = pkvm_pgtable_sync_map(&ptdev->vpgt, pgt, prot_override,
+					    pkvm_pgstate_pgt_map_leaf);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 static bool allow_shadow_ept_mapping(struct pkvm_shadow_vm *vm,
 				     u64 gpa, unsigned long hpa,
 				     unsigned long size)
@@ -771,6 +822,18 @@ static bool allow_shadow_ept_mapping(struct pkvm_shadow_vm *vm,
 	struct pkvm_pgtable *pgstate_pgt = &vm->pgstate_pgt;
 	unsigned long mapped_hpa;
 	int level;
+
+	/*
+	 * VM will be marked as need_prepopulation when a passthrough device is
+	 * attached. With this flag being set, VM's pgstate_pgt will be pre-populated
+	 * before handling EPT violation. After the population is done, this flag
+	 * can be cleared.
+	 */
+	if (vm->need_prepopulation) {
+		if (populate_pgstate_pgt(pgstate_pgt))
+			return false;
+		vm->need_prepopulation = false;
+	}
 
 	/*
 	 * Lookup the page state pgt to check if the mapping is already created

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -242,26 +242,6 @@ void pkvm_host_ept_destroy(void)
 	pkvm_pgtable_destroy(&host_ept, NULL);
 }
 
-int host_ept_create_idmap_locked(u64 addr, u64 size, int pgsz_mask, u64 prot)
-{
-	return pkvm_pgtable_map(&host_ept, addr, addr, size, pgsz_mask, prot, NULL);
-}
-
-/*
- * host_ept_create_idmap() - create the identity mapping for host ept
- * @addr: GPA in host ept, and GPA == HPA.
- */
-int host_ept_create_idmap(u64 addr, u64 size, int pgsz_mask, u64 prot)
-{
-	int ret;
-
-	pkvm_spin_lock(&_host_ept_lock);
-	ret = host_ept_create_idmap_locked(addr, size, pgsz_mask, prot);
-	pkvm_spin_unlock(&_host_ept_lock);
-
-	return ret;
-}
-
 void host_ept_lock(void)
 {
 	pkvm_spin_lock(&_host_ept_lock);

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.h
@@ -50,6 +50,7 @@ void pkvm_shadow_clear_suppress_ve(struct kvm_vcpu *vcpu, unsigned long gfn);
 
 int pkvm_pgstate_pgt_init(struct pkvm_shadow_vm *vm);
 void pkvm_pgstate_pgt_deinit(struct pkvm_shadow_vm *vm);
+bool is_pgt_ops_ept(struct pkvm_pgtable *pgt);
 
 static inline bool is_valid_eptp(u64 eptp)
 {

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.h
@@ -24,8 +24,6 @@ enum sept_handle_ret {
 
 void host_ept_lock(void);
 void host_ept_unlock(void);
-int host_ept_create_idmap(u64 addr, u64 size, int pgsz_mask, u64 prot);
-int host_ept_create_idmap_locked(u64 addr, u64 size, int pgsz_mask, u64 prot);
 int pkvm_host_ept_map(unsigned long vaddr_start, unsigned long phys_start,
 		unsigned long size, int pgsz_mask, u64 prot);
 int pkvm_host_ept_unmap(unsigned long vaddr_start, unsigned long phys_start,

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.h
@@ -48,6 +48,9 @@ void pkvm_invalidate_shadow_ept_with_range(struct shadow_ept_desc *desc,
 void pkvm_flush_shadow_ept(struct shadow_ept_desc *desc);
 void pkvm_shadow_clear_suppress_ve(struct kvm_vcpu *vcpu, unsigned long gfn);
 
+int pkvm_pgstate_pgt_init(struct pkvm_shadow_vm *vm);
+void pkvm_pgstate_pgt_deinit(struct pkvm_shadow_vm *vm);
+
 static inline bool is_valid_eptp(u64 eptp)
 {
 	if (!eptp || (eptp == INVALID_GPA))

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
@@ -14,10 +14,10 @@
 #include "iommu_internal.h"
 #include "debug.h"
 
-#define for_each_valid_iommu(p)					\
-	for (p = iommus; p < iommus + PKVM_MAX_IOMMU_NUM; p++)	\
-		if (!p || !p->iommu.reg_phys) {			\
-			continue;				\
+#define for_each_valid_iommu(p)						\
+	for ((p) = iommus; (p) < iommus + PKVM_MAX_IOMMU_NUM; (p)++)	\
+		if (!(p) || !(p)->iommu.reg_phys) {			\
+			continue;					\
 		} else
 
 static struct pkvm_iommu iommus[PKVM_MAX_IOMMU_NUM];
@@ -45,9 +45,9 @@ struct pgt_sync_walk_data {
 	u16 did;
 };
 
-#define DEFINE_PGT_SYNC_WALK_DATA(name, iommu, domain_id)	\
-	struct pgt_sync_walk_data name = {			\
-		.iommu = iommu,					\
+#define DEFINE_PGT_SYNC_WALK_DATA(name, _iommu, domain_id)	\
+	struct pgt_sync_walk_data (name) = {			\
+		.iommu = (_iommu),				\
 		.shadow_pa = {0},				\
 		.did = (domain_id),				\
 	}

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
@@ -13,6 +13,7 @@
 #include "pgtable.h"
 #include "iommu_internal.h"
 #include "debug.h"
+#include "ptdev.h"
 
 #define for_each_valid_iommu(p)						\
 	for ((p) = iommus; (p) < iommus + PKVM_MAX_IOMMU_NUM; (p)++)	\
@@ -69,6 +70,7 @@ struct pgt_sync_data {
 	u64 iommu_ecap;
 	u64 shadow_pa;
 	struct pkvm_pgtable *spgt;
+	unsigned long vaddr;
 };
 
 static inline void *iommu_zalloc_pages(size_t size)
@@ -393,25 +395,75 @@ static bool sync_shadow_pasid_dir_entry(struct pgt_sync_data *sdata)
 	return false;
 }
 
+static struct pkvm_ptdev *iommu_find_ptdev(struct pkvm_iommu *iommu, u16 bdf, u32 pasid)
+{
+	struct pkvm_ptdev *p;
+
+	list_for_each_entry(p, &iommu->ptdev_head, iommu_node) {
+		if (match_ptdev(p, bdf, pasid))
+			return p;
+	}
+
+	return NULL;
+}
+
+static struct pkvm_ptdev *iommu_add_ptdev(struct pkvm_iommu *iommu, u16 bdf, u32 pasid)
+{
+	struct pkvm_ptdev *ptdev = pkvm_get_ptdev(bdf, pasid);
+
+	if (!ptdev)
+		return NULL;
+
+	list_add_tail(&ptdev->iommu_node, &iommu->ptdev_head);
+	return ptdev;
+}
+
+static void iommu_del_ptdev(struct pkvm_iommu *iommu, struct pkvm_ptdev *ptdev)
+{
+	list_del_init(&ptdev->iommu_node);
+	pkvm_put_ptdev(ptdev);
+}
+
 /* sync pasid table entry when guest_ptep valid, otherwise un-present it */
 static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 {
+	u16 bdf = sdata->vaddr >> DEVFN_SHIFT;
+	u32 pasid = sdata->vaddr & ((1UL << MAX_NR_PASID_BITS) - 1);
+	struct pkvm_iommu *iommu = pgt_to_pkvm_iommu(sdata->spgt);
+	struct pkvm_ptdev *ptdev = iommu_find_ptdev(iommu, bdf, pasid);
 	struct pasid_entry *shadow_pte = sdata->shadow_ptep, tmp_pte = {0};
 	struct pasid_entry *guest_pte;
+	bool synced = false;
 	u64 type, aw;
+
+	if (!ptdev) {
+		ptdev = iommu_add_ptdev(iommu, bdf, pasid);
+		if (!ptdev)
+			return false;
+	}
 
 	if (!sdata->guest_ptep) {
 		if (pasid_pte_is_present(shadow_pte)) {
-			pasid_clear_entry(shadow_pte);
-			return true;
-		}
+			/*
+			 * Making a pasid entry not present needs to remove
+			 * the corresponding ptdev from IOMMU. It also means
+			 * a ptdev's vpgt/did should be reset as well as
+			 * deleting ptdev from this iommu.
+			 */
+			pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL);
+			pkvm_setup_ptdev_did(ptdev, 0);
+			iommu_del_ptdev(iommu, ptdev);
 
-		return false;
+			synced = pasid_copy_entry(shadow_pte, &tmp_pte);
+		}
+		return synced;
 	}
 
 	guest_pte = sdata->guest_ptep;
 	type = pasid_pte_get_pgtt(guest_pte);
-	if (type == PASID_ENTRY_PGTT_FL_ONLY)
+	if (type == PASID_ENTRY_PGTT_FL_ONLY) {
+		struct pkvm_pgtable_cap cap;
+
 		/*
 		 * When host IOMMU driver is using first-level only
 		 * translation, pkvm IOMMU will actually use nested
@@ -420,7 +472,16 @@ static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 		 * EPT.
 		 */
 		type = PASID_ENTRY_PGTT_NESTED;
-	else if (type == PASID_ENTRY_PGTT_PT)
+
+		/*
+		 * For nested translation, ptdev vpgt can be initialized
+		 * with flptr.
+		 */
+		cap.level = pasid_get_flpm(guest_pte) == 0 ? 4 : 5;
+		cap.allowed_pgsz = pkvm_hyp->mmu_cap.allowed_pgsz;
+		pkvm_setup_ptdev_vpgt(ptdev, pasid_get_flptr(guest_pte),
+				      &viommu_mm_ops, &mmu_ops, &cap);
+	} else if (type == PASID_ENTRY_PGTT_PT) {
 		/*
 		 * When host IOMMU driver is using pass-through mode, pkvm
 		 * IOMMU will actually use the second-level only translation
@@ -428,18 +489,30 @@ static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 		 * the EPT.
 		 */
 		type = PASID_ENTRY_PGTT_SL_ONLY;
-	else {
+	} else {
 		/*
 		 * As the host IOMMU driver in the pkvm enabled kernel has
 		 * already been configured to use first-level only or
-		 * pass-through mode, it will not to use any other mode. But
-		 * in case this happened, just clear the shadow entry and not
-		 * to support it.
+		 * pass-through mode, it will not use any other mode. But
+		 * in case this has happened, reset the ptdev vpgt/did while
+		 * keep ptdev linked to this IOMMU, and clear the shadow entry
+		 * so that not to support it.
 		 */
+		pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL);
+		pkvm_setup_ptdev_did(ptdev, 0);
+
 		pkvm_err("pkvm: unsupported pasid type %lld\n", type);
-		pasid_clear_entry(shadow_pte);
-		return true;
+
+		return pasid_copy_entry(shadow_pte, &tmp_pte);
 	}
+
+	pkvm_setup_ptdev_did(ptdev, pasid_get_domain_id(guest_pte));
+	/*
+	 * ptdev->pgt will be used as second-level translation table
+	 * which should be EPT format.
+	 */
+	if (!is_pgt_ops_ept(ptdev->pgt))
+		return false;
 
 	memcpy(&tmp_pte, guest_pte, sizeof(struct pasid_entry));
 
@@ -454,8 +527,8 @@ static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 	 * Reuse FPD/P
 	 */
 	pasid_set_translation_type(&tmp_pte, type);
-	pasid_set_slptr(&tmp_pte, sdata->shadow_pa);
-	aw = (pkvm_hyp->ept_iommu_pgt_level == 4) ? 2 : 3;
+	pasid_set_slptr(&tmp_pte, ptdev->pgt->root_pa);
+	aw = (ptdev->pgt->level == 4) ? 2 : 3;
 	pasid_set_address_width(&tmp_pte, aw);
 	pasid_set_ssade(&tmp_pte, 0);
 	pasid_set_ssee(&tmp_pte, 0);
@@ -570,6 +643,8 @@ int pkvm_init_iommu(unsigned long mem_base, unsigned long nr_pages)
 		if (!info->reg_phys)
 			break;
 
+		INIT_LIST_HEAD(&piommu->ptdev_head);
+
 		pkvm_spinlock_init(&piommu->lock);
 		piommu->iommu.reg_phys = info->reg_phys;
 		piommu->iommu.reg_size = info->reg_size;
@@ -620,11 +695,12 @@ static int free_shadow_id_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 	sync_data.level = level;
 	sync_data.spgt = pgt;
 	sync_data.iommu_ecap = iommu->iommu.ecap;
+	sync_data.vaddr = vaddr;
 
 	/* Un-present a present PASID Table entry */
 	if (LAST_LEVEL(level)) {
-		iommu_id_sync_entry(&sync_data);
-		mm_ops->put_page(ptep);
+		if (iommu_id_sync_entry(&sync_data))
+			mm_ops->put_page(ptep);
 		return 0;
 	}
 
@@ -635,9 +711,10 @@ static int free_shadow_id_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 	 */
 	child_ptep = mm_ops->phys_to_virt(pgt_ops->pgt_entry_to_phys(ptep));
 	if (mm_ops->page_count(child_ptep) == 1) {
-		iommu_id_sync_entry(&sync_data);
-		mm_ops->put_page(ptep);
-		mm_ops->put_page(child_ptep);
+		if (iommu_id_sync_entry(&sync_data)) {
+			mm_ops->put_page(ptep);
+			mm_ops->put_page(child_ptep);
+		}
 	}
 
 	return 0;
@@ -701,6 +778,7 @@ static int init_sync_id_data(struct pgt_sync_data *sync_data,
 	sync_data->spgt = spgt;
 	sync_data->iommu_ecap = iommu->iommu.ecap;
 	sync_data->shadow_pa = 0;
+	sync_data->vaddr = vaddr;
 
 	return 0;
 }
@@ -782,13 +860,10 @@ static int sync_shadow_id_cb(struct pkvm_pgtable *vpgt, unsigned long vaddr,
 				return ret;
 
 			/*
-			 * The PASID table entry always require to use EPT
-			 * for the second-level translation no matter in nested
-			 * transltion mode or second-level only mode. So get the
-			 * EPT physical address for the leaf entry, which is the
-			 * pasid table entry.
+			 * The shadow_pa to configur the PASID table entry is
+			 * depending on the pgt used by the corresponding ptdev.
+			 * So no need to set sync_data.shadow_pa.
 			 */
-			sync_data.shadow_pa = pkvm_hyp->host_vm.ept->root_pa;
 		} else {
 			/*
 			 * Right now reference to a virtual 2nd-stage paging table.

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.h
@@ -9,5 +9,6 @@ int pkvm_init_iommu(unsigned long mem_base, unsigned long nr_pages);
 unsigned long pkvm_access_iommu(bool is_read, int len, unsigned long reg, unsigned long val);
 bool is_mem_range_overlap_iommu(unsigned long start, unsigned long end);
 int pkvm_activate_iommu(void);
+int pkvm_iommu_sync(u16 bdf, u32 pasid);
 
 #endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
@@ -39,6 +39,9 @@ struct pkvm_iommu {
 	struct q_inval qi;
 	pkvm_spinlock_t qi_lock;
 	u64 piommu_iqa;
+
+	/* Link ptdev information of this IOMMU */
+	struct list_head ptdev_head;
 };
 
 enum lm_level {
@@ -188,6 +191,26 @@ static inline u16
 pasid_get_domain_id(struct pasid_entry *pe)
 {
 	return (u16)(READ_ONCE(pe->val[1]) & GENMASK_ULL(15, 0));
+}
+
+/*
+ * Get the FLPTPTR(First Level Page Table Pointer) field (Bit 140 ~ 191)
+ * of a scalable mode PASID entry.
+ */
+static inline u64
+pasid_get_flptr(struct pasid_entry *pe)
+{
+	return (u64)(READ_ONCE(pe->val[2]) & VTD_PAGE_MASK);
+}
+
+/*
+ * Get the First Level Paging Mode field (Bit 130~131) of a
+ * scalable mode PASID entry.
+ */
+static inline u8
+pasid_get_flpm(struct pasid_entry *pe)
+{
+	return (u8)((READ_ONCE(pe->val[2]) & GENMASK_ULL(3, 2)) >> 2);
 }
 
 /*

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
@@ -55,7 +55,7 @@ enum sm_level {
 };
 
 #define LAST_LEVEL(level)	\
-	((level == 1) ? true : false)
+	(((level) == 1) ? true : false)
 
 #define LM_DEVFN_BITS	8
 #define LM_DEVFN_SHIFT	0
@@ -88,8 +88,8 @@ enum sm_level {
 #define IOMMU_MAX_VADDR_LEN	(BUS_SHIFT + BUS_BITS)
 #define IOMMU_MAX_VADDR		BIT(IOMMU_MAX_VADDR_LEN)
 
-#define MAX_NUM_OF_ADDRESS_SPACE(iommu)		\
-	(ecap_smts(iommu->iommu.ecap) ?	\
+#define MAX_NUM_OF_ADDRESS_SPACE(_iommu)		\
+	(ecap_smts((_iommu)->iommu.ecap) ?		\
 		IOMMU_MAX_VADDR : IOMMU_LM_MAX_VADDR)
 
 #define DMAR_GSTS_EN_BITS	(DMA_GCMD_TE | DMA_GCMD_EAFL | \
@@ -104,29 +104,29 @@ enum sm_level {
 #define PKVM_IOMMU_WAIT_OP(offset, op, cond, sts)			\
 do {									\
 	while (1) {							\
-		sts = op(offset);					\
+		(sts) = op(offset);					\
 		if (cond)						\
 			break;						\
 		cpu_relax();						\
 	}								\
 } while (0)
 
-#define IQ_DESC_BASE_PHYS(reg)		(reg & ~0xfff)
-#define IQ_DESC_DW(reg)			((reg >> 11) & 1)
-#define IQ_DESC_QS(reg)			(reg & GENMASK_ULL(2, 0))
+#define IQ_DESC_BASE_PHYS(reg)		((reg) & ~0xfff)
+#define IQ_DESC_DW(reg)			(((reg) >> 11) & 1)
+#define IQ_DESC_QS(reg)			((reg) & GENMASK_ULL(2, 0))
 #define IQ_DESC_LEN(reg)		(1 << (7 + IQ_DESC_QS(reg) + !IQ_DESC_DW(reg)))
 #define IQ_DESC_SHIFT(reg)		(4 + IQ_DESC_DW(reg))
 
-#define QI_DESC_TYPE(qw)		(qw & GENMASK_ULL(3, 0))
-#define QI_DESC_CC_GRANU(qw)		((qw & GENMASK_ULL(5, 4)) >> 4)
-#define QI_DESC_CC_DID(qw)		((qw & GENMASK_ULL(31, 16)) >> 16)
-#define QI_DESC_CC_SID(qw)		((qw & GENMASK_ULL(47, 32)) >> 32)
+#define QI_DESC_TYPE(qw)		((qw) & GENMASK_ULL(3, 0))
+#define QI_DESC_CC_GRANU(qw)		(((qw) & GENMASK_ULL(5, 4)) >> 4)
+#define QI_DESC_CC_DID(qw)		(((qw) & GENMASK_ULL(31, 16)) >> 16)
+#define QI_DESC_CC_SID(qw)		(((qw) & GENMASK_ULL(47, 32)) >> 32)
 
-#define QI_DESC_PC_GRANU(qw)		((qw & GENMASK_ULL(5, 4)) >> 4)
-#define QI_DESC_PC_DID(qw)		((qw & GENMASK_ULL(31, 16)) >> 16)
-#define QI_DESC_PC_PASID(qw)		((qw & GENMASK_ULL(51, 32)) >> 32)
+#define QI_DESC_PC_GRANU(qw)		(((qw) & GENMASK_ULL(5, 4)) >> 4)
+#define QI_DESC_PC_DID(qw)		(((qw) & GENMASK_ULL(31, 16)) >> 16)
+#define QI_DESC_PC_PASID(qw)		(((qw) & GENMASK_ULL(51, 32)) >> 32)
 
-#define pgt_to_pkvm_iommu(pgt) container_of(pgt, struct pkvm_iommu, pgt)
+#define pgt_to_pkvm_iommu(_pgt) container_of(_pgt, struct pkvm_iommu, pgt)
 
 struct pasid_dir_entry {
 	u64 val;

--- a/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.c
@@ -442,6 +442,46 @@ int __pkvm_host_donate_guest(u64 hpa, struct pkvm_pgtable *guest_pgt,
 	return ret;
 }
 
+/*
+ * Fastpath interface will use the host EPT instance without doing tlbflushing
+ * to have a better performance. It is usually used in the scenario that caller
+ * needs to change a bunch of pages' state without having the TLB flushing
+ * overhead in the each iteration, but caller still needs to do TLB flushing
+ * after completing all the iterations.
+ */
+int __pkvm_host_donate_guest_fastpath(u64 hpa, struct pkvm_pgtable *guest_pgt,
+				      u64 gpa, u64 size, u64 prot)
+{
+	int ret;
+	struct pkvm_mem_transition donation = {
+		.size		= size,
+		.initiator	= {
+			.id	= PKVM_ID_HOST,
+			.host	= {
+				.pgt_override	= pkvm_hyp->host_vm.ept_notlbflush,
+				.addr		= hpa,
+			},
+		},
+		.completer	= {
+			.id	= PKVM_ID_GUEST,
+			.guest	= {
+				.pgt		= guest_pgt,
+				.addr		= gpa,
+				.phys		= hpa,
+			},
+			.prot	= prot,
+		},
+	};
+
+	host_ept_lock();
+
+	ret = do_donate(&donation);
+
+	host_ept_unlock();
+
+	return ret;
+}
+
 int __pkvm_host_undonate_guest(u64 hpa, struct pkvm_pgtable *guest_pgt,
 			       u64 gpa, u64 size)
 {

--- a/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.c
@@ -47,14 +47,14 @@ struct pkvm_mem_transition {
 	struct pkvm_mem_trans_desc	completer;
 };
 
-static void guest_sept_lock(struct pkvm_pgtable *sept)
+static void guest_pgstate_pgt_lock(struct pkvm_pgtable *pgt)
 {
-	pkvm_spin_lock(&sept_to_shadow_vm(sept)->lock);
+	pkvm_spin_lock(&pgstate_pgt_to_shadow_vm(pgt)->lock);
 }
 
-static void guest_sept_unlock(struct pkvm_pgtable *sept)
+static void guest_pgstate_pgt_unlock(struct pkvm_pgtable *pgt)
 {
-	pkvm_spin_unlock(&sept_to_shadow_vm(sept)->lock);
+	pkvm_spin_unlock(&pgstate_pgt_to_shadow_vm(pgt)->lock);
 }
 
 static u64 pkvm_init_invalid_leaf_owner(pkvm_id owner_id)
@@ -142,10 +142,8 @@ static int __guest_check_page_state_range(struct pkvm_pgtable *pgt,
 
 static pkvm_id pkvm_guest_id(struct pkvm_pgtable *pgt)
 {
-	struct pkvm_shadow_vm *shadow_vm = sept_to_shadow_vm(pgt);
-
 	/* Using the shadow_vm_handle as guest_id. */
-	return shadow_vm->shadow_vm_handle;
+	return pgstate_pgt_to_shadow_vm(pgt)->shadow_vm_handle;
 }
 
 static pkvm_id __pkvm_owner_id(const struct pkvm_mem_trans_desc *desc)
@@ -188,8 +186,9 @@ static int guest_request_donation(const struct pkvm_mem_transition *tx)
 					};
 
 	/*
-	 * When destroy vm, there may be multiple page state in the guest ept.
-	 * In this case, both page state is ok to be reclaimed back by host.
+	 * When destroying vm, there may be multiple page state in the guest
+	 * pgstate pgt. In this case, both page state is ok to be reclaimed
+	 * back by host.
 	 */
 	return check_page_state_range(tx->initiator.guest.pgt,
 				      addr, size, states, ARRAY_SIZE(states));
@@ -703,7 +702,7 @@ int __pkvm_guest_share_host(struct pkvm_pgtable *guest_pgt,
 		return -EINVAL;
 
 	host_ept_lock();
-	guest_sept_lock(guest_pgt);
+	guest_pgstate_pgt_lock(guest_pgt);
 
 	while (size) {
 		pkvm_pgtable_lookup(guest_pgt, gpa, &hpa, &prot, NULL);
@@ -720,7 +719,7 @@ int __pkvm_guest_share_host(struct pkvm_pgtable *guest_pgt,
 		gpa += PAGE_SIZE;
 	}
 
-	guest_sept_unlock(guest_pgt);
+	guest_pgstate_pgt_unlock(guest_pgt);
 	host_ept_unlock();
 
 	return ret;
@@ -947,7 +946,7 @@ int __pkvm_guest_unshare_host(struct pkvm_pgtable *guest_pgt,
 	int ret = 0;
 
 	host_ept_lock();
-	guest_sept_lock(guest_pgt);
+	guest_pgstate_pgt_lock(guest_pgt);
 
 	while (size) {
 		pkvm_pgtable_lookup(guest_pgt, gpa, &hpa, &prot, NULL);
@@ -964,7 +963,7 @@ int __pkvm_guest_unshare_host(struct pkvm_pgtable *guest_pgt,
 		gpa += PAGE_SIZE;
 	}
 
-	guest_sept_unlock(guest_pgt);
+	guest_pgstate_pgt_unlock(guest_pgt);
 	host_ept_unlock();
 
 	return ret;

--- a/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.h
@@ -132,6 +132,18 @@ int __pkvm_host_donate_guest(u64 hpa, struct pkvm_pgtable *guest_pgt,
 			     u64 gpa, u64 size, u64 prot);
 
 /*
+ * __pkvm_host_donate_guest_fastpath() - Similar to __pkvm_host_donate_guest() but
+ * will use the fastpath to set annotation in host EPT to donate a page. The fastpath
+ * of setting annotation doesn't do the TLB flushing when unmaps from the host EPT.
+ * This function is used in the scenario that, the caller can do TLB flushing after
+ * doing a bunch of donating pages which can improve the performance. The caller
+ * should guarantee that doing TLB flushing after donating doesn't bring any security
+ * window that host can steal the data from the donated page.
+ */
+int __pkvm_host_donate_guest_fastpath(u64 hpa, struct pkvm_pgtable *guest_pgt,
+				      u64 gpa, u64 size, u64 prot);
+
+/*
  * __pkvm_host_undoate_guest() - Host reclaim these pages donated to guest.
  * Then guest can't access these pages and host can access.
  *

--- a/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.h
@@ -47,14 +47,6 @@ static inline enum pkvm_page_state pkvm_getstate(u64 pte)
 	return pte & PKVM_PAGE_STATE_PROT_MASK;
 }
 
-static inline bool owned_this_page(void *ptep)
-{
-	enum pkvm_page_state page_state = pkvm_getstate(*(u64 *)ptep);
-
-	return (page_state == PKVM_PAGE_OWNED) || (page_state == PKVM_PAGE_SHARED_OWNED);
-}
-
-
 typedef u32 pkvm_id;
 static const pkvm_id pkvm_hyp_id = 0;
 

--- a/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.h
@@ -50,8 +50,6 @@ static inline enum pkvm_page_state pkvm_getstate(u64 pte)
 typedef u32 pkvm_id;
 static const pkvm_id pkvm_hyp_id = 0;
 
-int host_ept_set_owner(phys_addr_t addr, u64 size, pkvm_id owner_id);
-
 /*
  * __pkvm_host_donate_hyp() - Donate pages from host to hyp, then host cannot
  * access these donated pages.

--- a/arch/x86/kvm/vmx/pkvm/hyp/mmu.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/mmu.h
@@ -23,4 +23,6 @@ void pkvm_mmu_clone_host(int level, unsigned long start_vaddr);
 static inline void pkvm_mmu_clone_host(int level, unsigned long start_vaddr) {}
 #endif
 
+extern struct pkvm_pgtable_ops mmu_ops;
+
 #endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/nested.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/nested.c
@@ -1311,7 +1311,7 @@ static bool nested_handle_vmcall(struct kvm_vcpu *vcpu)
 {
 	u64 nr, a0, a1, a2, a3;
 	struct shadow_vcpu_state *shadow_vcpu = to_pkvm_hvcpu(vcpu)->current_shadow_vcpu;
-	struct pkvm_pgtable *guest_pgt = &shadow_vcpu->vm->sept_desc.sept;
+	struct pkvm_pgtable *pgstate_pgt = &shadow_vcpu->vm->pgstate_pgt;
 	bool handled = false;
 	int ret = 0;
 
@@ -1327,11 +1327,11 @@ static bool nested_handle_vmcall(struct kvm_vcpu *vcpu)
 
 	switch (nr) {
 	case PKVM_GHC_SHARE_MEM:
-		ret = __pkvm_guest_share_host(guest_pgt, a0, a1);
+		ret = __pkvm_guest_share_host(pgstate_pgt, a0, a1);
 		handled = true;
 		break;
 	case PKVM_GHC_UNSHARE_MEM:
-		ret = __pkvm_guest_unshare_host(guest_pgt, a0, a1);
+		ret = __pkvm_guest_unshare_host(pgstate_pgt, a0, a1);
 		handled = true;
 		break;
 	case PKVM_GHC_GET_VE_INFO:

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
@@ -710,3 +710,56 @@ int pkvm_pgtable_annotate(struct pkvm_pgtable *pgt, unsigned long addr,
 				  size, 1 << PG_LEVEL_4K, 0,
 				  NULL, annotation);
 }
+
+static int pgtable_sync_map_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
+			       unsigned long vaddr_end, int level, void *ptep,
+			       unsigned long flags, struct pgt_flush_data *flush_data,
+			       void *const arg)
+{
+	struct pkvm_pgtable_ops *pgt_ops = pgt->pgt_ops;
+	struct pkvm_pgtable_sync_data *data = arg;
+	unsigned long phys;
+	unsigned long size;
+	u64 prot;
+
+	if (!pgt->pgt_ops->pgt_entry_present(ptep))
+		return 0;
+
+	phys = pgt_ops->pgt_entry_to_phys(ptep);
+	size = pgt_ops->pgt_level_to_size(level);
+	if (data->prot_override)
+		prot = *data->prot_override;
+	else
+		prot = pgt_ops->pgt_entry_to_prot(ptep);
+
+	return pkvm_pgtable_map(data->dest_pgt, vaddr, phys,
+				size, 0, prot, data->map_leaf_override);
+}
+
+/*
+ * pkvm_pgtable_sync_map() - map the destination pgtable_pgt according to the source
+ * pgtable_pgt, with the same phys address and desired property bits.
+ *
+ * @src:	source pgtable_pgt.
+ * @dest:	destination pgtable_pgt.
+ * @prot:	desired property bits. Can be NULL if use the same property
+ *		bits as the source pgtable_pgt
+ * @map_leaf:	function to map the leaf entry for destination pgtable_pgt.
+ */
+int pkvm_pgtable_sync_map(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
+			  u64 *prot, pgtable_leaf_ov_fn_t map_leaf)
+{
+	struct pkvm_pgtable_sync_data data = {
+		.dest_pgt = dest,
+		.prot_override = prot,
+		.map_leaf_override = map_leaf,
+	};
+	struct pkvm_pgtable_walker walker = {
+		.cb = pgtable_sync_map_cb,
+		.flags = PKVM_PGTABLE_WALK_LEAF,
+		.arg = &data,
+	};
+	unsigned long size = src->pgt_ops->pgt_level_to_size(src->level + 1);
+
+	return pgtable_walk(src, 0, size, true, &walker);
+}

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
@@ -97,6 +97,13 @@ struct pkvm_pgtable_free_data {
 	pgtable_leaf_ov_fn_t free_leaf_override;
 };
 
+struct pkvm_pgtable_sync_data {
+	struct pkvm_pgtable *dest_pgt;
+	u64 *prot_override;
+
+	pgtable_leaf_ov_fn_t map_leaf_override;
+};
+
 #define PGTABLE_WALK_DONE      1
 
 struct pkvm_pgtable_walker {
@@ -131,4 +138,6 @@ void pkvm_pgtable_lookup(struct pkvm_pgtable *pgt, unsigned long vaddr,
 void pkvm_pgtable_destroy(struct pkvm_pgtable *pgt, pgtable_leaf_ov_fn_t free_leaf);
 int pkvm_pgtable_annotate(struct pkvm_pgtable *pgt, unsigned long addr,
 			  unsigned long size, u64 annotation);
+int pkvm_pgtable_sync_map(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
+			  u64 *prot, pgtable_leaf_ov_fn_t map_leaf);
 #endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
@@ -449,6 +449,7 @@ int pkvm_add_ptdev(int shadow_vm_handle, u16 bdf, u32 pasid)
 		if (ptdev) {
 			pkvm_spin_lock(&vm->lock);
 			list_add_tail(&ptdev->vm_node, &vm->ptdev_head);
+			vm->need_prepopulation = true;
 			pkvm_spin_unlock(&vm->lock);
 		} else {
 			ret = -ENODEV;

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
@@ -10,6 +10,7 @@
 #include "ept.h"
 #include "mem_protect.h"
 #include "lapic.h"
+#include "ptdev.h"
 
 struct pkvm_hyp *pkvm_hyp;
 
@@ -117,6 +118,7 @@ int __pkvm_init_shadow_vm(struct kvm_vcpu *hvcpu, unsigned long kvm_va,
 
 	memset(vm, 0, shadow_size);
 	pkvm_spinlock_init(&vm->lock);
+	INIT_LIST_HEAD(&vm->ptdev_head);
 
 	vm->host_kvm_va = kvm_va;
 	vm->shadow_size = shadow_size;
@@ -147,6 +149,7 @@ undonate:
 unsigned long __pkvm_teardown_shadow_vm(int shadow_vm_handle)
 {
 	struct pkvm_shadow_vm *vm = free_shadow_vm_handle(shadow_vm_handle);
+	struct pkvm_ptdev *ptdev, *tmp;
 	unsigned long shadow_size;
 
 	if (!vm)
@@ -155,6 +158,14 @@ unsigned long __pkvm_teardown_shadow_vm(int shadow_vm_handle)
 	pkvm_shadow_ept_deinit(&vm->sept_desc);
 
 	pkvm_pgstate_pgt_deinit(vm);
+
+	list_for_each_entry_safe(ptdev, tmp, &vm->ptdev_head, vm_node) {
+		pkvm_spin_lock(&vm->lock);
+		list_del(&ptdev->vm_node);
+		pkvm_spin_unlock(&vm->lock);
+
+		pkvm_detach_ptdev(ptdev);
+	}
 
 	shadow_size = vm->shadow_size;
 	memset(vm, 0, shadow_size);
@@ -422,4 +433,29 @@ void pkvm_kick_vcpu(struct kvm_vcpu *vcpu)
 		return;
 
 	pkvm_lapic_send_init(pcpu);
+}
+
+int pkvm_add_ptdev(int shadow_vm_handle, u16 bdf, u32 pasid)
+{
+	struct pkvm_shadow_vm *vm = get_shadow_vm(shadow_vm_handle);
+	struct pkvm_ptdev *ptdev;
+	int ret = 0;
+
+	if (!vm)
+		return -EINVAL;
+
+	if (vm->vm_type != KVM_X86_DEFAULT_VM) {
+		ptdev = pkvm_attach_ptdev(bdf, pasid, vm);
+		if (ptdev) {
+			pkvm_spin_lock(&vm->lock);
+			list_add_tail(&ptdev->vm_node, &vm->ptdev_head);
+			pkvm_spin_unlock(&vm->lock);
+		} else {
+			ret = -ENODEV;
+		}
+	}
+
+	put_shadow_vm(shadow_vm_handle);
+
+	return ret;
 }

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
@@ -122,15 +122,22 @@ int __pkvm_init_shadow_vm(struct kvm_vcpu *hvcpu, unsigned long kvm_va,
 	vm->shadow_size = shadow_size;
 	vm->vm_type = vm_type;
 
-	if (pkvm_shadow_ept_init(&vm->sept_desc))
+	if (pkvm_pgstate_pgt_init(vm))
 		goto undonate;
+
+	if (pkvm_shadow_ept_init(&vm->sept_desc))
+		goto deinit_pgstate_pgt;
 
 	shadow_vm_handle = allocate_shadow_vm_handle(vm);
 	if (shadow_vm_handle < 0)
-		goto undonate;
+		goto deinit_shadow_ept;
 
 	return shadow_vm_handle;
 
+deinit_shadow_ept:
+	pkvm_shadow_ept_deinit(&vm->sept_desc);
+deinit_pgstate_pgt:
+	pkvm_pgstate_pgt_deinit(vm);
 undonate:
 	memset(vm, 0, shadow_size);
 	__pkvm_hyp_donate_host(shadow_pa, shadow_size);
@@ -146,6 +153,8 @@ unsigned long __pkvm_teardown_shadow_vm(int shadow_vm_handle)
 		return 0;
 
 	pkvm_shadow_ept_deinit(&vm->sept_desc);
+
+	pkvm_pgstate_pgt_deinit(vm);
 
 	shadow_size = vm->shadow_size;
 	memset(vm, 0, shadow_size);

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
@@ -131,6 +131,9 @@ struct pkvm_shadow_vm {
 	 */
 	struct pkvm_pgtable pgstate_pgt;
 
+	/* link the passthrough devices of a protected VM */
+	struct list_head ptdev_head;
+
 	/* The vm_type to indicate if this is a protected VM */
 	unsigned long vm_type;
 
@@ -158,6 +161,7 @@ struct shadow_vcpu_state *get_shadow_vcpu(s64 shadow_vcpu_handle);
 void put_shadow_vcpu(s64 shadow_vcpu_handle);
 s64 find_shadow_vcpu_handle_by_vmcs(unsigned long vmcs12_pa);
 void pkvm_kick_vcpu(struct kvm_vcpu *vcpu);
+int pkvm_add_ptdev(int shadow_vm_handle, u16 bdf, u32 pasid);
 
 #define PKVM_REQ_TLB_FLUSH_HOST_EPT			KVM_ARCH_REQ(0)
 #define PKVM_REQ_TLB_FLUSH_SHADOW_EPT			KVM_ARCH_REQ(1)

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
@@ -143,6 +143,8 @@ struct pkvm_shadow_vm {
 
 #define sept_to_shadow_vm(_sept) sept_desc_to_shadow_vm(sept_to_shadow_ept_desc(_sept))
 
+#define pgstate_pgt_to_shadow_vm(_pgt) container_of(_pgt, struct pkvm_shadow_vm, pgstate_pgt)
+
 int __pkvm_init_shadow_vm(struct kvm_vcpu *hvcpu, unsigned long kvm_va,
 			  unsigned long shadow_pa,  size_t shadow_size);
 unsigned long __pkvm_teardown_shadow_vm(int shadow_vm_handle);

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
@@ -122,6 +122,15 @@ struct pkvm_shadow_vm {
 	 */
 	struct shadow_ept_desc sept_desc;
 
+	/*
+	 * Page state page table manages the page states, and
+	 * works as IOMMU second-level page table for protected
+	 * VM with passthrough devices. For the protected VM
+	 * without passthrough devices or normal VM, it manages
+	 * the page states only.
+	 */
+	struct pkvm_pgtable pgstate_pgt;
+
 	/* The vm_type to indicate if this is a protected VM */
 	unsigned long vm_type;
 

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
@@ -130,6 +130,8 @@ struct pkvm_shadow_vm {
 	 * the page states only.
 	 */
 	struct pkvm_pgtable pgstate_pgt;
+	/* Indicate if pgstate_pgt needs to be prepopulated */
+	bool need_prepopulation;
 
 	/* link the passthrough devices of a protected VM */
 	struct list_head ptdev_head;

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright(c) 2022 Intel Corporation. */
+
+#include <linux/hashtable.h>
+#include <pkvm_spinlock.h>
+#include <pkvm.h>
+#include "pkvm_hyp.h"
+#include "iommu.h"
+#include "ptdev.h"
+#include "bug.h"
+
+#define MAX_PTDEV_NUM	(PKVM_MAX_PDEV_NUM + PKVM_MAX_PASID_PDEV_NUM)
+static DEFINE_HASHTABLE(ptdev_hasht, 8);
+static DECLARE_BITMAP(ptdevs_bitmap, MAX_PTDEV_NUM);
+static struct pkvm_ptdev pkvm_ptdev[MAX_PTDEV_NUM];
+static pkvm_spinlock_t ptdev_lock = { __ARCH_PKVM_SPINLOCK_UNLOCKED };
+
+struct pkvm_ptdev *pkvm_get_ptdev(u16 bdf, u32 pasid)
+{
+	struct pkvm_ptdev *ptdev = NULL, *tmp;
+	unsigned long index;
+
+	pkvm_spin_lock(&ptdev_lock);
+
+	hash_for_each_possible(ptdev_hasht, tmp, hnode, bdf) {
+		if (match_ptdev(tmp, bdf, pasid)) {
+			ptdev = tmp;
+			break;
+		}
+	}
+
+	if (ptdev)
+		goto out;
+
+	index = find_next_zero_bit(ptdevs_bitmap, MAX_PTDEV_NUM, 0);
+	if (index < MAX_PTDEV_NUM) {
+		__set_bit(index, ptdevs_bitmap);
+		ptdev = &pkvm_ptdev[index];
+		ptdev->bdf = bdf;
+		ptdev->pasid = pasid;
+		ptdev->index = index;
+		ptdev->pgt = pkvm_hyp->host_vm.ept;
+		INIT_LIST_HEAD(&ptdev->iommu_node);
+		hash_add(ptdev_hasht, &ptdev->hnode, bdf);
+	}
+out:
+	pkvm_spin_unlock(&ptdev_lock);
+
+	return ptdev;
+}
+
+void pkvm_put_ptdev(struct pkvm_ptdev *ptdev)
+{
+	pkvm_spin_lock(&ptdev_lock);
+
+	hlist_del(&ptdev->hnode);
+
+	__clear_bit(ptdev->index, ptdevs_bitmap);
+
+	memset(ptdev, 0, sizeof(struct pkvm_ptdev));
+
+	pkvm_spin_unlock(&ptdev_lock);
+}
+
+void pkvm_setup_ptdev_vpgt(struct pkvm_ptdev *ptdev, unsigned long root_gpa,
+			   struct pkvm_mm_ops *mm_ops, struct pkvm_pgtable_ops *paging_ops,
+			   struct pkvm_pgtable_cap *cap)
+{
+	if (!root_gpa || root_gpa == INVALID_ADDR || !mm_ops || !paging_ops || !cap) {
+		memset(&ptdev->vpgt, 0, sizeof(struct pkvm_pgtable));
+		return;
+	}
+
+	ptdev->vpgt.root_pa = root_gpa;
+	PKVM_ASSERT(pkvm_pgtable_init(&ptdev->vpgt, mm_ops, paging_ops, cap, false) == 0);
+}
+
+void pkvm_setup_ptdev_did(struct pkvm_ptdev *ptdev, u16 did)
+{
+	ptdev->did = did;
+}

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
@@ -7,6 +7,7 @@
 #include "pgtable.h"
 
 struct pkvm_ptdev {
+	atomic_t refcount;
 	struct hlist_node hnode;
 	u16 did;
 	u16 bdf;
@@ -18,6 +19,9 @@ struct pkvm_ptdev {
 	struct pkvm_pgtable vpgt;
 	/* Represents the page table maintained by pKVM */
 	struct pkvm_pgtable *pgt;
+
+	int shadow_vm_handle;
+	struct list_head vm_node;
 };
 
 struct pkvm_ptdev *pkvm_get_ptdev(u16 bdf, u32 pasid);
@@ -26,6 +30,8 @@ void pkvm_setup_ptdev_vpgt(struct pkvm_ptdev *ptdev, unsigned long root_gpa,
 			   struct pkvm_mm_ops *mm_ops, struct pkvm_pgtable_ops *paging_ops,
 			   struct pkvm_pgtable_cap *cap);
 void pkvm_setup_ptdev_did(struct pkvm_ptdev *ptdev, u16 did);
+void pkvm_detach_ptdev(struct pkvm_ptdev *ptdev);
+struct pkvm_ptdev *pkvm_attach_ptdev(u16 bdf, u32 pasid, struct pkvm_shadow_vm *vm);
 
 static inline bool match_ptdev(struct pkvm_ptdev *ptdev, u16 bdf, u32 pasid)
 {

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright(c) 2022 Intel Corporation. */
+
+#ifndef _PKVM_PTDEV_H_
+#define _PKVM_PTDEV_H_
+
+#include "pgtable.h"
+
+struct pkvm_ptdev {
+	struct hlist_node hnode;
+	u16 did;
+	u16 bdf;
+	u32 pasid;
+	unsigned long index;
+	struct list_head iommu_node;
+
+	/* Represents the page table maintained by primary VM */
+	struct pkvm_pgtable vpgt;
+	/* Represents the page table maintained by pKVM */
+	struct pkvm_pgtable *pgt;
+};
+
+struct pkvm_ptdev *pkvm_get_ptdev(u16 bdf, u32 pasid);
+void pkvm_put_ptdev(struct pkvm_ptdev *ptdev);
+void pkvm_setup_ptdev_vpgt(struct pkvm_ptdev *ptdev, unsigned long root_gpa,
+			   struct pkvm_mm_ops *mm_ops, struct pkvm_pgtable_ops *paging_ops,
+			   struct pkvm_pgtable_cap *cap);
+void pkvm_setup_ptdev_did(struct pkvm_ptdev *ptdev, u16 did);
+
+static inline bool match_ptdev(struct pkvm_ptdev *ptdev, u16 bdf, u32 pasid)
+{
+	return ptdev && (ptdev->bdf == bdf) && (ptdev->pasid == pasid);
+}
+#endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
@@ -37,4 +37,10 @@ static inline bool match_ptdev(struct pkvm_ptdev *ptdev, u16 bdf, u32 pasid)
 {
 	return ptdev && (ptdev->bdf == bdf) && (ptdev->pasid == pasid);
 }
+
+static inline bool ptdev_attached_to_vm(struct pkvm_ptdev *ptdev)
+{
+	/* Attached ptdev has non-zero shadow_vm_handle */
+	return cmpxchg(&ptdev->shadow_vm_handle, 0, 0) != 0;
+}
 #endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/vmexit.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/vmexit.c
@@ -133,6 +133,9 @@ static unsigned long handle_vmcall(struct kvm_vcpu *vcpu)
 	case PKVM_HC_SET_MMIO_VE:
 		pkvm_shadow_clear_suppress_ve(vcpu, a0);
 		break;
+	case PKVM_HC_ADD_PTDEV:
+		ret = pkvm_add_ptdev(a0, a1, a2);
+		break;
 	default:
 		ret = -EINVAL;
 	}

--- a/arch/x86/kvm/vmx/pkvm/include/pkvm.h
+++ b/arch/x86/kvm/vmx/pkvm/include/pkvm.h
@@ -49,6 +49,7 @@ struct pkvm_host_vcpu {
 struct pkvm_host_vm {
 	struct pkvm_host_vcpu *host_vcpus[CONFIG_NR_CPUS];
 	struct pkvm_pgtable *ept;
+	struct pkvm_pgtable *ept_notlbflush;
 };
 
 struct pkvm_iommu_info {

--- a/arch/x86/kvm/vmx/pkvm/pkvm_host.c
+++ b/arch/x86/kvm/vmx/pkvm/pkvm_host.c
@@ -1024,6 +1024,36 @@ out:
 	return ret;
 }
 
+static int add_device_to_pkvm(struct device *dev, void *data)
+{
+	struct kvm_protected_vm *pkvm = data;
+	struct pci_dev *pdev;
+	u16 devid;
+
+	if (!dev_is_pci(dev))
+		return 0;
+
+	pdev = to_pci_dev(dev);
+	devid = PCI_DEVID(pdev->bus->number, pdev->devfn);
+
+	return kvm_hypercall3(PKVM_HC_ADD_PTDEV, pkvm->shadow_vm_handle, devid, 0);
+}
+
+int kvm_arch_add_device_to_pkvm(struct kvm *kvm, struct iommu_group *grp)
+{
+	int ret = 0;
+
+	kvm_get_kvm(kvm);
+
+	if (kvm->arch.vm_type == KVM_X86_PROTECTED_VM)
+		ret = iommu_group_for_each_dev(grp, &kvm->pkvm,
+					       add_device_to_pkvm);
+
+	kvm_put_kvm(kvm);
+
+	return ret;
+}
+
 int pkvm_init_shadow_vm(struct kvm *kvm)
 {
 	struct kvm_protected_vm *pkvm = &kvm->pkvm;

--- a/include/linux/kvm_host.h
+++ b/include/linux/kvm_host.h
@@ -2296,4 +2296,5 @@ static inline void kvm_handle_signal_exit(struct kvm_vcpu *vcpu)
 /* Max number of entries allowed for each kvm dirty ring */
 #define  KVM_DIRTY_RING_MAX_ENTRIES  65536
 
+int kvm_arch_add_device_to_pkvm(struct kvm *kvm, struct iommu_group *grp);
 #endif


### PR DESCRIPTION
This series is to add support for general passthrough device support for protected VM using scalable mode IOMMU.

Patch 1: Fix some macro issues.

Patch 2 ~ 3: is to introduce a new pgstate_pgt to separate the page state from shadow EPT to this pgstate_pgt. With this, shadow EPT works only as EPT role without managing page state anymore, so can directly use the page table framework API to do map/unmap/destroy. This change allows the pgstate_pgt to be populated with all protected VM's memory donated before it is running when there are passthrough devices.

Patch 4: add a new hypercall for KVM high to send the passthrough device information to pKVM so that pKVM can know which device will be assigned to a protected VM.

Patch 5: introduce ptdev structure to cache all the passthrough devices information for primary VM/normal VM/protected VM.

Patch 6 ~ 10: Attach the ptdev to the shadow VM if it is for protected VM and isolate them with protected VM's pgstate_pgt and audit the DID for each passthrough device to make sure its DID is not shared with any other VMs (primary VM, or normal VM, or other protected VM). Then populate the pgstate_pgt before handling any shadow EPT violation to make sure the device can access memory. When protected VM is destroying, un-isolate the passthrough devices and detach the ptdev instances from shadow VM.

Patch 11 ~ 12: optimize the host EPT TLB flushing for page donating. The original implementation will do remote TLB flushing for each donating which caused a lot of overhead in the pgstate_pgt population as the population will donate all the protected VM's memory. The optimization provide a way to do the remote TLB flushing after all the donating is done. This is safe because the donating only un-maps the memory from host EPT but doesn't map to shadow EPT so there is no secret generated in the memory during donating. Thus, we can do remote TLB flushing after all the donations are done but before map in shadow EPT.
