### PR TITLE
pkvm: x86: Fix missed TLB flushing in pgtable_unmap_leaf

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
@@ -266,9 +266,10 @@ static int pgtable_unmap_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		PKVM_ASSERT(phys == data->phys);
 	}
 
-	pgtable_set_entry(pgt_ops, mm_ops, ptep, pgt_ops->default_prot);
 	if (pgt_ops->pgt_entry_present(ptep))
 		flush_data->flushtlb |= true;
+
+	pgtable_set_entry(pgt_ops, mm_ops, ptep, pgt_ops->default_prot);
 	mm_ops->put_page(ptep);
 
 	if (data->phys != INVALID_ADDR) {


### PR DESCRIPTION
The flushtlb flag should be set before unmap an entry if that entry was present.

Fixes: e30674b32a3a (pkvm: x86: add pgt_entry_mapped callback for pgtable ops)
Signed-off-by: Chuanxiao Dong <chuanxiao.dong@intel.com>