### PR TITLE
Shadow IOMMU page tables for legacy IOMMU

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -200,6 +200,33 @@ static inline unsigned long pkvm_shadow_ept_pgtable_pages(int nr_vm)
 	return (res * 2);
 }
 
+/*
+ * Calculate the total pages for shadow IOMMU page tables for the host's
+ * devices used with Legacy IOMMU. Similarly to the calculation for shadow EPT,
+ * we assume that there is no shared memory between devices using different
+ * page tables.
+ *
+ * TODO: do not reserve these pages if legacy mode is not used by pKVM, i.e.
+ * if all the IOMMUs have scalable mode capability.
+ */
+static inline unsigned long pkvm_host_shadow_iommu_pgtable_pages(int nr_pdev)
+{
+	unsigned long pgtable_pages = __pkvm_pgtable_total_pages();
+	unsigned long res;
+
+	res = pgtable_pages;
+
+	/*
+	 * Similarly to shadow VMs (see the comment in
+	 * pkvm_shadow_ept_pgtable_pages()), each device may require
+	 * its own level2:level5 page table pages.
+	 */
+	res += __pkvm_pgtable_max_pages(pgtable_pages) * (nr_pdev - 1);
+
+	return res;
+}
+
+
 u64 pkvm_total_reserve_pages(void);
 
 int pkvm_init_shadow_vm(struct kvm *kvm);

--- a/arch/x86/kvm/vmx/pkvm/hyp/Makefile
+++ b/arch/x86/kvm/vmx/pkvm/hyp/Makefile
@@ -18,7 +18,7 @@ pkvm-hyp-obj	:= $(obj)/vmx_asm.o $(obj)/vmexit.o \
 		   $(obj)/vmx.o $(obj)/vmsr.o \
 		   $(obj)/iommu.o $(obj)/iommu_debug.o \
 		   $(obj)/mem_protect.o $(obj)/lapic.o \
-		   $(obj)/ptdev.o \
+		   $(obj)/ptdev.o $(obj)/iommu_spgt.o \
 		   $(obj)/trace.o
 
 virt-dir	:= $(objtree)/$(KVM_PKVM)

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -255,6 +255,12 @@ int pkvm_host_ept_unmap(unsigned long vaddr_start, unsigned long phys_start,
 	return pkvm_pgtable_unmap_safe(&host_ept, vaddr_start, phys_start, size, NULL);
 }
 
+void pkvm_host_ept_lookup(unsigned long vaddr, unsigned long *pphys,
+			  u64 *pprot, int *plevel)
+{
+	pkvm_pgtable_lookup(&host_ept, vaddr, pphys, pprot, plevel);
+}
+
 void pkvm_host_ept_destroy(void)
 {
 	pkvm_pgtable_destroy(&host_ept, NULL);

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.c
@@ -482,15 +482,32 @@ static struct pkvm_mm_ops shadow_ept_mm_ops = {
 };
 
 /*
- * pgstate_pgt_mm_ops is similar to the shadow_ept_mm_ops as its
- * memory is reserved together with shadow EPT pages. The
- * difference is that it doesn't have the flush_tlb callback as
- * pgstate_pgt only works as IOMMU second-level page table for
- * protected VM when there are passthrough devices, and in this
- * case the memory is pinned, and the mapping is not allowed to
- * be removed from pgstate_pgt.
+ * mm_ops for shadow second-level IOMMU page tables. These tables
+ * are similar to shadow EPT tables, as they also have the EPT
+ * format and their memory is reserved together with shadow EPT
+ * pages. The difference is that this mm_ops doesn't have the
+ * flush_tlb callback.
+ *
+ * Precisely, shadow_sl_iommu_pgt_mm_ops is used for two kinds of
+ * 2nd level iommu page tables:
+ *
+ * - pgstate_pgt which is reused as IOMMU page table for protected
+ *   VM with passthrough devices. In this case the memory is pinned,
+ *   and the mapping is not allowed to be removed from pgstate_pgt,
+ *   so the flush_tlb callback is not needed.
+ *
+ * - Host shadow IOMMU page tables used for the host's devices when
+ *   legacy IOMMU is used. They do not need the flush_tlb callback
+ *   either, since IOTLB flush after unmapping pages from these
+ *   tables is performed in other ways: either as a part of vIOMMU
+ *   IOTLB flush emulation when initiated by the host, or together
+ *   with host EPT TLB flush when ensuring pKVM memory protection.
+ *
+ * TODO: refactor the code: move all the management of both types
+ * of 2nd level iommu page tables to iommu_spgt.c to some common API.
+ * That means also refactoring of pkvm_ptdev structure.
  */
-static struct pkvm_mm_ops pgstate_pgt_mm_ops = {
+static struct pkvm_mm_ops shadow_sl_iommu_pgt_mm_ops = {
 	.phys_to_virt = pkvm_phys_to_virt,
 	.virt_to_phys = pkvm_virt_to_phys,
 	.zalloc_page = shadow_pgt_zalloc_page,
@@ -501,12 +518,12 @@ static struct pkvm_mm_ops pgstate_pgt_mm_ops = {
 };
 
 /*
- * As pgstate pgt may be used as IOMMU page table, flushing cache is
- * needed when modifying the page table entries if IOMMU is not coherent.
- * This ops has flush_cache callback and can be used for the pgstate_pgt
- * which is used as IOMMU page table with noncoherent IOMMU.
+ * Flushing cache is needed when modifying IOMMU page table entries
+ * if the IOMMU is not coherent. This ops has flush_cache callback
+ * so it can be used for a pgtable which is used as IOMMU page table
+ * with noncoherent IOMMU.
  */
-static struct pkvm_mm_ops pgstate_pgt_mm_ops_noncoherency = {
+static struct pkvm_mm_ops shadow_sl_iommu_pgt_mm_ops_noncoherency = {
 	.phys_to_virt = pkvm_phys_to_virt,
 	.virt_to_phys = pkvm_virt_to_phys,
 	.zalloc_page = shadow_pgt_zalloc_page,
@@ -753,15 +770,21 @@ int pkvm_pgstate_pgt_init(struct pkvm_shadow_vm *vm)
 		.table_prot = VMX_EPT_RWX_MASK,
 	};
 
-	return pkvm_pgtable_init(pgt, &pgstate_pgt_mm_ops, &ept_ops, &cap, true);
+	return pkvm_pgtable_init(pgt, &shadow_sl_iommu_pgt_mm_ops, &ept_ops, &cap, true);
 }
 
-void pkvm_pgstate_pgt_update_coherency(struct pkvm_pgtable *pgt, bool coherent)
+struct pkvm_mm_ops *pkvm_shadow_sl_iommu_pgt_get_mm_ops(bool coherent)
+{
+	return coherent ? &shadow_sl_iommu_pgt_mm_ops
+			: &shadow_sl_iommu_pgt_mm_ops_noncoherency;
+}
+
+void pkvm_shadow_sl_iommu_pgt_update_coherency(struct pkvm_pgtable *pgt, bool coherent)
 {
 	if (coherent)
-		pkvm_pgtable_set_mm_ops(pgt, &pgstate_pgt_mm_ops);
+		pkvm_pgtable_set_mm_ops(pgt, &shadow_sl_iommu_pgt_mm_ops);
 	else
-		pkvm_pgtable_set_mm_ops(pgt, &pgstate_pgt_mm_ops_noncoherency);
+		pkvm_pgtable_set_mm_ops(pgt, &shadow_sl_iommu_pgt_mm_ops_noncoherency);
 }
 
 /*

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.h
@@ -48,7 +48,10 @@ void pkvm_shadow_clear_suppress_ve(struct kvm_vcpu *vcpu, unsigned long gfn);
 
 int pkvm_pgstate_pgt_init(struct pkvm_shadow_vm *vm);
 void pkvm_pgstate_pgt_deinit(struct pkvm_shadow_vm *vm);
-void pkvm_pgstate_pgt_update_coherency(struct pkvm_pgtable *pgt, bool coherent);
+
+struct pkvm_mm_ops *pkvm_shadow_sl_iommu_pgt_get_mm_ops(bool coherent);
+void pkvm_shadow_sl_iommu_pgt_update_coherency(struct pkvm_pgtable *pgt, bool coherent);
+
 bool is_pgt_ops_ept(struct pkvm_pgtable *pgt);
 
 static inline bool is_valid_eptp(u64 eptp)

--- a/arch/x86/kvm/vmx/pkvm/hyp/ept.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ept.h
@@ -28,6 +28,8 @@ int pkvm_host_ept_map(unsigned long vaddr_start, unsigned long phys_start,
 		unsigned long size, int pgsz_mask, u64 prot);
 int pkvm_host_ept_unmap(unsigned long vaddr_start, unsigned long phys_start,
 		unsigned long size);
+void pkvm_host_ept_lookup(unsigned long vaddr, unsigned long *pphys,
+			  u64 *pprot, int *plevel);
 void pkvm_host_ept_destroy(void);
 int pkvm_host_ept_init(struct pkvm_pgtable_cap *cap, void *ept_pool_base,
 		unsigned long ept_pool_pages);

--- a/arch/x86/kvm/vmx/pkvm/hyp/init_finalise.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/init_finalise.c
@@ -66,7 +66,8 @@ static int divide_memory_pool(phys_addr_t phys, unsigned long size)
 		return -ENOMEM;
 
 	nr_pages = pkvm_shadow_ept_pgtable_pages(PKVM_MAX_NORMAL_VM_NUM +
-						 PKVM_MAX_SECURE_VM_NUM);
+						 PKVM_MAX_SECURE_VM_NUM) +
+		   pkvm_host_shadow_iommu_pgtable_pages(PKVM_MAX_PDEV_NUM);
 	shadow_ept_base = pkvm_early_alloc_contig(nr_pages);
 	if (!shadow_ept_base)
 		return -ENOMEM;
@@ -333,7 +334,8 @@ int __pkvm_init_finalise(struct kvm_vcpu *vcpu, struct pkvm_section sections[],
 
 	ret = pkvm_shadow_ept_pool_init(shadow_ept_base,
 					pkvm_shadow_ept_pgtable_pages(PKVM_MAX_NORMAL_VM_NUM +
-								      PKVM_MAX_SECURE_VM_NUM));
+								      PKVM_MAX_SECURE_VM_NUM) +
+					pkvm_host_shadow_iommu_pgtable_pages(PKVM_MAX_PDEV_NUM));
 	if (ret)
 		goto out;
 

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
@@ -414,7 +414,7 @@ static bool sync_shadow_context_entry(struct pgt_sync_data *sdata)
 
 		if (!sdata->guest_ptep) {
 			if (context_lm_is_present(shadow_ce)) {
-				pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL);
+				pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL, false);
 				pkvm_setup_ptdev_did(ptdev, 0);
 				iommu_del_ptdev(iommu, ptdev);
 
@@ -431,7 +431,7 @@ static bool sync_shadow_context_entry(struct pgt_sync_data *sdata)
 			if (aw != 1 && aw != 2 && aw != 3) {
 				pkvm_err("pkvm: unsupported address width %u\n", aw);
 
-				pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL);
+				pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL, false);
 				pkvm_setup_ptdev_did(ptdev, 0);
 
 				/*
@@ -446,7 +446,7 @@ static bool sync_shadow_context_entry(struct pgt_sync_data *sdata)
 				    (aw == 2) ? 4 : 5;
 			cap.allowed_pgsz = pkvm_hyp->ept_cap.allowed_pgsz;
 			pkvm_setup_ptdev_vpgt(ptdev, context_lm_get_slptr(guest_ce),
-					      &viommu_mm_ops, &ept_ops, &cap);
+					      &viommu_mm_ops, &ept_ops, &cap, false);
 
 			break;
 		case CONTEXT_TT_PASS_THROUGH:
@@ -460,7 +460,7 @@ static bool sync_shadow_context_entry(struct pgt_sync_data *sdata)
 		default:
 			pkvm_err("pkvm: unsupported translation type %u\n", tt);
 
-			pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL);
+			pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL, false);
 			pkvm_setup_ptdev_did(ptdev, 0);
 			goto update_shadow_ce;
 		}
@@ -559,7 +559,7 @@ static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 			 * a ptdev's vpgt/did should be reset as well as
 			 * deleting ptdev from this iommu.
 			 */
-			pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL);
+			pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL, false);
 			pkvm_setup_ptdev_did(ptdev, 0);
 			iommu_del_ptdev(iommu, ptdev);
 
@@ -593,7 +593,7 @@ static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 		cap.level = pasid_get_flpm(guest_pte) == 0 ? 4 : 5;
 		cap.allowed_pgsz = pkvm_hyp->mmu_cap.allowed_pgsz;
 		pkvm_setup_ptdev_vpgt(ptdev, pasid_get_flptr(guest_pte),
-				      &viommu_mm_ops, &mmu_ops, &cap);
+				      &viommu_mm_ops, &mmu_ops, &cap, false);
 	} else if (type == PASID_ENTRY_PGTT_PT) {
 		/*
 		 * When host IOMMU driver is using pass-through mode, pkvm
@@ -611,7 +611,7 @@ static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 		 * linked to this IOMMU, and clear the shadow entry in order
 		 * not to support it.
 		 */
-		pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL);
+		pkvm_setup_ptdev_vpgt(ptdev, 0, NULL, NULL, NULL, false);
 		pkvm_setup_ptdev_did(ptdev, 0);
 
 		pkvm_err("pkvm: unsupported pasid type %lld\n", type);

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
@@ -26,38 +26,38 @@ static struct pkvm_iommu iommus[PKVM_MAX_IOMMU_NUM];
 static struct pkvm_pool iommu_pool;
 
 /*
- * Guest page table walking parameter.
+ * Guest root/context/pasid table (hereinafter "id table") walking parameter.
  * pkvm IOMMU driver walks the guest page table when syncing
- * with the shadow page table.
+ * with the shadow id table.
  */
