### PR TITLE
Fix detection of IOMMU coherency in legacy mode

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/pkvm_host.c
+++ b/arch/x86/kvm/vmx/pkvm/pkvm_host.c
@@ -169,8 +169,7 @@ static int check_and_init_iommu(struct pkvm_hyp *pkvm)
 		iounmap(addr);
 
 		/*
-		 * If pkvm IOMMU works in scalable mode, it needs to check SMPWC for
-		 * the coherency of the paging structure accessed through pasid table entry.
+		 * If pkvm IOMMU works in scalable mode, it requires to use nested translation.
 		 */
 		if (ecap_smts(ecap) && !ecap_nest(ecap)) {
 			pr_err("pkvm: drhd reg_base 0x%llx: nested translation not supported\n",

--- a/arch/x86/kvm/vmx/pkvm/pkvm_host.c
+++ b/arch/x86/kvm/vmx/pkvm/pkvm_host.c
@@ -75,6 +75,15 @@ static int check_pci_device_count(void)
 	return 0;
 }
 
+/*
+ * Check for the coherency of paging structures accessed through pasid table
+ * entries (in scalable mode) or context table entries (in legacy mode).
+ */
+static inline bool is_iommu_coherent(u64 ecap)
+{
+	return ecap_smts(ecap) ? !!ecap_smpwc(ecap) : !!ecap_coherent(ecap);
+}
+
 static int check_and_init_iommu(struct pkvm_hyp *pkvm)
 {
 	struct pkvm_iommu_info *info;
@@ -170,10 +179,9 @@ static int check_and_init_iommu(struct pkvm_hyp *pkvm)
 		}
 
 		/*
-		 * Check SMPWC for the coherency of the paging structure accessed
-		 * through pasid table entry.
+		 * Check for the coherency of the paging structure access.
 		 */
-		if (!ecap_smpwc(ecap))
+		if (!is_iommu_coherent(ecap))
 			pkvm->iommu_coherent = false;
 
 		info->reg_phys = drhd->reg_base_addr;


### PR DESCRIPTION
The ECAP.SMPWC (scalable-mode page-walk coherency) capability bit is valid only in scalable mode. In legacy mode the coherency of IOMMU paging structures is reported via the ECAP.C (page-walk coherency) bit instead.