### PR TITLE
pkvm: x86: Rename context_clear_dte() to context_sm_clear_dte()

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
@@ -331,7 +331,7 @@ static bool sync_shadow_context_entry(struct pgt_sync_data *sdata)
 
 		if (ecap_smts(sdata->iommu_ecap))
 			/* Clear DTE to make sure device TLB is disabled for security */
-			context_clear_dte(&tmp);
+			context_sm_clear_dte(&tmp);
 		else {
 			/*
 			 * Set translation type to CONTEXT_TT_MULTI_LEVEL to ensure using

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
@@ -147,7 +147,7 @@ static inline void entry_set_bits(u64 *ptr, u64 mask, u64 bits)
 	WRITE_ONCE(*ptr, (old & ~mask) | bits);
 }
 
-static inline void context_clear_dte(struct context_entry *ce)
+static inline void context_sm_clear_dte(struct context_entry *ce)
 {
 	entry_set_bits(&ce->lo, 1 << 2, 0);
 }


### PR DESCRIPTION
context_clear_dte() is only valid for context entry under scalable mode, so rename it to context_sm_clear_dte().

Signed-off-by: Jason Chen CJ <jason.cj.chen@intel.com>