### PR TITLE
Virtualization Exception (#VE) guest support

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -877,6 +877,15 @@ config INTEL_TDX_GUEST
 	  memory contents and CPU state. TDX guests are protected from
 	  some attacks from the VMM.
 
+config PKVM_GUEST
+	bool "PKVM Guest Support"
+	depends on X86_64 && !PKVM_INTEL
+	default n
+	help
+	  Support running as a protected guest under Protected KVM.
+	  Without this support, the guest kernel can not boot or run
+	  under Protected KVM.
+
 endif # HYPERVISOR_GUEST
 
 source "arch/x86/Kconfig.cpu"

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -880,6 +880,8 @@ config INTEL_TDX_GUEST
 config PKVM_GUEST
 	bool "PKVM Guest Support"
 	depends on X86_64 && !PKVM_INTEL
+	select ARCH_HAS_CC_PLATFORM
+	select X86_MEM_ENCRYPT
 	default n
 	help
 	  Support running as a protected guest under Protected KVM.

--- a/arch/x86/coco/Makefile
+++ b/arch/x86/coco/Makefile
@@ -5,5 +5,5 @@ CFLAGS_core.o		+= -fno-stack-protector
 
 obj-y += core.o
 
-obj-$(CONFIG_INTEL_TDX_GUEST)	+= tdx/
+obj-$(CONFIG_INTEL_TDX_GUEST)	+= tdx/ virt_exception.o
 obj-$(CONFIG_PKVM_GUEST) += pkvm/

--- a/arch/x86/coco/Makefile
+++ b/arch/x86/coco/Makefile
@@ -6,4 +6,4 @@ CFLAGS_core.o		+= -fno-stack-protector
 obj-y += core.o
 
 obj-$(CONFIG_INTEL_TDX_GUEST)	+= tdx/ virt_exception.o
-obj-$(CONFIG_PKVM_GUEST) += pkvm/
+obj-$(CONFIG_PKVM_GUEST) += pkvm/ virt_exception.o

--- a/arch/x86/coco/Makefile
+++ b/arch/x86/coco/Makefile
@@ -6,3 +6,4 @@ CFLAGS_core.o		+= -fno-stack-protector
 obj-y += core.o
 
 obj-$(CONFIG_INTEL_TDX_GUEST)	+= tdx/
+obj-$(CONFIG_PKVM_GUEST) += pkvm/

--- a/arch/x86/coco/core.c
+++ b/arch/x86/coco/core.c
@@ -16,6 +16,38 @@
 static enum cc_vendor vendor __ro_after_init;
 static u64 cc_mask __ro_after_init;
 
+static bool pkvm_cc_platform_has(enum cc_attr attr)
+{
+	/*
+	 * Since primary VM can't access pkvm guest's memory, pkvm guest need
+	 * explicitly share DMA buffer with primary VM to make virtio work. By
+	 * using these attribute, pkvm guest will using bounce buffer for DMA
+	 * operation, and share the bounce buffer with primary VM.
+	 *
+	 * CC_ATTR_GUEST_UNROLL_STRING_IO: Since string io cause KVM to do
+	 * instruction decode, to avoid it, using this attribute will unroll the
+	 * string io. For example, in <asm/io.h>, the definition of the outsb
+	 * check to attribute to determine if using string io.
+	 *
+	 * CC_ATTR_GUEST_MEM_ENCRYPT: This attribute has been checked in the
+	 * force_dma_unencrypted(). Which means all DMA buffer will be shared
+	 * between pkvm guest and primary VM. And checked in
+	 * pci_swiotlb_detect(), this makes pkvm guest using bounce buffer.
+	 *
+	 * CC_ATTR_MEM_ENCRYPT: This attribute has been checked in the
+	 * mem_encrypt_init(). Which will make all bounce buffer being shared
+	 * between pkvm guest and primary VM.
+	 */
+	switch (attr) {
+	case CC_ATTR_GUEST_UNROLL_STRING_IO:
+	case CC_ATTR_GUEST_MEM_ENCRYPT:
+	case CC_ATTR_MEM_ENCRYPT:
+		return true;
+	default:
+		return false;
+	}
+}
+
 static bool intel_cc_platform_has(enum cc_attr attr)
 {
 	switch (attr) {
@@ -90,6 +122,8 @@ bool cc_platform_has(enum cc_attr attr)
 		return intel_cc_platform_has(attr);
 	case CC_VENDOR_HYPERV:
 		return hyperv_cc_platform_has(attr);
+	case CC_VENDOR_PKVM:
+		return pkvm_cc_platform_has(attr);
 	default:
 		return false;
 	}

--- a/arch/x86/coco/pkvm/Makefile
+++ b/arch/x86/coco/pkvm/Makefile
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: GPL-2.0
 
-obj-y += pkvm.o
+obj-y += pkvm.o pkvmcall.o

--- a/arch/x86/coco/pkvm/Makefile
+++ b/arch/x86/coco/pkvm/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0
+
+obj-y += pkvm.o

--- a/arch/x86/coco/pkvm/pkvm.c
+++ b/arch/x86/coco/pkvm/pkvm.c
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <asm/pkvm.h>
+
+__init void pkvm_guest_early_init(void)
+{
+	u32 sig;
+
+	/*
+	 * The convension with pkvm hypervisor to detect if guest is running on
+	 * pkvm as a protected vm is:
+	 *
+	 * Use cpuid leaf=0x21, subleaf=0x0, and the return result will in eax,
+	 * it's a string "pkvm".
+	 */
+	sig = cpuid_eax(0x21);
+
+	if (memcmp("pkvm", &sig, sizeof(u32)))
+		return;
+
+	pr_info("pkvm guest detected\n");
+}

--- a/arch/x86/coco/pkvm/pkvm.c
+++ b/arch/x86/coco/pkvm/pkvm.c
@@ -1,5 +1,40 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <asm/pkvm.h>
+#include <linux/kvm_para.h>
+
+static bool pkvm_guest_detected;
+
+bool pkvm_is_protected_guest(void)
+{
+	return pkvm_guest_detected;
+}
+
+int pkvm_set_mem_host_visibility(unsigned long addr, int numpages, bool enc)
+{
+	unsigned long size = numpages * PAGE_SIZE;
+
+	if (!enc) {
+		/*
+		 * When pkvm guest want to share a range of memory, these pages
+		 * may have not been setup in the guest ept pagetables. So when
+		 * the pkvm do the __pkvm_guest_share_host() thing, if no page
+		 * found in guest ept, this function will failed, thus the share
+		 * page function will failed.
+		 * So before share these pages to host, first touch them, so
+		 * they will have entry in the guest ept, to make sure the
+		 * sharing will success.
+		 *
+		 * TODO: Another good way to mitigate this touch is to fake ept
+		 * violation when the sharing function find that there is no
+		 * page in the guest ept.
+		 */
+		memset((void *)addr, 0, size);
+		kvm_hypercall2(PKVM_GHC_SHARE_MEM, __pa(addr), size);
+	} else
+		kvm_hypercall2(PKVM_GHC_UNSHARE_MEM, __pa(addr), size);
+
+	return 0;
+}
 
 __init void pkvm_guest_early_init(void)
 {
@@ -16,6 +51,10 @@ __init void pkvm_guest_early_init(void)
 
 	if (memcmp("pkvm", &sig, sizeof(u32)))
 		return;
+
+	cc_set_vendor(CC_VENDOR_PKVM);
+
+	pkvm_guest_detected = true;
 
 	pr_info("pkvm guest detected\n");
 }

--- a/arch/x86/coco/pkvm/pkvm.c
+++ b/arch/x86/coco/pkvm/pkvm.c
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0
-#include <asm/pkvm.h>
+
+#undef pr_fmt
+#define pr_fmt(fmt)     "pkvm: " fmt
+
+#include <linux/cpufeature.h>
 #include <linux/kvm_para.h>
+#include <asm/coco.h>
+#include <asm/vmx.h>
+#include <asm/pkvm.h>
+#include <asm/insn.h>
+#include <asm/insn-eval.h>
+#include <asm/pgtable.h>
+#include <asm/virt_exception.h>
 
 static bool pkvm_guest_detected;
 
@@ -36,6 +47,59 @@ int pkvm_set_mem_host_visibility(unsigned long addr, int numpages, bool enc)
 	return 0;
 }
 
+void pkvm_get_ve_info(struct ve_info *ve)
+{
+	/* Reuse the tdx output for pkvm. */
+	struct tdx_module_output out;
+
+	__pkvm_module_call(PKVM_GHC_GET_VE_INFO, &out);
+
+	/* Transfer the output parameters */
+	ve->exit_reason = out.rcx;
+	ve->exit_qual   = out.rdx;
+	ve->gla         = out.r8;
+	ve->gpa         = out.r9;
+}
+
+static bool mmio_write(int size, unsigned long addr, unsigned long val)
+{
+	kvm_hypercall3(PKVM_GHC_IOWRITE, addr, size, val);
+
+	return true;
+}
+
+static bool mmio_read(int size, unsigned long addr, unsigned long *val)
+{
+	*val = kvm_hypercall2(PKVM_GHC_IOREAD, addr, size);
+
+	return true;
+}
+
+static int virt_exception_kernel(struct pt_regs *regs, struct ve_info *ve)
+{
+	switch (ve->exit_reason) {
+	case EXIT_REASON_EPT_VIOLATION:
+		return ve_handle_mmio(regs, ve);
+	default:
+		pr_warn("Unexpected #VE: %lld\n", ve->exit_reason);
+		return -EIO;
+	}
+}
+
+static bool pkvm_handle_virt_exception(struct pt_regs *regs, struct ve_info *ve)
+{
+	int insn_len;
+
+	insn_len = virt_exception_kernel(regs, ve);
+	if (insn_len < 0)
+		return false;
+
+	/* After successful #VE handling, move the IP */
+	regs->ip += insn_len;
+
+	return true;
+}
+
 __init void pkvm_guest_early_init(void)
 {
 	u32 sig;
@@ -56,5 +120,10 @@ __init void pkvm_guest_early_init(void)
 
 	pkvm_guest_detected = true;
 
-	pr_info("pkvm guest detected\n");
+	ve_x86_ops.mmio_read = mmio_read;
+	ve_x86_ops.mmio_write = mmio_write;
+	ve_x86_ops.handle_virt_exception = pkvm_handle_virt_exception;
+	ve_x86_ops.get_ve_info = pkvm_get_ve_info;
+
+	pr_info("Guest detected\n");
 }

--- a/arch/x86/coco/pkvm/pkvmcall.S
+++ b/arch/x86/coco/pkvm/pkvmcall.S
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <asm/asm-offsets.h>
+#include <asm/asm.h>
+#include <asm/frame.h>
+#include <asm/unwind_hints.h>
+
+#include <linux/linkage.h>
+#include <linux/bits.h>
+#include <linux/errno.h>
+
+.macro PKVM_MODULE_CALL
+	/* Save the output parameter. */
+	push %r12
+
+	/* Push output pointer to stack. */
+	push %rsi
+
+	mov %rdi, %rax
+
+	vmcall
+
+	pop %r12
+
+	test %r12, %r12
+	jz .Lno_output_struct
+
+	/* Copy result registers to output struct. */
+	movq %rcx, 0(%r12)
+	movq %rdx, 8(%r12)
+	movq %r8, 16(%r12)
+	movq %r9, 24(%r12)
+
+.Lno_output_struct:
+	pop %r12
+.endm
+
+SYM_FUNC_START(__pkvm_module_call)
+	FRAME_BEGIN
+	PKVM_MODULE_CALL
+	FRAME_END
+	RET
+SYM_FUNC_END(__pkvm_module_call)

--- a/arch/x86/coco/tdx/tdx.c
+++ b/arch/x86/coco/tdx/tdx.c
@@ -309,7 +309,7 @@ static int handle_cpuid(struct pt_regs *regs, struct ve_info *ve)
 	return ve_instr_len(ve);
 }
 
