### PR TITLE
Flush cache for pgstate_pgt

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -30,7 +30,7 @@ static struct pkvm_pgtable host_ept;
 static struct pkvm_pgtable host_ept_notlbflush;
 static pkvm_spinlock_t _host_ept_lock = __PKVM_SPINLOCK_UNLOCKED;
 
-static struct pkvm_pool shadow_ept_pool;
+static struct pkvm_pool shadow_pgt_pool;
 static struct rsvd_bits_validate ept_zero_check;
 
 static void flush_tlb_noop(struct pkvm_pgtable *pgt) { };
@@ -407,22 +407,22 @@ int pkvm_shadow_ept_pool_init(void *ept_pool_base, unsigned long ept_pool_pages)
 {
 	unsigned long pfn = __pkvm_pa(ept_pool_base) >> PAGE_SHIFT;
 
-	return pkvm_pool_init(&shadow_ept_pool, pfn, ept_pool_pages, 0);
+	return pkvm_pool_init(&shadow_pgt_pool, pfn, ept_pool_pages, 0);
 }
 
-static void *shadow_ept_zalloc_page(void)
+static void *shadow_pgt_zalloc_page(void)
 {
-	return ept_zalloc_page(&shadow_ept_pool);
+	return ept_zalloc_page(&shadow_pgt_pool);
 }
 
-static void shadow_ept_get_page(void *vaddr)
+static void shadow_pgt_get_page(void *vaddr)
 {
-	pkvm_get_page(&shadow_ept_pool, vaddr);
+	pkvm_get_page(&shadow_pgt_pool, vaddr);
 }
 
-static void shadow_ept_put_page(void *vaddr)
+static void shadow_pgt_put_page(void *vaddr)
 {
-	pkvm_put_page(&shadow_ept_pool, vaddr);
+	pkvm_put_page(&shadow_pgt_pool, vaddr);
 }
 
 static void shadow_ept_flush_tlb(struct pkvm_pgtable *pgt)
@@ -462,9 +462,9 @@ next:
 static struct pkvm_mm_ops shadow_ept_mm_ops = {
 	.phys_to_virt = pkvm_phys_to_virt,
 	.virt_to_phys = pkvm_virt_to_phys,
-	.zalloc_page = shadow_ept_zalloc_page,
-	.get_page = shadow_ept_get_page,
-	.put_page = shadow_ept_put_page,
+	.zalloc_page = shadow_pgt_zalloc_page,
+	.get_page = shadow_pgt_get_page,
+	.put_page = shadow_pgt_put_page,
 	.page_count = pkvm_page_count,
 	.flush_tlb = shadow_ept_flush_tlb,
 };
@@ -481,9 +481,9 @@ static struct pkvm_mm_ops shadow_ept_mm_ops = {
 static struct pkvm_mm_ops pgstate_pgt_mm_ops = {
 	.phys_to_virt = pkvm_phys_to_virt,
 	.virt_to_phys = pkvm_virt_to_phys,
-	.zalloc_page = shadow_ept_zalloc_page,
-	.get_page = shadow_ept_get_page,
-	.put_page = shadow_ept_put_page,
+	.zalloc_page = shadow_pgt_zalloc_page,
+	.get_page = shadow_pgt_get_page,
+	.put_page = shadow_pgt_put_page,
 	.page_count = pkvm_page_count,
 	.flush_tlb = flush_tlb_noop,
 };

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -488,6 +488,23 @@ static struct pkvm_mm_ops pgstate_pgt_mm_ops = {
 	.flush_tlb = flush_tlb_noop,
 };
 
+/*
+ * As pgstate pgt may be used as IOMMU page table, flushing cache is
+ * needed when modifying the page table entries if IOMMU is not coherent.
+ * This ops has flush_cache callback and can be used for the pgstate_pgt
+ * which is used as IOMMU page table with noncoherent IOMMU.
+ */
+static struct pkvm_mm_ops pgstate_pgt_mm_ops_noncoherency = {
+	.phys_to_virt = pkvm_phys_to_virt,
+	.virt_to_phys = pkvm_virt_to_phys,
+	.zalloc_page = shadow_pgt_zalloc_page,
+	.get_page = shadow_pgt_get_page,
+	.put_page = shadow_pgt_put_page,
+	.page_count = pkvm_page_count,
+	.flush_tlb = flush_tlb_noop,
+	.flush_cache = pkvm_clflush_cache_range,
+};
+
 static int pkvm_pgstate_pgt_map_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr, int level,
 				     void *ptep, struct pgt_flush_data *flush_data, void *arg)
 {
@@ -725,6 +742,14 @@ int pkvm_pgstate_pgt_init(struct pkvm_shadow_vm *vm)
 	};
 
 	return pkvm_pgtable_init(pgt, &pgstate_pgt_mm_ops, &ept_ops, &cap, true);
