### PR TITLE
Fix regression caused by inline asm in pkvm_init_ept_page()

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -45,11 +45,7 @@ static inline void pkvm_init_ept_page(void *page)
 	 * For simplicity, unconditionally initialize SEPT to set "suppress
 	 * #VE".
 	 */
-	asm volatile ("rep stosq\n\t"
-		      :
-		      : "a"(EPT_PROT_DEF), "c"(512), "D"(page)
-		      : "memory"
-	);
+	memset64((u64 *)page, EPT_PROT_DEF, 512);
 }
 
 static void *ept_zalloc_page(struct pkvm_pool *pool)


### PR DESCRIPTION
Fix kernel bootup failure observed on ChromeOS pKVM-IA builds after commit 346eeda8c163 (`"pkvm: x86: Initialize every SEPT entry with "suppress #VE" bit set"`). More details below:

LLVM produces the following code for `host_ept_zalloc_page()` with inlined `pkvm_init_ept_page()`:

```
pushq	%rbp
movq	%rsp, %rbp
movq	$0, %rdi
xorl	%esi, %esi
callq	0x12 <host_ept_zalloc_page+0x12>
movq	%rax, %rdi
testq	%rax, %rax
je	0x2c <host_ept_zalloc_page+0x2c>
movabsq	$-9223372036854775808, %rax # imm = 0x8000000000000000
movl	$512, %ecx              # imm = 0x200
rep		stosq	%rax, %es:(%rdi)
movq	%rdi, %rax
popq	%rbp
jmp	0x35 <pkvm_page_count>
```

i.e. the RAX register (the return value of `host_ept_zalloc_page()`) is corrupted with the RDI register value which has been modified by "rep stosq" in the inline asm. As a result, kernel bootup fails.

The problem is that RDI is specified as input-only, so the compiler assumes that RDI is not modified by the inline asm. It can be fixed by making RDI also an output operand. This is properly implemented in `memset64()` in `arch/x86/include/asm/string_64.h`. So just replace this inline asm with `memset64()`.