-bool mmio_read(int size, unsigned long addr, unsigned long *val)
+static bool mmio_read(int size, unsigned long addr, unsigned long *val)
 {
 	struct tdx_hypercall_args args = {
 		.r10 = TDX_HYPERCALL_STANDARD,
@@ -326,7 +326,7 @@ bool mmio_read(int size, unsigned long addr, unsigned long *val)
 	return true;
 }
 
-bool mmio_write(int size, unsigned long addr, unsigned long val)
+static bool mmio_write(int size, unsigned long addr, unsigned long val)
 {
 	return !_tdx_hypercall(hcall_func(EXIT_REASON_EPT_VIOLATION), size,
 			       EPT_WRITE, addr, val);
@@ -500,7 +500,7 @@ static int virt_exception_kernel(struct pt_regs *regs, struct ve_info *ve)
 	}
 }
 
-bool tdx_handle_virt_exception(struct pt_regs *regs, struct ve_info *ve)
+static bool tdx_handle_virt_exception(struct pt_regs *regs, struct ve_info *ve)
 {
 	int insn_len;
 
@@ -668,6 +668,11 @@ void __init tdx_early_init(void)
 	x86_platform.guest.enc_cache_flush_required = tdx_cache_flush_required;
 	x86_platform.guest.enc_tlb_flush_required   = tdx_tlb_flush_required;
 	x86_platform.guest.enc_status_change_finish = tdx_enc_status_changed;
+
+	ve_x86_ops.mmio_read = mmio_read;
+	ve_x86_ops.mmio_write = mmio_write;
+	ve_x86_ops.handle_virt_exception = tdx_handle_virt_exception;
+	ve_x86_ops.get_ve_info = tdx_get_ve_info;
 
 	pr_info("Guest detected\n");
 }

