### PR TITLE
pkvm: x86: Fix deadlocks caused by __pkvm_guest_share_host()/__pkvm_g…

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/mem_protect.c
@@ -742,8 +742,8 @@ int __pkvm_guest_share_host(struct pkvm_pgtable *guest_pgt,
 	if (!PAGE_ALIGNED(size))
 		return -EINVAL;
 
-	host_ept_lock();
 	guest_pgstate_pgt_lock(guest_pgt);
+	host_ept_lock();
 
 	while (size) {
 		pkvm_pgtable_lookup(guest_pgt, gpa, &hpa, &prot, NULL);
@@ -760,8 +760,9 @@ int __pkvm_guest_share_host(struct pkvm_pgtable *guest_pgt,
 		gpa += PAGE_SIZE;
 	}
 
-	guest_pgstate_pgt_unlock(guest_pgt);
 	host_ept_unlock();
+	guest_pgstate_pgt_unlock(guest_pgt);
+
 
 	return ret;
 }
@@ -987,8 +988,8 @@ int __pkvm_guest_unshare_host(struct pkvm_pgtable *guest_pgt,
 	u64 prot;
 	int ret = 0;
 
-	host_ept_lock();
 	guest_pgstate_pgt_lock(guest_pgt);
+	host_ept_lock();
 
 	while (size) {
 		pkvm_pgtable_lookup(guest_pgt, gpa, &hpa, &prot, NULL);
@@ -1005,8 +1006,8 @@ int __pkvm_guest_unshare_host(struct pkvm_pgtable *guest_pgt,
 		gpa += PAGE_SIZE;
 	}
 
-	guest_pgstate_pgt_unlock(guest_pgt);
 	host_ept_unlock();
+	guest_pgstate_pgt_unlock(guest_pgt);
 
 	return ret;
 }


### PR DESCRIPTION
…uest_unshare_host()

The __pkvm_guest_share_host()/__pkvm_guest_unshare_host() first gets _host_ept_lock, then gets vm->lock, meanwhile in pkvm_handle_shadow_ept_ violation()[1], the logic first gets vm->lock and then the _host_ept_lock. If a protected VM with more than one vCPU and one vCPU exits caused by shadow ept violation while another vCPU exits caused by handling share/unshare vmcall, a deadlock may come out as the two vCPUs are racing with each other on the two locks.

This patch fixes this issue by correcting the locking order to get vm->lock first, then _host_ept_lock.

[1]: The code path of invoking host_ept_lock() is: pkvm_handle_shadow_ept_violation()
  -> allow_shadow_ept_mapping()
    -> pkvm_pgtable_map()
      -> pkvm_pgstate_pgt_map_leaf()
        -> __pkvm_host_donate_guest()/__pkvm_host_donate_guest()
          -> host_ept_lock()

Signed-off-by: Tina Zhang <tina.zhang@intel.com>