-struct pgt_sync_walk_data {
+struct id_sync_walk_data {
 	struct pkvm_iommu *iommu;
 	/*
-	 * Used to hold shadow page table physical address
+	 * Used to hold shadow id table physical address
 	 * which is used for sync shadow entries at each
-	 * page table level.
+	 * id table level.
 	 */
 	u64 shadow_pa[IOMMU_SM_LEVEL_NUM];
 	/*
 	 * Used when just syncing a part of shadow
-	 * page table entries which match with this did if
+	 * id table entries which match with this did if
 	 * it is set as a non-zero did value.
 	 */
 	u16 did;
 };
 
-#define DEFINE_PGT_SYNC_WALK_DATA(name, _iommu, domain_id)	\
-	struct pgt_sync_walk_data (name) = {			\
+#define DEFINE_ID_SYNC_WALK_DATA(name, _iommu, domain_id)	\
+	struct id_sync_walk_data (name) = {			\
 		.iommu = (_iommu),				\
 		.shadow_pa = {0},				\
 		.did = (domain_id),				\
 	}
 
 /*
- * Used to config a shadow page table entry in root/context/pasid
+ * Used to config a shadow id table entry in root/context/pasid
  * level.
  */
-struct pgt_sync_data {
+struct id_sync_data {
 	union {
 		u64 root_entry;
 		struct context_entry ct_entry;
@@ -69,7 +69,7 @@ struct pgt_sync_data {
 	int level;
 	u64 iommu_ecap;
 	u64 shadow_pa;
-	struct pkvm_pgtable *spgt;
+	struct pkvm_pgtable *shadow_id;
 	unsigned long vaddr;
 };
 
@@ -362,7 +362,7 @@ static int iommu_audit_did(struct pkvm_iommu *iommu, u16 did, int shadow_vm_hand
 }
 
 /* present root entry when shadow_pa valid, otherwise un-present it */
-static bool sync_root_entry(struct pgt_sync_data *sdata)
+static bool sync_root_entry(struct id_sync_data *sdata)
 {
 	u64 *sre = sdata->shadow_ptep;
 	u64 sre_val = sdata->shadow_pa ? (sdata->shadow_pa | 1) : 0;
@@ -376,11 +376,11 @@ static bool sync_root_entry(struct pgt_sync_data *sdata)
 }
 
 /* sync context entry when guest_ptep & shadow_pa valid, otherwise un-present it */
-static bool sync_shadow_context_entry(struct pgt_sync_data *sdata)
+static bool sync_shadow_context_entry(struct id_sync_data *sdata)
 {
 	struct context_entry *shadow_ce = sdata->shadow_ptep, tmp = {0};
 	struct context_entry *guest_ce = sdata->guest_ptep;
-	struct pkvm_iommu *iommu = pgt_to_pkvm_iommu(sdata->spgt);
+	struct pkvm_iommu *iommu = pgt_to_pkvm_iommu(sdata->shadow_id);
 	struct pkvm_ptdev *ptdev;
 	struct pkvm_pgtable_cap cap;
 	bool updated = false;
@@ -513,7 +513,7 @@ update_shadow_ce:
 }
 
 /* sync pasid dir entry when guest_ptep & shadow_pa valid, otherwise un-present it */
-static bool sync_shadow_pasid_dir_entry(struct pgt_sync_data *sdata)
+static bool sync_shadow_pasid_dir_entry(struct id_sync_data *sdata)
 {
 	struct pasid_dir_entry *shadow_pde = sdata->shadow_ptep;
 	u64 val = 0;
@@ -534,11 +534,11 @@ static bool sync_shadow_pasid_dir_entry(struct pgt_sync_data *sdata)
 }
 
 /* sync pasid table entry when guest_ptep valid, otherwise un-present it */
-static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
+static bool sync_shadow_pasid_table_entry(struct id_sync_data *sdata)
 {
 	u16 bdf = sdata->vaddr >> DEVFN_SHIFT;
 	u32 pasid = sdata->vaddr & ((1UL << MAX_NR_PASID_BITS) - 1);
-	struct pkvm_iommu *iommu = pgt_to_pkvm_iommu(sdata->spgt);
+	struct pkvm_iommu *iommu = pgt_to_pkvm_iommu(sdata->shadow_id);
 	struct pkvm_ptdev *ptdev = iommu_find_ptdev(iommu, bdf, pasid);
 	struct pasid_entry *shadow_pte = sdata->shadow_ptep, tmp_pte = {0};
 	struct pasid_entry *guest_pte;
@@ -678,10 +678,10 @@ static bool sync_shadow_pasid_table_entry(struct pgt_sync_data *sdata)
 	return pasid_copy_entry(shadow_pte, &tmp_pte);
 }
 
-static bool iommu_id_sync_entry(struct pgt_sync_data *sdata)
+static bool iommu_id_sync_entry(struct id_sync_data *sdata)
 {
 	bool ret = false;
-	struct pkvm_pgtable *spgt = sdata->spgt;
+	struct pkvm_pgtable *shadow_id = sdata->shadow_id;
 
 	if (ecap_smts(sdata->iommu_ecap)) {
 		switch (sdata->level) {
@@ -714,10 +714,10 @@ static bool iommu_id_sync_entry(struct pgt_sync_data *sdata)
 	}
 
 	if (ret) {
-		int entry_size = spgt->pgt_ops->pgt_level_entry_size(sdata->level);
+		int entry_size = shadow_id->pgt_ops->pgt_level_entry_size(sdata->level);
 
-		if (entry_size && spgt->mm_ops->flush_cache)
-			spgt->mm_ops->flush_cache(sdata->shadow_ptep, entry_size);
+		if (entry_size && shadow_id->mm_ops->flush_cache)
+			shadow_id->mm_ops->flush_cache(sdata->shadow_ptep, entry_size);
 	}
 
 	return ret;
@@ -825,7 +825,7 @@ static int free_shadow_id_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 {
 	struct pkvm_pgtable_ops *pgt_ops = pgt->pgt_ops;
 	struct pkvm_mm_ops *mm_ops = pgt->mm_ops;
-	struct pgt_sync_data sync_data = {0};
+	struct id_sync_data sync_data = {0};
 	struct pkvm_iommu *iommu = pgt_to_pkvm_iommu(pgt);
 	void *child_ptep;
 
@@ -835,7 +835,7 @@ static int free_shadow_id_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 
 	sync_data.shadow_ptep = ptep;
 	sync_data.level = level;
-	sync_data.spgt = pgt;
+	sync_data.shadow_id = pgt;
 	sync_data.iommu_ecap = iommu->iommu.ecap;
 	sync_data.vaddr = vaddr;
 
@@ -863,14 +863,14 @@ static int free_shadow_id_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 }
 
 /* sync_data != NULL, data != NULL */
-static int init_sync_id_data(struct pgt_sync_data *sync_data,
-		struct pgt_sync_walk_data *data,
+static int init_sync_id_data(struct id_sync_data *sync_data,
+		struct id_sync_walk_data *data,
 		struct pkvm_iommu *iommu, void *guest_ptep,
 		unsigned long vaddr, int level)
 {
-	struct pkvm_pgtable *spgt = &iommu->pgt;
-	int idx = spgt->pgt_ops->pgt_entry_to_index(vaddr, level);
-	int entry_size = spgt->pgt_ops->pgt_level_entry_size(level);
+	struct pkvm_pgtable *shadow_id = &iommu->pgt;
+	int idx = shadow_id->pgt_ops->pgt_entry_to_index(vaddr, level);
+	int entry_size = shadow_id->pgt_ops->pgt_level_entry_size(level);
 
 	if (ecap_smts(iommu->iommu.ecap)) {
 		switch (level) {
@@ -913,11 +913,11 @@ static int init_sync_id_data(struct pgt_sync_data *sync_data,
 		return -EINVAL;
 
 	/* get current shadow_ptep */
-	sync_data->shadow_ptep = spgt->mm_ops->phys_to_virt(data->shadow_pa[level]);
+	sync_data->shadow_ptep = shadow_id->mm_ops->phys_to_virt(data->shadow_pa[level]);
 	sync_data->shadow_ptep += idx * entry_size;
 
 	sync_data->level = level;
-	sync_data->spgt = spgt;
+	sync_data->shadow_id = shadow_id;
 	sync_data->iommu_ecap = iommu->iommu.ecap;
 	sync_data->shadow_pa = 0;
 	sync_data->vaddr = vaddr;
@@ -933,10 +933,10 @@ static int sync_shadow_id_cb(struct pkvm_pgtable *vpgt, unsigned long vaddr,
 			  void *const arg)
 {
 	struct pkvm_pgtable_ops *vpgt_ops = vpgt->pgt_ops;
-	struct pgt_sync_walk_data *data = arg;
+	struct id_sync_walk_data *data = arg;
 	struct pkvm_iommu *iommu = data->iommu;
-	struct pkvm_pgtable *spgt = &iommu->pgt;
-	struct pgt_sync_data sync_data;
+	struct pkvm_pgtable *shadow_id = &iommu->pgt;
+	struct id_sync_data sync_data;
 	void *shadow_ptep, *guest_ptep;
 	bool shadow_p, guest_p;
 	int ret = init_sync_id_data(&sync_data, data, iommu, ptep, vaddr, level);
@@ -958,7 +958,7 @@ static int sync_shadow_id_cb(struct pkvm_pgtable *vpgt, unsigned long vaddr,
 		!vpgt_ops->pgt_entry_is_leaf(guest_ptep, level)))
 		return -EAGAIN;
 
-	shadow_p = spgt->pgt_ops->pgt_entry_present(shadow_ptep);
+	shadow_p = shadow_id->pgt_ops->pgt_entry_present(shadow_ptep);
 	guest_p = vpgt_ops->pgt_entry_present(guest_ptep);
 	if (!guest_p) {
 		if (shadow_p) {
@@ -966,16 +966,16 @@ static int sync_shadow_id_cb(struct pkvm_pgtable *vpgt, unsigned long vaddr,
 			 * For the case that guest not present but shadow present, just
 			 * simply free the shadow to make them consistent.
 			 */
-			unsigned long new_vaddr_end = spgt->pgt_ops->pgt_level_to_size(level) +
+			unsigned long new_vaddr_end = shadow_id->pgt_ops->pgt_level_to_size(level) +
 						      vaddr;
 			/*
 			 * Get a reference count before free to make sure the current page
 			 * of this level and the pages of its parent levels won't be freed.
 			 * As here we only want to free its specific sub-level.
 			 */
-			spgt->mm_ops->get_page(shadow_ptep);
+			shadow_id->mm_ops->get_page(shadow_ptep);
 			free_shadow_id(iommu, vaddr, new_vaddr_end);
-			spgt->mm_ops->put_page(shadow_ptep);
+			shadow_id->mm_ops->put_page(shadow_ptep);
 		}
 		/*
 		 * As now both guest and shadow are not
@@ -1018,32 +1018,32 @@ static int sync_shadow_id_cb(struct pkvm_pgtable *vpgt, unsigned long vaddr,
 		 * size. As we fixed the pasid to only support 15 bits,
 		 * the pasid dir is also one page with 4K size.
 		 */
-		void *shadow = spgt->mm_ops->zalloc_page();
+		void *shadow = shadow_id->mm_ops->zalloc_page();
 
 		if (!shadow)
 			return -ENOMEM;
-		/* Get the shadow page physical address of the child level */
-		sync_data.shadow_pa = spgt->mm_ops->virt_to_phys(shadow);
+		/* Get the shadow id physical address of the child level */
+		sync_data.shadow_pa = shadow_id->mm_ops->virt_to_phys(shadow);
 	} else
 		/*
 		 * For a present non-leaf (which is probably root/context/pasid dir)
-		 * entry, get the shadow page physical address of its child level.
+		 * entry, get the shadow id physical address of its child level.
 		 */
-		sync_data.shadow_pa = spgt->pgt_ops->pgt_entry_to_phys(shadow_ptep);
+		sync_data.shadow_pa = shadow_id->pgt_ops->pgt_entry_to_phys(shadow_ptep);
 
 	if (iommu_id_sync_entry(&sync_data)) {
 		if (!shadow_p)
 			/*
 			 * A non-present to present changing needs to get
-			 * a new reference count for the shadow page.
+			 * a new reference count for the shadow id page.
 			 */
-			spgt->mm_ops->get_page(shadow_ptep);
+			shadow_id->mm_ops->get_page(shadow_ptep);
 	}
 
 	if ((flags == PKVM_PGTABLE_WALK_TABLE_PRE) && (!LAST_LEVEL(level))) {
 		/*
 		 * As guest page table walking will go to the child level, pass
-		 * the shadow page physical address of the child level to sync.
+		 * the shadow id physical address of the child level to sync.
 		 */
 		data->shadow_pa[level - 1] = sync_data.shadow_pa;
 	}
@@ -1073,7 +1073,7 @@ static int free_shadow_id(struct pkvm_iommu *iommu, unsigned long vaddr,
 static int sync_shadow_id(struct pkvm_iommu *iommu, unsigned long vaddr,
 		       unsigned long vaddr_end, u16 did)
 {
-	DEFINE_PGT_SYNC_WALK_DATA(arg, iommu, did);
+	DEFINE_ID_SYNC_WALK_DATA(arg, iommu, did);
 	struct pkvm_pgtable_walker walker = {
 		.cb = sync_shadow_id_cb,
 		.flags = PKVM_PGTABLE_WALK_TABLE_PRE |
@@ -1740,7 +1740,7 @@ static void handle_gcmd_te(struct pkvm_iommu *iommu, bool en)
 	if (en) {
 		viommu->vreg.gsts |= DMA_GSTS_TES;
 		/*
-		 * Sync shadow page table to emulate Translation enable.
+		 * Sync shadow id table to emulate Translation enable.
 		 */
 		if (sync_shadow_id(iommu, vaddr, vaddr_end, 0))
 			return;

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu.c
@@ -14,6 +14,8 @@
 #include "iommu_internal.h"
 #include "debug.h"
 #include "ptdev.h"
+#include "iommu_spgt.h"
+#include "bug.h"
 
 #define for_each_valid_iommu(p)						\
 	for ((p) = iommus; (p) < iommus + PKVM_MAX_IOMMU_NUM; (p)++)	\
@@ -24,6 +26,12 @@
 static struct pkvm_iommu iommus[PKVM_MAX_IOMMU_NUM];
 
 static struct pkvm_pool iommu_pool;
+
+/* Used in legacy mode only. */
+struct shadow_pgt_sync_data {
+	unsigned long vaddr;
+	unsigned long vaddr_end;
+};
 
 /*
  * Guest root/context/pasid table (hereinafter "id table") walking parameter.
@@ -44,13 +52,19 @@ struct id_sync_walk_data {
 	 * it is set as a non-zero did value.
 	 */
 	u16 did;
+	/*
+	 * Used in legacy mode when just syncing a specific
+	 * range of pages in shadow page tables.
+	 */
+	struct shadow_pgt_sync_data *spgt_data;
 };
 
-#define DEFINE_ID_SYNC_WALK_DATA(name, _iommu, domain_id)	\
-	struct id_sync_walk_data (name) = {			\
-		.iommu = (_iommu),				\
-		.shadow_pa = {0},				\
-		.did = (domain_id),				\
+#define DEFINE_ID_SYNC_WALK_DATA(name, _iommu, domain_id, _spgt_data)	\
+	struct id_sync_walk_data (name) = {				\
+		.iommu = (_iommu),					\
+		.shadow_pa = {0},					\
+		.did = (domain_id),					\
+		.spgt_data = (_spgt_data),				\
 	}
 
 /*
@@ -71,6 +85,7 @@ struct id_sync_data {
 	u64 shadow_pa;
 	struct pkvm_pgtable *shadow_id;
 	unsigned long vaddr;
+	struct shadow_pgt_sync_data *spgt_data;
 };
 
 static inline void *iommu_zalloc_pages(size_t size)
@@ -361,6 +376,58 @@ static int iommu_audit_did(struct pkvm_iommu *iommu, u16 did, int shadow_vm_hand
 	return ret;
 }
 
+static int shadow_pgt_map_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr, int level,
+			       void *ptep, struct pgt_flush_data *flush_data, void *arg)
+{
+	struct pkvm_pgtable_map_data *data = arg;
+	unsigned long map_phys;
+	int ret = 0;
+
+	host_ept_lock();
+
+	pkvm_host_ept_lookup(data->phys, &map_phys, NULL, NULL);
+	if (map_phys == INVALID_ADDR) {
+		pkvm_err("pkvm: phys addr 0x%lx not mapped in host ept\n", data->phys);
+		goto out;
+	}
+
+	ret = pgtable_map_leaf(pgt, vaddr, level, ptep, flush_data, arg);
+
+out:
+	host_ept_unlock();
+	return ret;
+}
+
+/* used in legacy mode only */
+static void sync_shadow_pgt(struct pkvm_ptdev *ptdev, struct shadow_pgt_sync_data *sdata)
+{
+	struct pkvm_pgtable *spgt;
+	int ret;
+
+	PKVM_ASSERT(is_pgt_ops_ept(&ptdev->vpgt));
+
+	/*
+	 * ptdev->pgt should be already set to this shadow iommu pgtable.
+	 * However, ptdev->pgt could change in the meantime due to ptdev
+	 * attach to a VM. So to avoid race, do not use ptdev->pgt directly
+	 * but get the same shadow iommu pgtable on our own.
+	 */
+	spgt = pkvm_get_host_iommu_spgt(ptdev->vpgt.root_pa, ptdev->iommu_coherency);
+	PKVM_ASSERT(spgt);
+
+	if (sdata)
+		ret = pkvm_pgtable_sync_map_range(&ptdev->vpgt, spgt,
+						  sdata->vaddr,
+						  sdata->vaddr_end - sdata->vaddr,
+						  NULL, shadow_pgt_map_leaf);
+	else
+		ret = pkvm_pgtable_sync_map(&ptdev->vpgt, spgt,
+					    NULL, shadow_pgt_map_leaf);
+	PKVM_ASSERT(ret == 0);
+
+	pkvm_put_host_iommu_spgt(spgt, ptdev->iommu_coherency);
+}
+
 /* present root entry when shadow_pa valid, otherwise un-present it */
 static bool sync_root_entry(struct id_sync_data *sdata)
 {
@@ -446,7 +513,10 @@ static bool sync_shadow_context_entry(struct id_sync_data *sdata)
 				    (aw == 2) ? 4 : 5;
 			cap.allowed_pgsz = pkvm_hyp->ept_cap.allowed_pgsz;
 			pkvm_setup_ptdev_vpgt(ptdev, context_lm_get_slptr(guest_ce),
-					      &viommu_mm_ops, &ept_ops, &cap, false);
+					      &viommu_mm_ops, &ept_ops, &cap, true);
+
+			if (!ptdev_attached_to_vm(ptdev))
+				sync_shadow_pgt(ptdev, sdata->spgt_data);
 
 			break;
 		case CONTEXT_TT_PASS_THROUGH:
@@ -481,21 +551,10 @@ static bool sync_shadow_context_entry(struct id_sync_data *sdata)
 		 * translation and to disable device TLB for security.
 		 */
 		context_lm_set_tt(&tmp, CONTEXT_TT_MULTI_LEVEL);
-
-		if (tt != CONTEXT_TT_PASS_THROUGH && !ptdev_attached_to_vm(ptdev)) {
-			/*
-			 * For now reference to the host's vIOMMU page table.
-			 * FIXME: Reference to the shadow page table once pKVM
-			 * supports shadowing vIOMMU page tables, to guarantee
-			 * the protection.
-			 */
-			context_lm_set_slptr(&tmp, ptdev->vpgt.root_pa);
-		} else {
-			context_lm_set_slptr(&tmp, ptdev->pgt->root_pa);
-			aw = (ptdev->pgt->level == 3) ? 1 :
-			     (ptdev->pgt->level == 4) ? 2 : 3;
-			context_lm_set_aw(&tmp, aw);
-		}
+		context_lm_set_slptr(&tmp, ptdev->pgt->root_pa);
+		aw = (ptdev->pgt->level == 3) ? 1 :
+		     (ptdev->pgt->level == 4) ? 2 : 3;
+		context_lm_set_aw(&tmp, aw);
 	}
 
 update_shadow_ce:
@@ -921,6 +980,7 @@ static int init_sync_id_data(struct id_sync_data *sync_data,
 	sync_data->iommu_ecap = iommu->iommu.ecap;
 	sync_data->shadow_pa = 0;
 	sync_data->vaddr = vaddr;
+	sync_data->spgt_data = data->spgt_data;
 
 	return 0;
 }
@@ -1071,9 +1131,10 @@ static int free_shadow_id(struct pkvm_iommu *iommu, unsigned long vaddr,
 }
 
 static int sync_shadow_id(struct pkvm_iommu *iommu, unsigned long vaddr,
-		       unsigned long vaddr_end, u16 did)
+		       unsigned long vaddr_end, u16 did,
+		       struct shadow_pgt_sync_data *spgt_data)
 {
-	DEFINE_ID_SYNC_WALK_DATA(arg, iommu, did);
+	DEFINE_ID_SYNC_WALK_DATA(arg, iommu, did, spgt_data);
 	struct pkvm_pgtable_walker walker = {
 		.cb = sync_shadow_id_cb,
 		.flags = PKVM_PGTABLE_WALK_TABLE_PRE |
@@ -1461,7 +1522,7 @@ static int activate_iommu(struct pkvm_iommu *iommu)
 
 	initialize_viommu_reg(iommu);
 
-	ret = sync_shadow_id(iommu, vaddr, vaddr_end, 0);
+	ret = sync_shadow_id(iommu, vaddr, vaddr_end, 0, NULL);
 	if (ret)
 		goto out;
 
@@ -1506,7 +1567,7 @@ static int context_cache_invalidate(struct pkvm_iommu *iommu, struct qi_desc *de
 		start = 0;
 		end = MAX_NUM_OF_ADDRESS_SPACE(iommu);
 		pkvm_dbg("pkvm: %s: iommu%d: global\n", __func__, iommu->iommu.seq_id);
-		ret = sync_shadow_id(iommu, start, end, 0);
+		ret = sync_shadow_id(iommu, start, end, 0, NULL);
 		break;
 	case DMA_CCMD_DOMAIN_INVL:
 		/*
@@ -1518,7 +1579,7 @@ static int context_cache_invalidate(struct pkvm_iommu *iommu, struct qi_desc *de
 		end = MAX_NUM_OF_ADDRESS_SPACE(iommu);
 		pkvm_dbg("pkvm: %s: iommu%d: domain selective\n",
 			 __func__, iommu->iommu.seq_id);
-		ret = sync_shadow_id(iommu, start, end, did);
+		ret = sync_shadow_id(iommu, start, end, did, NULL);
 		break;
 	case DMA_CCMD_DEVICE_INVL:
 		if (ecap_smts(iommu->iommu.ecap)) {
@@ -1530,7 +1591,7 @@ static int context_cache_invalidate(struct pkvm_iommu *iommu, struct qi_desc *de
 		}
 		pkvm_dbg("pkvm: %s: iommu%d: device selective sid 0x%x\n",
 			 __func__, iommu->iommu.seq_id, sid);
-		ret = sync_shadow_id(iommu, start, end, did);
+		ret = sync_shadow_id(iommu, start, end, did, NULL);
 		break;
 	default:
 		pkvm_err("pkvm: %s: iommu%d: invalidate granu %lld\n",
@@ -1563,7 +1624,7 @@ static int pasid_cache_invalidate(struct pkvm_iommu *iommu, struct qi_desc *desc
 			 __func__, iommu->iommu.seq_id, did);
 		start = 0;
 		end = IOMMU_MAX_VADDR;
-		ret = sync_shadow_id(iommu, start, end, did);
+		ret = sync_shadow_id(iommu, start, end, did, NULL);
 		break;
 	case QI_PC_PASID_SEL: {
 		/*
@@ -1576,7 +1637,7 @@ static int pasid_cache_invalidate(struct pkvm_iommu *iommu, struct qi_desc *desc
 		for (bdf = 0; bdf < end_bdf; bdf++) {
 			start = (bdf << DEVFN_SHIFT) + pasid;
 			end = start + 1;
-			ret = sync_shadow_id(iommu, start, end, did);
+			ret = sync_shadow_id(iommu, start, end, did, NULL);
 			if (ret)
 				break;
 		}
@@ -1586,7 +1647,7 @@ static int pasid_cache_invalidate(struct pkvm_iommu *iommu, struct qi_desc *desc
 		start = 0;
 		end = IOMMU_MAX_VADDR;
 		pkvm_dbg("pkvm: %s: iommu%d: global\n", __func__, iommu->iommu.seq_id);
-		ret = sync_shadow_id(iommu, start, end, 0);
+		ret = sync_shadow_id(iommu, start, end, 0, NULL);
 		break;
 	default:
 		pkvm_err("pkvm: %s: iommu%d: invalid granularity %d 0x%llx\n",
@@ -1598,6 +1659,55 @@ static int pasid_cache_invalidate(struct pkvm_iommu *iommu, struct qi_desc *desc
 	if (ret)
 		pkvm_err("pkvm: %s: iommu%d: granularity %d failed with ret %d\n",
 			 __func__, iommu->iommu.seq_id, granu, ret);
+
+	return ret;
+}
+
+static int iotlb_lm_invalidate(struct pkvm_iommu *iommu, struct qi_desc *desc)
+{
+	u16 did = QI_DESC_IOTLB_DID(desc->qw0);
+	u64 granu = QI_DESC_IOTLB_GRANU(desc->qw0) << DMA_TLB_FLUSH_GRANU_OFFSET;
+	u64 addr = QI_DESC_IOTLB_ADDR(desc->qw1);
+	u64 mask = ((u64)-1) << (VTD_PAGE_SHIFT + QI_DESC_IOTLB_AM(desc->qw1));
+	struct shadow_pgt_sync_data data;
+	struct pkvm_ptdev *p;
+	int ret;
+
+	switch (granu) {
+	case DMA_TLB_GLOBAL_FLUSH:
+		pkvm_dbg("pkvm: %s: iommu%d: global\n", __func__, iommu->iommu.seq_id);
+		ret = sync_shadow_id(iommu, 0, IOMMU_LM_MAX_VADDR, 0, NULL);
+		break;
+	case DMA_TLB_DSI_FLUSH:
+		pkvm_dbg("pkvm: %s: iommu%d: domain selective did %u\n",
+			 __func__, iommu->iommu.seq_id, did);
+
+		/* optimization: walk just the needed devices, not the entire bdf space */
+		list_for_each_entry(p, &iommu->ptdev_head, iommu_node)
+			if (p->did == did)
+				ret = sync_shadow_id(iommu, p->bdf, p->bdf + 1, did, NULL);
+		break;
+	case DMA_TLB_PSI_FLUSH:
+		data.vaddr = addr & mask;
+		data.vaddr_end = (addr | ~mask) + 1;
+		pkvm_dbg("pkvm: %s: iommu%d: page selective did %u start 0x%lx end 0x%lx\n",
+			 __func__, iommu->iommu.seq_id, did, data.vaddr, data.vaddr_end);
+
+		/* optimization: walk just the needed devices, not the entire bdf space */
+		list_for_each_entry(p, &iommu->ptdev_head, iommu_node)
+			if (p->did == did)
+				ret = sync_shadow_id(iommu, p->bdf, p->bdf + 1, did, &data);
+		break;
+	default:
+		pkvm_err("pkvm: %s: iommu%d: invalid granularity %lld\n",
+			__func__, iommu->iommu.seq_id, granu >> DMA_TLB_FLUSH_GRANU_OFFSET);
+		ret = -EINVAL;
+		break;
+	}
+
+	if (ret)
+		pkvm_err("pkvm: %s: iommu%d: granularity %lld failed with ret %d\n",
+			__func__, iommu->iommu.seq_id, granu >> DMA_TLB_FLUSH_GRANU_OFFSET, ret);
 
 	return ret;
 }
@@ -1614,7 +1724,6 @@ static int handle_descriptor(struct pkvm_iommu *iommu, struct qi_desc *desc)
 	 */
 	case QI_PGRP_RESP_TYPE:
 	case QI_PSTRM_RESP_TYPE:
-	case QI_IOTLB_TYPE:
 	case QI_DIOTLB_TYPE:
 	case QI_DEIOTLB_TYPE:
 	case QI_IEC_TYPE:
@@ -1626,6 +1735,10 @@ static int handle_descriptor(struct pkvm_iommu *iommu, struct qi_desc *desc)
 		break;
 	case QI_PC_TYPE:
 		ret = pasid_cache_invalidate(iommu, desc);
+		break;
+	case QI_IOTLB_TYPE:
+		if (!ecap_smts(iommu->iommu.ecap))
+			ret = iotlb_lm_invalidate(iommu, desc);
 		break;
 	default:
 		pkvm_err("pkvm: %s: iommu%d: invalid type %d desc addr 0x%llx val 0x%llx\n",
@@ -1742,7 +1855,7 @@ static void handle_gcmd_te(struct pkvm_iommu *iommu, bool en)
 		/*
 		 * Sync shadow id table to emulate Translation enable.
 		 */
-		if (sync_shadow_id(iommu, vaddr, vaddr_end, 0))
+		if (sync_shadow_id(iommu, vaddr, vaddr_end, 0, NULL))
 			return;
 		pkvm_dbg("pkvm: %s: enable TE\n", __func__);
 		goto out;
@@ -1782,7 +1895,7 @@ static void handle_gcmd_srtp(struct pkvm_iommu *iommu)
 		unsigned long vaddr = 0, vaddr_end = MAX_NUM_OF_ADDRESS_SPACE(iommu);
 
 		/* TE is already enabled, sync shadow */
-		if (sync_shadow_id(iommu, vaddr, vaddr_end, 0))
+		if (sync_shadow_id(iommu, vaddr, vaddr_end, 0, NULL))
 			return;
 
 		flush_context_cache(iommu, 0, 0, 0, DMA_CCMD_GLOBAL_INVL);
@@ -2119,7 +2232,7 @@ int pkvm_iommu_sync(u16 bdf, u32 pasid)
 	}
 
 	pkvm_spin_lock(&iommu->lock);
-	ret = sync_shadow_id(iommu, id_addr, id_addr_end, 0);
+	ret = sync_shadow_id(iommu, id_addr, id_addr_end, 0, NULL);
 	if (!ret) {
 		if (old_did != ptdev->did) {
 			/* Flush pasid cache and IOTLB for the valid old_did */

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_internal.h
@@ -129,9 +129,12 @@ do {									\
 #define QI_DESC_PC_DID(qw)		(((qw) & GENMASK_ULL(31, 16)) >> 16)
 #define QI_DESC_PC_PASID(qw)		(((qw) & GENMASK_ULL(51, 32)) >> 32)
 
-#define pgt_to_pkvm_iommu(_pgt) container_of(_pgt, struct pkvm_iommu, pgt)
-
+#define QI_DESC_IOTLB_GRANU(qw)		(((qw) & GENMASK_ULL(5, 4)) >> 4)
 #define QI_DESC_IOTLB_DID(qw)		(((qw) & GENMASK_ULL(31, 16)) >> 16)
+#define QI_DESC_IOTLB_ADDR(qw)		((qw) & VTD_PAGE_MASK)
+#define QI_DESC_IOTLB_AM(qw)		((qw) & GENMASK_ULL(5, 0))
+
+#define pgt_to_pkvm_iommu(_pgt) container_of(_pgt, struct pkvm_iommu, pgt)
 
 struct pasid_dir_entry {
 	u64 val;

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_spgt.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_spgt.c
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright(c) 2022 Intel Corporation.
+ * Copyright(c) 2023 Semihalf.
+ */
+
+#include <linux/hashtable.h>
+#include <pkvm_spinlock.h>
+#include <pkvm.h>
+#include <gfp.h>
+#include "pkvm_hyp.h"
+#include "iommu_spgt.h"
+#include "ept.h"
+#include "bug.h"
+
+static DEFINE_HASHTABLE(iommu_spgt_hasht, 8);
+static DECLARE_BITMAP(iommu_spgt_bitmap, PKVM_MAX_PDEV_NUM);
+static struct pkvm_iommu_spgt pkvm_iommu_spgt[PKVM_MAX_PDEV_NUM];
+static pkvm_spinlock_t iommu_spgt_lock = { __ARCH_PKVM_SPINLOCK_UNLOCKED };
+
+struct pkvm_pgtable *pkvm_get_host_iommu_spgt(unsigned long root_gpa, bool coherency)
+{
+	struct pkvm_iommu_spgt *spgt = NULL, *tmp;
+	unsigned long index;
+	int ret;
+
+	pkvm_spin_lock(&iommu_spgt_lock);
+
+	hash_for_each_possible(iommu_spgt_hasht, tmp, hnode, root_gpa) {
+		if (tmp->root_gpa == root_gpa) {
+			if (tmp->refcount > 0) {
+				spgt = tmp;
+				break;
+			}
+		}
+	}
+
+	if (spgt) {
+		spgt->refcount++;
+		spgt->noncoherent_count += !coherency;
+		pkvm_shadow_sl_iommu_pgt_update_coherency(&spgt->pgt,
+							  !spgt->noncoherent_count);
+		goto out;
+	}
+
+	index = find_first_zero_bit(iommu_spgt_bitmap, PKVM_MAX_PDEV_NUM);
+	if (index < PKVM_MAX_PDEV_NUM) {
+		spgt = &pkvm_iommu_spgt[index];
+
+		ret = pkvm_pgtable_init(&spgt->pgt,
+					pkvm_shadow_sl_iommu_pgt_get_mm_ops(coherency),
+					&ept_ops, &pkvm_hyp->ept_cap, true);
+		if (ret) {
+			pkvm_err("%s: pgtable init failed err=%d\n", __func__, ret);
+			spgt = NULL;
+			goto out;
+		}
+
+		__set_bit(index, iommu_spgt_bitmap);
+		spgt->root_gpa = root_gpa;
+		spgt->index = index;
+		spgt->refcount = 1;
+		spgt->noncoherent_count = !coherency;
+		hash_add(iommu_spgt_hasht, &spgt->hnode, root_gpa);
+	}
+out:
+	pkvm_spin_unlock(&iommu_spgt_lock);
+
+	return spgt ? &spgt->pgt : NULL;
+}
+
+void pkvm_put_host_iommu_spgt(struct pkvm_pgtable *pgt, bool coherency)
+{
+	struct pkvm_iommu_spgt *spgt = NULL, *tmp;
+	int bkt;
+
+	pkvm_spin_lock(&iommu_spgt_lock);
+
+	hash_for_each(iommu_spgt_hasht, bkt, tmp, hnode) {
+		if (&tmp->pgt == pgt) {
+			spgt = tmp;
+			break;
+		}
+	}
+	PKVM_ASSERT(spgt);
+	PKVM_ASSERT(spgt->refcount > 0);
+
+	if (--spgt->refcount > 0) {
+		spgt->noncoherent_count -= !coherency;
+		PKVM_ASSERT(spgt->noncoherent_count >= 0);
+		pkvm_shadow_sl_iommu_pgt_update_coherency(&spgt->pgt,
+							  !spgt->noncoherent_count);
+		goto out;
+	}
+
+	hash_del(&spgt->hnode);
+
+	__clear_bit(spgt->index, iommu_spgt_bitmap);
+
+	pkvm_pgtable_destroy(&spgt->pgt, NULL);
+
+	memset(spgt, 0, sizeof(struct pkvm_iommu_spgt));
+
+out:
+	pkvm_spin_unlock(&iommu_spgt_lock);
+}

--- a/arch/x86/kvm/vmx/pkvm/hyp/iommu_spgt.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/iommu_spgt.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0
+ * Copyright(c) 2022 Intel Corporation.
+ * Copyright(c) 2023 Semihalf.
+ */
+
+#include "pgtable.h"
+
+struct pkvm_iommu_spgt {
+	int refcount;
+	int noncoherent_count;
+	struct hlist_node hnode;
+	unsigned long root_gpa;
+	unsigned long index;
+	struct pkvm_pgtable pgt;
+};
+
+struct pkvm_pgtable *pkvm_get_host_iommu_spgt(unsigned long root_gpa, bool coherency);
+void pkvm_put_host_iommu_spgt(struct pkvm_pgtable *spgt, bool coherency);

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
@@ -109,7 +109,7 @@ static void pgtable_split(struct pkvm_pgtable_ops *pgt_ops,
 	}
 }
 
-static int pgtable_map_leaf(struct pkvm_pgtable *pgt,
+int pgtable_map_leaf(struct pkvm_pgtable *pgt,
 			    unsigned long vaddr,
 			    int level, void *ptep,
 			    struct pgt_flush_data *flush_data,

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
@@ -752,6 +752,37 @@ static int pgtable_sync_map_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 }
 
 /*
+ * pkvm_pgtable_sync_map_range() - map the given address range in the destination
+ * pgtable according to the source pgtable, with the same phys address and desired
+ * property bits.
+ *
+ * @src:	source pgtable.
+ * @dest:	destination pgtable.
+ * @vaddr:	virtual start address of the range.
+ * @size:	size of the range in bytes.
+ * @prot:	desired property bits. Can be NULL if use the same property
+ *		bits as the source pgtable
+ * @map_leaf:	function to map the leaf entry for destination pgtable.
+ */
+int pkvm_pgtable_sync_map_range(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
+				unsigned long vaddr, unsigned long size,
+				u64 *prot, pgtable_leaf_ov_fn_t map_leaf)
+{
+	struct pkvm_pgtable_sync_data data = {
+		.dest_pgt = dest,
+		.prot_override = prot,
+		.map_leaf_override = map_leaf,
+	};
+	struct pkvm_pgtable_walker walker = {
+		.cb = pgtable_sync_map_cb,
+		.flags = PKVM_PGTABLE_WALK_LEAF,
+		.arg = &data,
+	};
+
+	return pgtable_walk(src, vaddr, size, true, &walker);
+}
+
+/*
  * pkvm_pgtable_sync_map() - map the destination pgtable according to the source
  * pgtable, with the same phys address and desired property bits.
  *
@@ -764,17 +795,7 @@ static int pgtable_sync_map_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 int pkvm_pgtable_sync_map(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
 			  u64 *prot, pgtable_leaf_ov_fn_t map_leaf)
 {
-	struct pkvm_pgtable_sync_data data = {
-		.dest_pgt = dest,
-		.prot_override = prot,
-		.map_leaf_override = map_leaf,
-	};
-	struct pkvm_pgtable_walker walker = {
-		.cb = pgtable_sync_map_cb,
-		.flags = PKVM_PGTABLE_WALK_LEAF,
-		.arg = &data,
-	};
 	unsigned long size = src->pgt_ops->pgt_level_to_size(src->level + 1);
 
-	return pgtable_walk(src, 0, size, true, &walker);
+	return pkvm_pgtable_sync_map_range(src, dest, 0, size, prot, map_leaf);
 }

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
@@ -752,14 +752,14 @@ static int pgtable_sync_map_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 }
 
 /*
- * pkvm_pgtable_sync_map() - map the destination pgtable_pgt according to the source
- * pgtable_pgt, with the same phys address and desired property bits.
+ * pkvm_pgtable_sync_map() - map the destination pgtable according to the source
+ * pgtable, with the same phys address and desired property bits.
  *
- * @src:	source pgtable_pgt.
- * @dest:	destination pgtable_pgt.
+ * @src:	source pgtable.
+ * @dest:	destination pgtable.
  * @prot:	desired property bits. Can be NULL if use the same property
- *		bits as the source pgtable_pgt
- * @map_leaf:	function to map the leaf entry for destination pgtable_pgt.
+ *		bits as the source pgtable
+ * @map_leaf:	function to map the leaf entry for destination pgtable.
  */
 int pkvm_pgtable_sync_map(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
 			  u64 *prot, pgtable_leaf_ov_fn_t map_leaf)

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.c
@@ -736,11 +736,12 @@ static int pgtable_sync_map_cb(struct pkvm_pgtable *pgt, unsigned long vaddr,
 	unsigned long size;
 	u64 prot;
 
-	if (!pgt->pgt_ops->pgt_entry_present(ptep))
-		return 0;
-
 	phys = pgt_ops->pgt_entry_to_phys(ptep);
 	size = pgt_ops->pgt_level_to_size(level);
+
+	if (!pgt->pgt_ops->pgt_entry_present(ptep))
+		return pkvm_pgtable_unmap(data->dest_pgt, vaddr, size, NULL);
+
 	if (data->prot_override)
 		prot = *data->prot_override;
 	else

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
@@ -141,6 +141,9 @@ int pkvm_pgtable_annotate(struct pkvm_pgtable *pgt, unsigned long addr,
 			  unsigned long size, u64 annotation);
 int pkvm_pgtable_sync_map(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
 			  u64 *prot, pgtable_leaf_ov_fn_t map_leaf);
+int pkvm_pgtable_sync_map_range(struct pkvm_pgtable *src, struct pkvm_pgtable *dest,
+				unsigned long vaddr, unsigned long size,
+				u64 *prot, pgtable_leaf_ov_fn_t map_leaf);
 
 static inline void pkvm_pgtable_set_mm_ops(struct pkvm_pgtable *pgt, struct pkvm_mm_ops *mm_ops)
 {

--- a/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pgtable.h
@@ -127,6 +127,9 @@ int pkvm_pgtable_init(struct pkvm_pgtable *pgt,
 int pkvm_pgtable_map(struct pkvm_pgtable *pgt, unsigned long vaddr_start,
 		unsigned long phys_start, unsigned long size,
 		int pgsz_mask, u64 entry_prot, pgtable_leaf_ov_fn_t map_leaf);
+int pgtable_map_leaf(struct pkvm_pgtable *pgt, unsigned long vaddr,
+		     int level, void *ptep, struct pgt_flush_data *flush_data,
+		     struct pkvm_pgtable_map_data *data);
 int pkvm_pgtable_unmap(struct pkvm_pgtable *pgt, unsigned long vaddr_start,
 		       unsigned long size, pgtable_leaf_ov_fn_t unmap_leaf);
 int pkvm_pgtable_unmap_safe(struct pkvm_pgtable *pgt, unsigned long vaddr_start,

--- a/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/pkvm.c
@@ -199,8 +199,8 @@ void pkvm_shadow_vm_link_ptdev(struct pkvm_shadow_vm *vm,
 	list_add_tail(node, &vm->ptdev_head);
 	vm->noncoherent_ptdev += !coherency;
 	vm->need_prepopulation = true;
-	pkvm_pgstate_pgt_update_coherency(&vm->pgstate_pgt,
-					  !vm->noncoherent_ptdev);
+	pkvm_shadow_sl_iommu_pgt_update_coherency(&vm->pgstate_pgt,
+						  !vm->noncoherent_ptdev);
 	pkvm_spin_unlock(&vm->lock);
 }
 
@@ -210,8 +210,8 @@ void pkvm_shadow_vm_unlink_ptdev(struct pkvm_shadow_vm *vm,
 	pkvm_spin_lock(&vm->lock);
 	list_del(node);
 	vm->noncoherent_ptdev -= !coherency;
-	pkvm_pgstate_pgt_update_coherency(&vm->pgstate_pgt,
-					  !vm->noncoherent_ptdev);
+	pkvm_shadow_sl_iommu_pgt_update_coherency(&vm->pgstate_pgt,
+						  !vm->noncoherent_ptdev);
 	pkvm_spin_unlock(&vm->lock);
 }
 

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.c
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.c
@@ -7,6 +7,7 @@
 #include "pkvm_hyp.h"
 #include "iommu.h"
 #include "ptdev.h"
+#include "iommu_spgt.h"
 #include "bug.h"
 
 #define MAX_PTDEV_NUM	(PKVM_MAX_PDEV_NUM + PKVM_MAX_PASID_PDEV_NUM)
@@ -34,6 +35,7 @@ struct pkvm_ptdev *pkvm_alloc_ptdev(u16 bdf, u32 pasid, bool coherency)
 		INIT_LIST_HEAD(&ptdev->iommu_node);
 		INIT_LIST_HEAD(&ptdev->vm_node);
 		atomic_set(&ptdev->refcount, 1);
+		pkvm_spinlock_init(&ptdev->lock);
 		hash_add(ptdev_hasht, &ptdev->hnode, bdf);
 	}
 
@@ -71,6 +73,9 @@ void pkvm_put_ptdev(struct pkvm_ptdev *ptdev)
 
 	__clear_bit(ptdev->index, ptdevs_bitmap);
 
+	if (ptdev->pgt != pkvm_hyp->host_vm.ept)
+		pkvm_put_host_iommu_spgt(ptdev->pgt, ptdev->iommu_coherency);
+
 	memset(ptdev, 0, sizeof(struct pkvm_ptdev));
 
 	pkvm_spin_unlock(&ptdev_lock);
@@ -78,15 +83,31 @@ void pkvm_put_ptdev(struct pkvm_ptdev *ptdev)
 
 void pkvm_setup_ptdev_vpgt(struct pkvm_ptdev *ptdev, unsigned long root_gpa,
 			   struct pkvm_mm_ops *mm_ops, struct pkvm_pgtable_ops *paging_ops,
-			   struct pkvm_pgtable_cap *cap)
+			   struct pkvm_pgtable_cap *cap, bool shadowed)
 {
+	pkvm_spin_lock(&ptdev->lock);
+
+	if (ptdev->pgt != pkvm_hyp->host_vm.ept &&
+			(!shadowed || root_gpa != ptdev->vpgt.root_pa) &&
+			!ptdev_attached_to_vm(ptdev)) {
+		pkvm_put_host_iommu_spgt(ptdev->pgt, ptdev->iommu_coherency);
+		ptdev->pgt = pkvm_hyp->host_vm.ept;
+	}
+
 	if (!root_gpa || root_gpa == INVALID_ADDR || !mm_ops || !paging_ops || !cap) {
 		memset(&ptdev->vpgt, 0, sizeof(struct pkvm_pgtable));
-		return;
+		goto out;
 	}
 
 	ptdev->vpgt.root_pa = root_gpa;
 	PKVM_ASSERT(pkvm_pgtable_init(&ptdev->vpgt, mm_ops, paging_ops, cap, false) == 0);
+
+	if (shadowed && ptdev->pgt == pkvm_hyp->host_vm.ept) {
+		ptdev->pgt = pkvm_get_host_iommu_spgt(root_gpa, ptdev->iommu_coherency);
+		PKVM_ASSERT(ptdev->pgt);
+	}
+out:
+	pkvm_spin_unlock(&ptdev->lock);
 }
 
 void pkvm_setup_ptdev_did(struct pkvm_ptdev *ptdev, u16 did)
@@ -104,8 +125,11 @@ void pkvm_setup_ptdev_did(struct pkvm_ptdev *ptdev, u16 did)
 void pkvm_detach_ptdev(struct pkvm_ptdev *ptdev, struct pkvm_shadow_vm *vm)
 {
 	/* Reset what the attach API has set */
+	pkvm_spin_lock(&ptdev->lock);
 	ptdev->shadow_vm_handle = 0;
 	ptdev->pgt = pkvm_hyp->host_vm.ept;
+	pkvm_spin_unlock(&ptdev->lock);
+
 	pkvm_shadow_vm_unlink_ptdev(vm, &ptdev->vm_node,
 				    ptdev->iommu_coherency);
 	pkvm_iommu_sync(ptdev->bdf, ptdev->pasid);
@@ -142,18 +166,28 @@ int pkvm_attach_ptdev(u16 bdf, u32 pasid, struct pkvm_shadow_vm *vm)
 			return -ENODEV;
 	}
 
+	pkvm_spin_lock(&ptdev->lock);
+
 	if (cmpxchg(&ptdev->shadow_vm_handle, 0, vm->shadow_vm_handle) != 0) {
 		pkvm_err("%s: ptdev with bdf 0x%x pasid 0x%x is already attached\n",
 			 __func__, bdf, pasid);
+		pkvm_spin_unlock(&ptdev->lock);
 		pkvm_put_ptdev(ptdev);
 		return -ENODEV;
 	}
+
+	PKVM_ASSERT(ptdev->pgt != &vm->pgstate_pgt);
+	if (ptdev->pgt != pkvm_hyp->host_vm.ept)
+		pkvm_put_host_iommu_spgt(ptdev->pgt, ptdev->iommu_coherency);
 
 	/*
 	 * Reset pgt of this ptdev to VM's pgstate_pgt so need to update
 	 * IOMMU page table accordingly.
 	 */
 	ptdev->pgt = &vm->pgstate_pgt;
+
+	pkvm_spin_unlock(&ptdev->lock);
+
 	pkvm_shadow_vm_link_ptdev(vm, &ptdev->vm_node,
 				  ptdev->iommu_coherency);
 	if (pkvm_iommu_sync(ptdev->bdf, ptdev->pasid)) {

--- a/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
+++ b/arch/x86/kvm/vmx/pkvm/hyp/ptdev.h
@@ -21,6 +21,9 @@ struct pkvm_ptdev {
 	/* Represents the page table maintained by pKVM */
 	struct pkvm_pgtable *pgt;
 
+	/* Protects updates of pgt pointer */
+	pkvm_spinlock_t lock;
+
 	int shadow_vm_handle;
 	struct list_head vm_node;
 };
@@ -30,7 +33,7 @@ struct pkvm_ptdev *pkvm_get_ptdev(u16 bdf, u32 pasid);
 void pkvm_put_ptdev(struct pkvm_ptdev *ptdev);
 void pkvm_setup_ptdev_vpgt(struct pkvm_ptdev *ptdev, unsigned long root_gpa,
 			   struct pkvm_mm_ops *mm_ops, struct pkvm_pgtable_ops *paging_ops,
-			   struct pkvm_pgtable_cap *cap);
+			   struct pkvm_pgtable_cap *cap, bool shadowed);
 void pkvm_setup_ptdev_did(struct pkvm_ptdev *ptdev, u16 did);
 void pkvm_detach_ptdev(struct pkvm_ptdev *ptdev, struct pkvm_shadow_vm *vm);
 int pkvm_attach_ptdev(u16 bdf, u32 pasid, struct pkvm_shadow_vm *vm);

--- a/arch/x86/kvm/vmx/pkvm/pkvm_host.c
+++ b/arch/x86/kvm/vmx/pkvm/pkvm_host.c
@@ -236,6 +236,7 @@ u64 pkvm_total_reserve_pages(void)
 				  PKVM_IOMMU_QI_DESC_STATUS_SIZE,
 				  num_possible_cpus());
 	total += pkvm_shadow_ept_pgtable_pages(PKVM_MAX_VM_NUM);
+	total += pkvm_host_shadow_iommu_pgtable_pages(PKVM_PDEV_NUM);
 
 	return total;
 }


### PR DESCRIPTION
Unlike scalable IOMMU, legacy IOMMU provides just one level of address translation. So in the cases when the host itself uses address translation for the given device (i.e. uses legacy IOMMU in non-passthrough mode), pKVM needs to shadow the host's vIOMMU page tables to ensure memory protection. This PR implements shadow IOMMU page tables and enables using them in legacy mode when needed (i.e. when a device is used by the host in non-passthrough mode and is not attached to a protected VM), replacing our temporary hack using host's vIOMMU page tables directly.

This PR still does not fully ensure memory protection, since it doesn't implement syncing of shadow page tables immediately after a page is donated. Protection is ensured only after the host itself triggers IOMMU sync some time later.

v3:
- Fixed lack of `spgt->noncoherent_count` initialization.
- Removed `ptdev->spgt` and reworked `ptdev->pgt` handling accordingly.
- Added TODO about code refactoring for all the types of shadow 2nd level iommu page tables.
- Improved TODO about not reserving memory if there is no legacy IOMMU.
- Corrected commit message (added TODO) about lack of shadow iommu pgtable sync after page donate.

v2:
- Split the 1st patch: reserve memory for iommu_spgt in one patch, implement iommu_spgt API in the next one.
- Renamed `pgstate_pgt_mm_ops` to `shadow_sl_iommu_pgt_mm_ops` and cleaned up its usage correspondingly.
- Renamed `pkvm_shadow_iommu_pgtable_pages` to `pkvm_host_shadow_iommu_pgtable_pages`.
- Renamed `pkvm_{get,put}_iommu_spgt` to `pkvm_{get,put}_host_iommu_spgt`.
- Added TODO for not reserving memory if there is no legacy IOMMU.

v1:
Almost the same as the patchset submitted to ChromiumOS gerrit some time ago: https://chromium-review.googlesource.com/c/chromiumos/third_party/kernel/+/4233618 but with a couple of improvements:

- Instead of adding a separate memory pool for shadow IOMMU page tables, use (extend) the memory pool used for shadow EPT and pgstate tables (as suggested by @JasonChenCJ) which allows to reuse `pgstate_pgt_mm_ops` instead of implementing new mm_ops.
- Improved coherency handling: don't flush cache for the given shadow IOMMU page table if all the ptdevs using this page table are behind cache-coherent IOMMUs, even if some other IOMMUs are not cache-coherent (inspired by the implementation in PR #19 )