--- a/arch/x86/coco/tdx/tdx.c
+++ b/arch/x86/coco/tdx/tdx.c
@@ -491,7 +491,7 @@ static int virt_exception_kernel(struct pt_regs *regs, struct ve_info *ve)
 	case EXIT_REASON_CPUID:
 		return handle_cpuid(regs, ve);
 	case EXIT_REASON_EPT_VIOLATION:
-		return handle_mmio(regs, ve);
+		return ve_handle_mmio(regs, ve);
 	case EXIT_REASON_IO_INSTRUCTION:
 		return handle_io(regs, ve);
 	default:

--- a/arch/x86/coco/tdx/tdx.c
+++ b/arch/x86/coco/tdx/tdx.c
@@ -11,6 +11,7 @@
 #include <asm/insn.h>
 #include <asm/insn-eval.h>
 #include <asm/pgtable.h>
+#include <asm/virt_exception.h>
 
 /* TDX module Call Leaf IDs */
 #define TDX_GET_INFO			1
@@ -308,7 +309,7 @@ static int handle_cpuid(struct pt_regs *regs, struct ve_info *ve)
 	return ve_instr_len(ve);
 }
 
-static bool mmio_read(int size, unsigned long addr, unsigned long *val)
+bool mmio_read(int size, unsigned long addr, unsigned long *val)
 {
 	struct tdx_hypercall_args args = {
 		.r10 = TDX_HYPERCALL_STANDARD,
@@ -325,115 +326,10 @@ static bool mmio_read(int size, unsigned long addr, unsigned long *val)
 	return true;
 }
 
-static bool mmio_write(int size, unsigned long addr, unsigned long val)
+bool mmio_write(int size, unsigned long addr, unsigned long val)
 {
 	return !_tdx_hypercall(hcall_func(EXIT_REASON_EPT_VIOLATION), size,
 			       EPT_WRITE, addr, val);
-}
-
-static int handle_mmio(struct pt_regs *regs, struct ve_info *ve)
-{
-	unsigned long *reg, val, vaddr;
-	char buffer[MAX_INSN_SIZE];
-	struct insn insn = {};
-	enum mmio_type mmio;
-	int size, extend_size;
-	u8 extend_val = 0;
-
-	/* Only in-kernel MMIO is supported */
-	if (WARN_ON_ONCE(user_mode(regs)))
-		return -EFAULT;
-
-	if (copy_from_kernel_nofault(buffer, (void *)regs->ip, MAX_INSN_SIZE))
-		return -EFAULT;
-
-	if (insn_decode(&insn, buffer, MAX_INSN_SIZE, INSN_MODE_64))
-		return -EINVAL;
-
-	mmio = insn_decode_mmio(&insn, &size);
-	if (WARN_ON_ONCE(mmio == MMIO_DECODE_FAILED))
-		return -EINVAL;
-
-	if (mmio != MMIO_WRITE_IMM && mmio != MMIO_MOVS) {
-		reg = insn_get_modrm_reg_ptr(&insn, regs);
-		if (!reg)
-			return -EINVAL;
-	}
-
-	/*
-	 * Reject EPT violation #VEs that split pages.
-	 *
-	 * MMIO accesses are supposed to be naturally aligned and therefore
-	 * never cross page boundaries. Seeing split page accesses indicates
-	 * a bug or a load_unaligned_zeropad() that stepped into an MMIO page.
-	 *
-	 * load_unaligned_zeropad() will recover using exception fixups.
-	 */
-	vaddr = (unsigned long)insn_get_addr_ref(&insn, regs);
-	if (vaddr / PAGE_SIZE != (vaddr + size - 1) / PAGE_SIZE)
-		return -EFAULT;
-
-	/* Handle writes first */
-	switch (mmio) {
-	case MMIO_WRITE:
-		memcpy(&val, reg, size);
-		if (!mmio_write(size, ve->gpa, val))
-			return -EIO;
-		return insn.length;
-	case MMIO_WRITE_IMM:
-		val = insn.immediate.value;
-		if (!mmio_write(size, ve->gpa, val))
-			return -EIO;
-		return insn.length;
-	case MMIO_READ:
-	case MMIO_READ_ZERO_EXTEND:
-	case MMIO_READ_SIGN_EXTEND:
-		/* Reads are handled below */
-		break;
-	case MMIO_MOVS:
-	case MMIO_DECODE_FAILED:
-		/*
-		 * MMIO was accessed with an instruction that could not be
-		 * decoded or handled properly. It was likely not using io.h
-		 * helpers or accessed MMIO accidentally.
-		 */
-		return -EINVAL;
-	default:
-		WARN_ONCE(1, "Unknown insn_decode_mmio() decode value?");
-		return -EINVAL;
-	}
-
-	/* Handle reads */
-	if (!mmio_read(size, ve->gpa, &val))
-		return -EIO;
-
-	switch (mmio) {
-	case MMIO_READ:
-		/* Zero-extend for 32-bit operation */
-		extend_size = size == 4 ? sizeof(*reg) : 0;
-		break;
-	case MMIO_READ_ZERO_EXTEND:
-		/* Zero extend based on operand size */
-		extend_size = insn.opnd_bytes;
-		break;
-	case MMIO_READ_SIGN_EXTEND:
-		/* Sign extend based on operand size */
-		extend_size = insn.opnd_bytes;
-		if (size == 1 && val & BIT(7))
-			extend_val = 0xFF;
-		else if (size > 1 && val & BIT(15))
-			extend_val = 0xFF;
-		break;
-	default:
-		/* All other cases has to be covered with the first switch() */
-		WARN_ON_ONCE(1);
-		return -EINVAL;
-	}
-
-	if (extend_size)
-		memset(reg, extend_val, extend_size);
-	memcpy(reg, &val, size);
-	return insn.length;
 }
 
 static bool handle_in(struct pt_regs *regs, int size, int port)

--- a/arch/x86/coco/virt_exception.c
+++ b/arch/x86/coco/virt_exception.c
@@ -4,7 +4,7 @@
 #include <asm/insn-eval.h>
 #include <asm/virt_exception.h>
 
-int handle_mmio(struct pt_regs *regs, struct ve_info *ve)
+int ve_handle_mmio(struct pt_regs *regs, struct ve_info *ve)
 {
 	unsigned long *reg, val, vaddr;
 	char buffer[MAX_INSN_SIZE];

--- a/arch/x86/coco/virt_exception.c
+++ b/arch/x86/coco/virt_exception.c
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <linux/cpufeature.h>
+#include <asm/insn.h>
+#include <asm/insn-eval.h>
+#include <asm/virt_exception.h>
+
+int handle_mmio(struct pt_regs *regs, struct ve_info *ve)
+{
+	unsigned long *reg, val, vaddr;
+	char buffer[MAX_INSN_SIZE];
+	struct insn insn = {};
+	enum mmio_type mmio;
+	int size, extend_size;
+	u8 extend_val = 0;
+
+	/* Only in-kernel MMIO is supported */
+	if (WARN_ON_ONCE(user_mode(regs)))
+		return -EFAULT;
+
+	if (copy_from_kernel_nofault(buffer, (void *)regs->ip, MAX_INSN_SIZE))
+		return -EFAULT;
+
+	if (insn_decode(&insn, buffer, MAX_INSN_SIZE, INSN_MODE_64))
+		return -EINVAL;
+
+	mmio = insn_decode_mmio(&insn, &size);
+	if (WARN_ON_ONCE(mmio == MMIO_DECODE_FAILED))
+		return -EINVAL;
+
+	if (mmio != MMIO_WRITE_IMM && mmio != MMIO_MOVS) {
+		reg = insn_get_modrm_reg_ptr(&insn, regs);
+		if (!reg)
+			return -EINVAL;
+	}
+
+	/*
+	 * Reject EPT violation #VEs that split pages.
+	 *
+	 * MMIO accesses are supposed to be naturally aligned and therefore
+	 * never cross page boundaries. Seeing split page accesses indicates
+	 * a bug or a load_unaligned_zeropad() that stepped into an MMIO page.
+	 *
+	 * load_unaligned_zeropad() will recover using exception fixups.
+	 */
+	vaddr = (unsigned long)insn_get_addr_ref(&insn, regs);
+	if (vaddr / PAGE_SIZE != (vaddr + size - 1) / PAGE_SIZE)
+		return -EFAULT;
+
+	/* Handle writes first */
+	switch (mmio) {
+	case MMIO_WRITE:
+		memcpy(&val, reg, size);
+		if (!mmio_write(size, ve->gpa, val))
+			return -EIO;
+		return insn.length;
+	case MMIO_WRITE_IMM:
+		val = insn.immediate.value;
+		if (!mmio_write(size, ve->gpa, val))
+			return -EIO;
+		return insn.length;
+	case MMIO_READ:
+	case MMIO_READ_ZERO_EXTEND:
+	case MMIO_READ_SIGN_EXTEND:
+		/* Reads are handled below */
+		break;
+	case MMIO_MOVS:
+	case MMIO_DECODE_FAILED:
+		/*
+		 * MMIO was accessed with an instruction that could not be
+		 * decoded or handled properly. It was likely not using io.h
+		 * helpers or accessed MMIO accidentally.
+		 */
+		return -EINVAL;
+	default:
+		WARN_ONCE(1, "Unknown insn_decode_mmio() decode value?");
+		return -EINVAL;
+	}
+
+	/* Handle reads */
+	if (!mmio_read(size, ve->gpa, &val))
+		return -EIO;
+
+	switch (mmio) {
+	case MMIO_READ:
+		/* Zero-extend for 32-bit operation */
+		extend_size = size == 4 ? sizeof(*reg) : 0;
+		break;
+	case MMIO_READ_ZERO_EXTEND:
+		/* Zero extend based on operand size */
+		extend_size = insn.opnd_bytes;
+		break;
+	case MMIO_READ_SIGN_EXTEND:
+		/* Sign extend based on operand size */
+		extend_size = insn.opnd_bytes;
+		if (size == 1 && val & BIT(7))
+			extend_val = 0xFF;
+		else if (size > 1 && val & BIT(15))
+			extend_val = 0xFF;
+		break;
+	default:
+		/* All other cases has to be covered with the first switch() */
+		WARN_ON_ONCE(1);
+		return -EINVAL;
+	}
+
+	if (extend_size)
+		memset(reg, extend_val, extend_size);
+	memcpy(reg, &val, size);
+	return insn.length;
+}

--- a/arch/x86/coco/virt_exception.c
+++ b/arch/x86/coco/virt_exception.c
@@ -4,6 +4,8 @@
 #include <asm/insn-eval.h>
 #include <asm/virt_exception.h>
 
+struct ve_x86_ops ve_x86_ops;
+
 int ve_handle_mmio(struct pt_regs *regs, struct ve_info *ve)
 {
 	unsigned long *reg, val, vaddr;
@@ -50,12 +52,12 @@ int ve_handle_mmio(struct pt_regs *regs, struct ve_info *ve)
 	switch (mmio) {
 	case MMIO_WRITE:
 		memcpy(&val, reg, size);
-		if (!mmio_write(size, ve->gpa, val))
+		if (!ve_x86_ops.mmio_write(size, ve->gpa, val))
 			return -EIO;
 		return insn.length;
 	case MMIO_WRITE_IMM:
 		val = insn.immediate.value;
-		if (!mmio_write(size, ve->gpa, val))
+		if (!ve_x86_ops.mmio_write(size, ve->gpa, val))
 			return -EIO;
 		return insn.length;
 	case MMIO_READ:
@@ -77,7 +79,7 @@ int ve_handle_mmio(struct pt_regs *regs, struct ve_info *ve)
 	}
 
 	/* Handle reads */
-	if (!mmio_read(size, ve->gpa, &val))
+	if (!ve_x86_ops.mmio_read(size, ve->gpa, &val))
 		return -EIO;
 
 	switch (mmio) {
@@ -107,4 +109,18 @@ int ve_handle_mmio(struct pt_regs *regs, struct ve_info *ve)
 		memset(reg, extend_val, extend_size);
 	memcpy(reg, &val, size);
 	return insn.length;
+}
+
+bool handle_virt_exception(struct pt_regs *regs, struct ve_info *ve)
+{
+	if (ve_x86_ops.handle_virt_exception)
+		return ve_x86_ops.handle_virt_exception(regs, ve);
+
+	return false;
+}
+
+void get_ve_info(struct ve_info *ve)
+{
+	if (ve_x86_ops.get_ve_info)
+		ve_x86_ops.get_ve_info(ve);
 }

--- a/arch/x86/include/asm/coco.h
+++ b/arch/x86/include/asm/coco.h
@@ -9,6 +9,7 @@ enum cc_vendor {
 	CC_VENDOR_AMD,
 	CC_VENDOR_HYPERV,
 	CC_VENDOR_INTEL,
+	CC_VENDOR_PKVM,
 };
 
 void cc_set_vendor(enum cc_vendor v);

--- a/arch/x86/include/asm/idtentry.h
+++ b/arch/x86/include/asm/idtentry.h
@@ -632,7 +632,7 @@ DECLARE_IDTENTRY_XENCB(X86_TRAP_OTHER,	exc_xen_hypervisor_callback);
 DECLARE_IDTENTRY_RAW(X86_TRAP_OTHER,	exc_xen_unknown_trap);
 #endif
 
-#ifdef CONFIG_INTEL_TDX_GUEST
+#if defined(CONFIG_INTEL_TDX_GUEST) || defined(CONFIG_PKVM_GUEST)
 DECLARE_IDTENTRY(X86_TRAP_VE,		exc_virtualization_exception);
 #endif
 

--- a/arch/x86/include/asm/pkvm.h
+++ b/arch/x86/include/asm/pkvm.h
@@ -129,4 +129,14 @@ static inline void pkvm_update_iommu_virtual_caps(u64 *cap, u64 *ecap)
 }
 #endif
 
+#ifdef CONFIG_PKVM_GUEST
+
+void pkvm_guest_early_init(void);
+
+#else
+
+static inline void pkvm_guest_early_init(void) {}
+
+#endif
+
 #endif

--- a/arch/x86/include/asm/pkvm.h
+++ b/arch/x86/include/asm/pkvm.h
@@ -8,6 +8,7 @@
 #include <asm/kvm_para.h>
 #include <asm/io.h>
 #include <asm/coco.h>
+#include <asm/virt_exception.h>
 
 /* PKVM Hypercalls */
 #define PKVM_HC_INIT_FINALISE		1
@@ -135,6 +136,8 @@ static inline void pkvm_update_iommu_virtual_caps(u64 *cap, u64 *ecap)
 void pkvm_guest_early_init(void);
 bool pkvm_is_protected_guest(void);
 int pkvm_set_mem_host_visibility(unsigned long addr, int numpages, bool enc);
+
+u64 __pkvm_module_call(u64 fn, struct tdx_module_output *out);
 
 #else
 

--- a/arch/x86/include/asm/pkvm.h
+++ b/arch/x86/include/asm/pkvm.h
@@ -7,6 +7,7 @@
 
 #include <asm/kvm_para.h>
 #include <asm/io.h>
+#include <asm/coco.h>
 
 /* PKVM Hypercalls */
 #define PKVM_HC_INIT_FINALISE		1
@@ -132,10 +133,14 @@ static inline void pkvm_update_iommu_virtual_caps(u64 *cap, u64 *ecap)
 #ifdef CONFIG_PKVM_GUEST
 
 void pkvm_guest_early_init(void);
+bool pkvm_is_protected_guest(void);
+int pkvm_set_mem_host_visibility(unsigned long addr, int numpages, bool enc);
 
 #else
 
 static inline void pkvm_guest_early_init(void) {}
+static inline bool pkvm_is_protected_guest(void) { return false; }
+static inline int pkvm_set_mem_host_visibility(unsigned long addr, int numpages, bool enc) { return 0; }
 
 #endif
 

--- a/arch/x86/include/asm/tdx.h
+++ b/arch/x86/include/asm/tdx.h
@@ -46,8 +46,6 @@ u64 __tdx_module_call(u64 fn, u64 rcx, u64 rdx, u64 r8, u64 r9,
 
 void tdx_get_ve_info(struct ve_info *ve);
 
-bool tdx_handle_virt_exception(struct pt_regs *regs, struct ve_info *ve);
-
 void tdx_safe_halt(void);
 
 bool tdx_early_handle_ve(struct pt_regs *regs);

--- a/arch/x86/include/asm/tdx.h
+++ b/arch/x86/include/asm/tdx.h
@@ -7,6 +7,7 @@
 #include <linux/bits.h>
 #include <asm/ptrace.h>
 #include <asm/shared/tdx.h>
+#include <asm/virt_exception.h>
 
 /*
  * SW-defined error codes.
@@ -33,22 +34,6 @@ struct tdx_module_output {
 	u64 r9;
 	u64 r10;
 	u64 r11;
-};
-
-/*
- * Used by the #VE exception handler to gather the #VE exception
- * info from the TDX module. This is a software only structure
- * and not part of the TDX module/VMM ABI.
- */
-struct ve_info {
-	u64 exit_reason;
-	u64 exit_qual;
-	/* Guest Linear (virtual) Address */
-	u64 gla;
-	/* Guest Physical Address */
-	u64 gpa;
-	u32 instr_len;
-	u32 instr_info;
 };
 
 #ifdef CONFIG_INTEL_TDX_GUEST

--- a/arch/x86/include/asm/virt_exception.h
+++ b/arch/x86/include/asm/virt_exception.h
@@ -24,8 +24,18 @@ struct ve_info {
 
 int ve_handle_mmio(struct pt_regs *regs, struct ve_info *ve);
 
-bool mmio_read(int size, unsigned long addr, unsigned long *val);
-bool mmio_write(int size, unsigned long addr, unsigned long val);
+void get_ve_info(struct ve_info *ve);
+
+bool handle_virt_exception(struct pt_regs *regs, struct ve_info *ve);
+
+struct ve_x86_ops {
+	bool (*mmio_read)(int size, unsigned long addr, unsigned long *val);
+	bool (*mmio_write)(int size, unsigned long addr, unsigned long val);
+	bool (*handle_virt_exception)(struct pt_regs *regs, struct ve_info *ve);
+	void (*get_ve_info)(struct ve_info *ve);
+};
+
+extern struct ve_x86_ops ve_x86_ops;
 
 #endif /* !__ASSEMBLY__ */
 #endif /* _ASM_X86_VIRT_EXCEPTION_H */

--- a/arch/x86/include/asm/virt_exception.h
+++ b/arch/x86/include/asm/virt_exception.h
@@ -22,7 +22,7 @@ struct ve_info {
 	u32 instr_info;
 };
 
-int handle_mmio(struct pt_regs *regs, struct ve_info *ve);
+int ve_handle_mmio(struct pt_regs *regs, struct ve_info *ve);
 
 bool mmio_read(int size, unsigned long addr, unsigned long *val);
 bool mmio_write(int size, unsigned long addr, unsigned long val);

--- a/arch/x86/include/asm/virt_exception.h
+++ b/arch/x86/include/asm/virt_exception.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _ASM_X86_VIRT_EXCEPTION_H
+#define _ASM_X86_VIRT_EXCEPTION_H
+
+#include <asm/ptrace.h>
+
+#ifndef __ASSEMBLY__
+
+/*
+ * Used by the #VE exception handler to gather the #VE exception
+ * info from the TDX module. This is a software only structure
+ * and not part of the TDX module/VMM ABI.
+ */
+struct ve_info {
+	u64 exit_reason;
+	u64 exit_qual;
+	/* Guest Linear (virtual) Address */
+	u64 gla;
+	/* Guest Physical Address */
+	u64 gpa;
+	u32 instr_len;
+	u32 instr_info;
+};
+
+int handle_mmio(struct pt_regs *regs, struct ve_info *ve);
+
+bool mmio_read(int size, unsigned long addr, unsigned long *val);
+bool mmio_write(int size, unsigned long addr, unsigned long val);
+
+#endif /* !__ASSEMBLY__ */
+#endif /* _ASM_X86_VIRT_EXCEPTION_H */

--- a/arch/x86/kernel/head64.c
+++ b/arch/x86/kernel/head64.c
@@ -41,6 +41,7 @@
 #include <asm/trapnr.h>
 #include <asm/sev.h>
 #include <asm/tdx.h>
+#include <asm/pkvm.h>
 
 /*
  * Manage page tables very early on.
@@ -523,6 +524,9 @@ asmlinkage __visible void __init x86_64_start_kernel(char * real_mode_data)
 
 	/* Needed before cc_platform_has() can be used for TDX */
 	tdx_early_init();
+
+	/* Needed before cc_platform_has() can be used for pkvm. */
+	pkvm_guest_early_init();
 
 	copy_bootdata(__va(real_mode_data));
 

--- a/arch/x86/kernel/idt.c
+++ b/arch/x86/kernel/idt.c
@@ -69,7 +69,7 @@ static const __initconst struct idt_data early_idts[] = {
 	 */
 	INTG(X86_TRAP_PF,		asm_exc_page_fault),
 #endif
-#ifdef CONFIG_INTEL_TDX_GUEST
+#if defined(CONFIG_INTEL_TDX_GUEST) || defined(CONFIG_PKVM_GUEST)
 	INTG(X86_TRAP_VE,		asm_exc_virtualization_exception),
 #endif
 };

--- a/arch/x86/kernel/traps.c
+++ b/arch/x86/kernel/traps.c
@@ -1344,7 +1344,7 @@ DEFINE_IDTENTRY(exc_device_not_available)
 	}
 }
 
-#ifdef CONFIG_INTEL_TDX_GUEST
+#if defined(CONFIG_INTEL_TDX_GUEST) || defined(CONFIG_PKVM_GUEST)
 
 #define VE_FAULT_STR "VE fault"
 

--- a/arch/x86/kernel/traps.c
+++ b/arch/x86/kernel/traps.c
@@ -62,7 +62,7 @@
 #include <asm/insn.h>
 #include <asm/insn-eval.h>
 #include <asm/vdso.h>
-#include <asm/tdx.h>
+#include <asm/virt_exception.h>
 
 #ifdef CONFIG_X86_64
 #include <asm/x86_init.h>
@@ -1413,15 +1413,15 @@ DEFINE_IDTENTRY(exc_virtualization_exception)
 	 * till TDGETVEINFO TDCALL is executed. This ensures that VE
 	 * info cannot be overwritten by a nested #VE.
 	 */
-	tdx_get_ve_info(&ve);
+	get_ve_info(&ve);
 
 	cond_local_irq_enable(regs);
 
 	/*
-	 * If tdx_handle_virt_exception() could not process
+	 * If handle_virt_exception() could not process
 	 * it successfully, treat it as #GP(0) and handle it.
 	 */
-	if (!tdx_handle_virt_exception(regs, &ve))
+	if (!handle_virt_exception(regs, &ve))
 		ve_raise_fault(regs, 0);
 
 	cond_local_irq_disable(regs);

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -976,7 +976,7 @@ void pkvm_shadow_clear_suppress_ve(struct kvm_vcpu *vcpu, unsigned long gfn)
 	struct shadow_ept_desc *desc = &vm->sept_desc;
 	struct pkvm_pgtable *sept = &desc->sept;
 
-	if (vm->vm_type != KVM_X86_PROTECTED_VM)
+	if (!shadow_vcpu_is_protected(shadow_vcpu))
 		return;
 
 	/*

--- a/arch/x86/kvm/vmx/pkvm/hyp/nested.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/nested.c
@@ -849,7 +849,7 @@ int handle_vmptrld(struct kvm_vcpu *vcpu)
 						/*
 						 * Write the #VE information physical address.
 						 */
-						if (shadow_vcpu->vm->vm_type == KVM_X86_PROTECTED_VM) {
+						if (shadow_vcpu_is_protected(shadow_vcpu)) {
 							memset(&shadow_vcpu->ve_info, 0, sizeof(shadow_vcpu->ve_info));
 							vmcs_write64(VE_INFO_ADDR, __pkvm_pa(&shadow_vcpu->ve_info));
 						}
@@ -1316,7 +1316,7 @@ static bool nested_handle_vmcall(struct kvm_vcpu *vcpu)
 	int ret = 0;
 
 	/* All normal guest's vmcall should be handled by KVM. */
-	if (shadow_vcpu->vm->vm_type == KVM_X86_DEFAULT_VM)
+	if (!shadow_vcpu_is_protected(shadow_vcpu))
 		return false;
 
 	nr = vcpu->arch.regs[VCPU_REGS_RAX];

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
@@ -170,4 +170,9 @@ int pkvm_add_ptdev(int shadow_vm_handle, u16 bdf, u32 pasid);
 
 extern struct pkvm_hyp *pkvm_hyp;
 
+static inline bool shadow_vcpu_is_protected(struct shadow_vcpu_state *shadow_vcpu)
+{
+	return shadow_vcpu->vm->vm_type == KVM_X86_PROTECTED_VM;
+}
+
 #endif

--- a/arch/x86/mm/pat/set_memory.c
+++ b/arch/x86/mm/pat/set_memory.c
@@ -32,6 +32,7 @@
 #include <asm/memtype.h>
 #include <asm/hyperv-tlfs.h>
 #include <asm/mshyperv.h>
+#include <asm/pkvm.h>
 
 #include "../mm_internal.h"
 
@@ -2071,6 +2072,9 @@ static int __set_memory_enc_pgtable(unsigned long addr, int numpages, bool enc)
 
 static int __set_memory_enc_dec(unsigned long addr, int numpages, bool enc)
 {
+	if (pkvm_is_protected_guest())
+		return pkvm_set_mem_host_visibility(addr, numpages, enc);
+
 	if (hv_is_isolation_supported())
 		return hv_set_mem_host_visibility(addr, numpages, !enc);
 


### PR DESCRIPTION
Virtualization Exception(#VE)[1] is a feature that can benefit pkvm. Since the KVM
can't access the memory of Protected VM, Protected VM need some other ways to do
MMIO operation. One way is to use #VE, this patch set adds guest support for
#VE.

When Protected VM (pVM) do MMIO operation, pVM will get a #VE, pVM need to
handle it. First pVM need to get #VE information from pkvm. Then do instruction
decode inside pVM, after get the instruction information. The pVM need pass the
instruction information to KVM, this can be done by hypercall. When return from
the #VE handler, pVM has done the MMIO operation.

patch 1-2: The first patch is a clean up patch, the second patch is to support
cpuid detection in pkvm.

patch 3-8: Add support for pkvm guest.

changelog:
----------
v6:
  - Rename the handle_mmio().
  - Replace cpuid_count() with cpuid_eax().
  - Add checking before call ve_x86_ops.
v5:
  - Refine the tdx code movement patch.
  - Refine the ve_x86_ops.
v4:
  - Modify the cpuid subleaf to align with TDX, but return different value.
  - Split the movement patch into two, one is pure movement, one is adding the
  ve_x86_ops.
v3:
  - Add cpuid support to detect if pkvm guest running on pkvm.
  - Add more comments.
  - Rename the coco_common.c to virt_exception.c.
v2:
  - add pkvm_cc_platform_has which used by pkvm.
  - split patch into two, one is code movement, one is implementation.