+}
+
+void pkvm_pgstate_pgt_update_coherency(struct pkvm_pgtable *pgt, bool coherent)
+{
+	if (coherent)
+		pkvm_pgtable_set_mm_ops(pgt, &pgstate_pgt_mm_ops);
+	else
+		pkvm_pgtable_set_mm_ops(pgt, &pgstate_pgt_mm_ops_noncoherency);
 }
 
 /*

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.h
@@ -48,6 +48,7 @@ void pkvm_shadow_clear_suppress_ve(struct kvm_vcpu *vcpu, unsigned long gfn);
 
 int pkvm_pgstate_pgt_init(struct pkvm_shadow_vm *vm);
 void pkvm_pgstate_pgt_deinit(struct pkvm_shadow_vm *vm);
+void pkvm_pgstate_pgt_update_coherency(struct pkvm_pgtable *pgt, bool coherent);
 bool is_pgt_ops_ept(struct pkvm_pgtable *pgt);
 
 static inline bool is_valid_eptp(u64 eptp)

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.h
@@ -10,5 +10,6 @@ unsigned long pkvm_access_iommu(bool is_read, int len, unsigned long reg, unsign
 bool is_mem_range_overlap_iommu(unsigned long start, unsigned long end);
 int pkvm_activate_iommu(void);
 int pkvm_iommu_sync(u16 bdf, u32 pasid);
+bool pkvm_iommu_coherency(u16 bdf, u32 pasid);
 
 #endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
@@ -66,6 +66,19 @@ static bool leaf_mapping_allowed(struct pkvm_pgtable_ops *pgt_ops,
 	return leaf_mapping_valid(pgt_ops, vaddr, vaddr_end, pgsz_mask, level);
 }
 
+static void *pgtable_alloc_page(struct pkvm_mm_ops *mm_ops)
+{
+	void *page = NULL;
+
+	if (mm_ops->zalloc_page)
+		page = mm_ops->zalloc_page();
+
+	if (page && mm_ops->flush_cache)
+		mm_ops->flush_cache(page, PAGE_SIZE);
+
+	return page;
+}
+
 static void pgtable_set_entry(struct pkvm_pgtable_ops *pgt_ops,
 			struct pkvm_mm_ops *mm_ops,
 			void *ptep, u64 pte)
@@ -177,7 +190,7 @@ static int pgtable_map_walk_leaf(struct pkvm_pgtable *pgt,
 	 * page mapping. And for current level, if the huge page mapping is already
 	 * present, we need further split it.
 	 */
-	page = mm_ops->zalloc_page();
+	page = pgtable_alloc_page(mm_ops);
 	if (!page)
 		return -ENOMEM;
 
@@ -337,7 +350,7 @@ static int pgtable_unmap_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		 * if it is huge pte, split and goto next level.
 		 */
 		u64 prot = pgt_ops->pgt_entry_to_prot(ptep);
-		void *page = mm_ops->zalloc_page();
+		void *page = pgtable_alloc_page(mm_ops);
 
 		if (!page)
 			return -ENOMEM;
