### PR TITLE
Passthrough device support with legacy IOMMU

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.h
@@ -58,4 +58,7 @@ static inline bool is_valid_eptp(u64 eptp)
 	/* TODO: other bits check */
 	return true;
 }
+
+extern struct pkvm_pgtable_ops ept_ops;
+
 #endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
@@ -973,20 +973,23 @@ static int sync_shadow_id_cb(struct pkvm_pgtable *vpgt, unsigned long vaddr,
 	}
 
 	if (LAST_LEVEL(level)) {
-		if (ecap_smts(iommu->iommu.ecap)) {
-			/*
-			 * For PASID_TABLE, cache invalidation may want to
-			 * sync specific PASID with DID matched. So do the
-			 * check before syncing the entry.
-			 *
-			 * According to vt-d spec 6.2.2.1, software must not
-			 * use domain-id value of 0 when programming
-			 * context-entries on implementations reporting CM=1
-			 * in the Capability register.
-			 *
-			 * So non-zero DID means a real DID from host software.
-			 */
-			if (data->did && (pasid_get_domain_id(guest_ptep) != data->did))
+		/*
+		 * Cache invalidation may want to sync specific PASID entries
+		 * (in scalable mode) or context entries (in legacy mode) with
+		 * DID matched. In such case we only need to sync the entries
+		 * with the matching DID.
+		 *
+		 * According to vt-d spec 6.2.2.1 and 6.2.3.1, software must
+		 * not use domain-id value of 0 when programming entries on
+		 * implementations reporting CM=1 in the Capability register.
+		 * So non-zero DID means a real DID from host software.
+		 */
+		if (data->did) {
+			u16 did = ecap_smts(iommu->iommu.ecap)
+				? pasid_get_domain_id(guest_ptep)
+				: context_lm_get_did(guest_ptep);
+
+			if (did != data->did)
 				return ret;
 		}
 

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
@@ -152,14 +152,39 @@ static inline void context_sm_clear_dte(struct context_entry *ce)
 	entry_set_bits(&ce->lo, 1 << 2, 0);
 }
 
+static inline bool context_lm_is_present(struct context_entry *ce)
+{
+	return READ_ONCE(ce->lo) & 1;
+}
+
 static inline u8 context_lm_get_tt(struct context_entry *ce)
 {
 	return (READ_ONCE(ce->lo) >> 2) & 3;
 }
 
+static inline u64 context_lm_get_slptr(struct context_entry *ce)
+{
+	return READ_ONCE(ce->lo) & VTD_PAGE_MASK;
+}
+
+static inline u8 context_lm_get_aw(struct context_entry *ce)
+{
+	return READ_ONCE(ce->hi) & 0x7;
+}
+
+static inline u16 context_lm_get_did(struct context_entry *ce)
+{
+	return (READ_ONCE(ce->hi) >> 8) & 0xffff;
+}
+
 static inline void context_lm_set_tt(struct context_entry *ce, u8 value)
 {
 	entry_set_bits(&ce->lo, 3 << 2, value << 2);
+}
+
+static inline void context_lm_set_slptr(struct context_entry *ce, u64 value)
+{
+	entry_set_bits(&ce->lo, VTD_PAGE_MASK, value);
 }
 
 static inline void context_lm_set_aw(struct context_entry *ce, u8 value)


### PR DESCRIPTION
This PR is the next step in filling the gaps in pKVM support for legacy IOMMU mode.

Patch 1 reorganizes the code to properly register and use ptdev structures for passthrough devices in legacy mode just like in scalable mode. It doesn't change any functionality yet but it prepares for the next patches.

Patch 2 adds the missing check for DID matching to optimize DID-selective context cache invalidations (avoid unneeded syncing of context entries with non-matching DID) just like in scalable mode. Actually it could be done after https://github.com/intel-staging/pKVM-IA/commit/f62c45133ffa9e0d388f100cefc3360eb07d3448 independently of this PR.

Patch 3 adds support for attaching passthrough devices to protected VMs in legacy mode just like in scalable mode, reusing the VM's pgstate_pgt as the attached ptdev's IOMMU page tables.

This PR still does not implement shadow IOMMU page tables for the cases when the host itself uses address translation (i.e. uses vIOMMU in non-passthrough mode) for the given device, so in such case we still directly use the host's vIOMMU page tables as a temporary workaround, which means that protected VM memory protection is still not ensured in such cases. Implementing shadow IOMMU page tables is more challenging, mainly because it's not clear how to efficiently implement shadow IOMMU page table sync with the host EPT after a change of page ownership in the host EPT, i.e. after a page donation.