@@ -550,8 +563,8 @@ int pkvm_pgtable_init(struct pkvm_pgtable *pgt,
 	if (!mm_ops || !pgt_ops || !cap)
 		return -EINVAL;
 
-	if (alloc_root && mm_ops->zalloc_page) {
-		root = mm_ops->zalloc_page();
+	if (alloc_root) {
+		root = pgtable_alloc_page(mm_ops);
 		if (!root)
 			return -ENOMEM;
 		pgt->root_pa = __pkvm_pa(root);

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
@@ -140,4 +140,9 @@ int pkvm_pgtable_annotate(struct pkvm_pgtable *pgt, unsigned long addr,
 			  unsigned long size, u64 annotation);
 int pkvm_pgtable_sync_map(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
 			  u64 *prot, pgtable_leaf_ov_fn_t map_leaf);
+
+static inline void pkvm_pgtable_set_mm_ops(struct pkvm_pgtable *pgt, struct pkvm_mm_ops *mm_ops)
+{
+	pgt->mm_ops = mm_ops;
+}
 #endif

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm_hyp.h
@@ -132,6 +132,11 @@ struct pkvm_shadow_vm {
 	struct pkvm_pgtable pgstate_pgt;
 	/* Indicate if pgstate_pgt needs to be prepopulated */
 	bool need_prepopulation;
+	/*
+	 * Indicate the count of the shadow VM passthrough devices
+	 * which are attached to non-coherent IOMMU.
+	 */
+	unsigned long noncoherent_ptdev;
 
 	/* link the passthrough devices of a protected VM */
 	struct list_head ptdev_head;
@@ -155,6 +160,10 @@ int __pkvm_init_shadow_vm(struct kvm_vcpu *hvcpu, unsigned long kvm_va,
 unsigned long __pkvm_teardown_shadow_vm(int shadow_vm_handle);
 struct pkvm_shadow_vm *get_shadow_vm(int shadow_vm_handle);
 void put_shadow_vm(int shadow_vm_handle);
+void pkvm_shadow_vm_link_ptdev(struct pkvm_shadow_vm *vm,
+			       struct list_head *node, bool coherency);
+void pkvm_shadow_vm_unlink_ptdev(struct pkvm_shadow_vm *vm,
+				 struct list_head *node, bool coherency);
 s64 __pkvm_init_shadow_vcpu(struct kvm_vcpu *hvcpu, int shadow_vm_handle,
 			    unsigned long vcpu_va, unsigned long shadow_pa,
 			    size_t shadow_size);

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.c
@@ -15,10 +15,36 @@ static DECLARE_BITMAP(ptdevs_bitmap, MAX_PTDEV_NUM);
 static struct pkvm_ptdev pkvm_ptdev[MAX_PTDEV_NUM];
 static pkvm_spinlock_t ptdev_lock = { __ARCH_PKVM_SPINLOCK_UNLOCKED };
 
+struct pkvm_ptdev *pkvm_alloc_ptdev(u16 bdf, u32 pasid, bool coherency)
+{
+	struct pkvm_ptdev *ptdev = NULL;
+	unsigned long index;
+
+	pkvm_spin_lock(&ptdev_lock);
+
+	index = find_next_zero_bit(ptdevs_bitmap, MAX_PTDEV_NUM, 0);
+	if (index < MAX_PTDEV_NUM) {
+		__set_bit(index, ptdevs_bitmap);
+		ptdev = &pkvm_ptdev[index];
+		ptdev->bdf = bdf;
+		ptdev->pasid = pasid;
+		ptdev->iommu_coherency = coherency;
+		ptdev->index = index;
+		ptdev->pgt = pkvm_hyp->host_vm.ept;
+		INIT_LIST_HEAD(&ptdev->iommu_node);
+		INIT_LIST_HEAD(&ptdev->vm_node);
+		atomic_set(&ptdev->refcount, 1);
+		hash_add(ptdev_hasht, &ptdev->hnode, bdf);
+	}
+
+	pkvm_spin_unlock(&ptdev_lock);
+
+	return ptdev;
+}
+
 struct pkvm_ptdev *pkvm_get_ptdev(u16 bdf, u32 pasid)
 {
 	struct pkvm_ptdev *ptdev = NULL, *tmp;
-	unsigned long index;
 
 	pkvm_spin_lock(&ptdev_lock);
 
@@ -30,25 +56,7 @@ struct pkvm_ptdev *pkvm_get_ptdev(u16 bdf, u32 pasid)
 		}
 	}
 
-	if (ptdev)
-		goto out;
-
-	index = find_next_zero_bit(ptdevs_bitmap, MAX_PTDEV_NUM, 0);
-	if (index < MAX_PTDEV_NUM) {
-		__set_bit(index, ptdevs_bitmap);
-		ptdev = &pkvm_ptdev[index];
-		ptdev->bdf = bdf;
-		ptdev->pasid = pasid;
-		ptdev->index = index;
-		ptdev->pgt = pkvm_hyp->host_vm.ept;
-		INIT_LIST_HEAD(&ptdev->iommu_node);
-		INIT_LIST_HEAD(&ptdev->vm_node);
-		atomic_set(&ptdev->refcount, 1);
-		hash_add(ptdev_hasht, &ptdev->hnode, bdf);
-	}
-out:
 	pkvm_spin_unlock(&ptdev_lock);
-
 	return ptdev;
 }
 
@@ -124,8 +132,12 @@ struct pkvm_ptdev *pkvm_attach_ptdev(u16 bdf, u32 pasid, struct pkvm_shadow_vm *
 {
 	struct pkvm_ptdev *ptdev = pkvm_get_ptdev(bdf, pasid);
 
-	if (!ptdev)
-		return NULL;
+	if (!ptdev) {
+		ptdev = pkvm_alloc_ptdev(bdf, pasid,
+					 pkvm_iommu_coherency(bdf, pasid));
+		if (!ptdev)
+			return NULL;
+	}
 
 	if (cmpxchg(&ptdev->shadow_vm_handle, 0, vm->shadow_vm_handle) != 0) {
 		pkvm_err("%s: ptdev with bdf 0x%x pasid 0x%x is already attached\n",

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
@@ -14,6 +14,7 @@ struct pkvm_ptdev {
 	u32 pasid;
 	unsigned long index;
 	struct list_head iommu_node;
+	bool iommu_coherency;
 
 	/* Represents the page table maintained by primary VM */
 	struct pkvm_pgtable vpgt;
@@ -24,6 +25,7 @@ struct pkvm_ptdev {
 	struct list_head vm_node;
 };
 
+struct pkvm_ptdev *pkvm_alloc_ptdev(u16 bdf, u32 pasid, bool coherency);
 struct pkvm_ptdev *pkvm_get_ptdev(u16 bdf, u32 pasid);
 void pkvm_put_ptdev(struct pkvm_ptdev *ptdev);
 void pkvm_setup_ptdev_vpgt(struct pkvm_ptdev *ptdev, unsigned long root_gpa,

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
@@ -32,8 +32,8 @@ void pkvm_setup_ptdev_vpgt(struct pkvm_ptdev *ptdev, unsigned long root_gpa,
 			   struct pkvm_mm_ops *mm_ops, struct pkvm_pgtable_ops *paging_ops,
 			   struct pkvm_pgtable_cap *cap);
 void pkvm_setup_ptdev_did(struct pkvm_ptdev *ptdev, u16 did);
-void pkvm_detach_ptdev(struct pkvm_ptdev *ptdev);
-struct pkvm_ptdev *pkvm_attach_ptdev(u16 bdf, u32 pasid, struct pkvm_shadow_vm *vm);
+void pkvm_detach_ptdev(struct pkvm_ptdev *ptdev, struct pkvm_shadow_vm *vm);
+int pkvm_attach_ptdev(u16 bdf, u32 pasid, struct pkvm_shadow_vm *vm);
 
 static inline bool match_ptdev(struct pkvm_ptdev *ptdev, u16 bdf, u32 pasid)
 {


### PR DESCRIPTION
Pgstate_pgt can be used as IOMMU page table when protected VM has passthrough device. If IOMMU is not coherent in this case, flush cache is needed when modify the pgstate_pgt.
