### PR TITLE
pvVMCS-POC-v6.12: fix compile issues

### DIFF
--- a/arch/x86/include/asm/extable.h
+++ b/arch/x86/include/asm/extable.h
@@ -3,6 +3,7 @@
 #define _ASM_X86_EXTABLE_H
 
 #include <asm/extable_fixup_types.h>
+#include <asm/processor.h>	/* for cpu_relax() */
 
 /*
  * The exception table consists of two addresses relative to the

--- a/arch/x86/kvm/lapic.h
+++ b/arch/x86/kvm/lapic.h
@@ -117,7 +117,6 @@ bool kvm_irq_delivery_to_apic_fast(struct kvm *kvm, struct kvm_lapic *src,
 		struct kvm_lapic_irq *irq, int *r, struct dest_map *dest_map);
 void kvm_apic_send_ipi(struct kvm_lapic *apic, u32 icr_low, u32 icr_high);
 
-u64 kvm_get_apic_base(struct kvm_vcpu *vcpu);
 int kvm_set_apic_base(struct kvm_vcpu *vcpu, struct msr_data *msr_info);
 int kvm_apic_get_state(struct kvm_vcpu *vcpu, struct kvm_lapic_state *s);
 int kvm_apic_set_state(struct kvm_vcpu *vcpu, struct kvm_lapic_state *s);

--- a/arch/x86/kvm/lapic.h
+++ b/arch/x86/kvm/lapic.h
@@ -120,7 +120,6 @@ void kvm_apic_send_ipi(struct kvm_lapic *apic, u32 icr_low, u32 icr_high);
 int kvm_set_apic_base(struct kvm_vcpu *vcpu, struct msr_data *msr_info);
 int kvm_apic_get_state(struct kvm_vcpu *vcpu, struct kvm_lapic_state *s);
 int kvm_apic_set_state(struct kvm_vcpu *vcpu, struct kvm_lapic_state *s);
-enum lapic_mode kvm_get_apic_mode(struct kvm_vcpu *vcpu);
 int kvm_lapic_find_highest_irr(struct kvm_vcpu *vcpu);
 
 u64 kvm_get_lapic_tscdeadline_msr(struct kvm_vcpu *vcpu);
@@ -275,6 +274,11 @@ bool kvm_can_use_hv_timer(struct kvm_vcpu *vcpu);
 static inline enum lapic_mode kvm_apic_mode(u64 apic_base)
 {
 	return apic_base & (MSR_IA32_APICBASE_ENABLE | X2APIC_ENABLE);
+}
+
+static inline enum lapic_mode kvm_get_apic_mode(struct kvm_vcpu *vcpu)
+{
+	return kvm_apic_mode(vcpu->arch.apic_base);
 }
 
 static inline u8 kvm_xapic_id(struct kvm_lapic *apic)

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -299,8 +299,10 @@ static int pkvm_vcpu_create(struct kvm_vcpu *shared_vcpu, unsigned long gpa)
 
 	shared_kvm = kern_pkvm_va(pkvm_vcpu->shared_vcpu->kvm);
 	pkvm_vm = get_pkvm_vm(shared_kvm->arch.pkvm.pkvm_vm_handle);
-	if (!pkvm_vm)
+	if (!pkvm_vm) {
+		ret = -EBUSY;
 		goto undonate;
+	}
 
 	ret = attach_pkvm_vcpu_to_vm(pkvm_vcpu, pkvm_vm);
 	if (ret)

--- a/arch/x86/kvm/pkvm/vmx/vmenter.S
+++ b/arch/x86/kvm/pkvm/vmx/vmenter.S
@@ -7,7 +7,7 @@
 #include <asm/nospec-branch.h>
 #include <asm/percpu.h>
 #include <asm/segment.h>
-#include <kvm-asm-offsets.h>
+#include "kvm-asm-offsets.h"
 #include <vmx/run_flags.h>
 
 #define WORD_SIZE (BITS_PER_LONG / 8)

--- a/arch/x86/kvm/pkvm/vmx/vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/vmx.c
@@ -6683,6 +6683,7 @@ out:
 	guest_state_exit_irqoff();
 #else
 out:
+	;
 #endif
 }
 

--- a/arch/x86/kvm/pkvm/x86.c
+++ b/arch/x86/kvm/pkvm/x86.c
@@ -261,17 +261,6 @@ noinstr void kvm_spurious_fault(void)
 }
 EXPORT_SYMBOL_GPL(kvm_spurious_fault);
 
-u64 kvm_get_apic_base(struct kvm_vcpu *vcpu)
-{
-	return vcpu->arch.apic_base;
-}
-
-enum lapic_mode kvm_get_apic_mode(struct kvm_vcpu *vcpu)
-{
-	return kvm_apic_mode(kvm_get_apic_base(vcpu));
-}
-EXPORT_SYMBOL_GPL(kvm_get_apic_mode);
-
 #define EXCPT_BENIGN		0
 #define EXCPT_CONTRIBUTORY	1
 #define EXCPT_PF		2
@@ -1924,7 +1913,7 @@ int kvm_get_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
 		msr_info->data = 1 << 24;
 		break;
 	case MSR_IA32_APICBASE:
-		msr_info->data = kvm_get_apic_base(vcpu);
+		msr_info->data = vcpu->arch.apic_base;
 		break;
 	case APIC_BASE_MSR ... APIC_BASE_MSR + 0xff:
 		return kvm_x2apic_msr_read(vcpu, msr_info->index, &msr_info->data);

--- a/arch/x86/kvm/vmx/pkvm/Makefile
+++ b/arch/x86/kvm/vmx/pkvm/Makefile
@@ -28,3 +28,5 @@ $(obj)/pkvm_constants.h: $(obj)/pkvm-constants.s FORCE
 
 obj-intel-pkvm := $(addprefix $(obj)/, $(pkvm-obj))
 $(obj-intel-pkvm): $(obj)/pkvm_constants.h
+
+CFLAGS_../pkvm_high.o += -iquote $(obj)

--- a/arch/x86/kvm/vmx/pkvm/hyp/Makefile
+++ b/arch/x86/kvm/vmx/pkvm/hyp/Makefile
@@ -31,6 +31,8 @@ pkvm-hyp-$(CONFIG_LIST_HARDENED)	+= $(lib-dir)/list_debug.o
 pkvm-obj 	:= $(patsubst %.o,%.pkvm.o,$(pkvm-hyp-y))
 obj-$(CONFIG_PKVM_INTEL)	+= pkvm.o
 
+AFLAGS_$(pkvm)/vmx/vmenter.pkvm.o	+= -iquote $(obj)/../../..
+
 $(obj)/$(pkvm)/vmx/vmenter.pkvm.o: $(obj)/../../../kvm-asm-offsets.h
 $(obj)/../../../kvm-asm-offsets.h: $(obj)/../../../kvm-asm-offsets.s FORCE
 	$(call filechk,offsets,__KVM_ASM_OFFSETS_H__)

--- a/arch/x86/kvm/vmx/pkvm/include/pkvm.h
+++ b/arch/x86/kvm/vmx/pkvm/include/pkvm.h
@@ -138,7 +138,7 @@ extern struct pkvm_hyp *pkvm_sym(pkvm_hyp);
 extern unsigned long pkvm_sym(__x86_clflush_size);
 extern struct cpuinfo_x86 pkvm_sym(boot_cpu_data);
 extern unsigned int pkvm_sym(tsc_khz);
-extern struct cpumask pkvm_sym(__cpu_possible_mask) __ro_after_init;
+extern struct cpumask pkvm_sym(__cpu_possible_mask);
 extern unsigned int pkvm_sym(nr_cpu_ids);
 extern u64 pkvm_sym(x86_pred_cmd);
 

--- a/arch/x86/kvm/vmx/pkvm_high.c
+++ b/arch/x86/kvm/vmx/pkvm_high.c
@@ -5,7 +5,7 @@
 #include <asm/fred.h>
 #include <asm/pkvm.h>
 #include "pkvm.h"
-#include "./pkvm/pkvm_constants.h"
+#include "pkvm_constants.h"
 
 #include "x86_ops.h"
 #include "vmx.h"

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -668,12 +668,6 @@ static void drop_user_return_notifiers(void)
 		kvm_on_user_return(&msrs->urn);
 }
 
-enum lapic_mode kvm_get_apic_mode(struct kvm_vcpu *vcpu)
-{
-	return kvm_apic_mode(vcpu->arch.apic_base);
-}
-EXPORT_SYMBOL_GPL(kvm_get_apic_mode);
-
 int kvm_set_apic_base(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
 {
 	enum lapic_mode old_mode = kvm_get_apic_mode(vcpu);

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -668,14 +668,9 @@ static void drop_user_return_notifiers(void)
 		kvm_on_user_return(&msrs->urn);
 }
 
-u64 kvm_get_apic_base(struct kvm_vcpu *vcpu)
-{
-	return vcpu->arch.apic_base;
-}
-
 enum lapic_mode kvm_get_apic_mode(struct kvm_vcpu *vcpu)
 {
-	return kvm_apic_mode(kvm_get_apic_base(vcpu));
+	return kvm_apic_mode(vcpu->arch.apic_base);
 }
 EXPORT_SYMBOL_GPL(kvm_get_apic_mode);
 
@@ -4329,7 +4324,7 @@ int kvm_get_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
 		msr_info->data = 1 << 24;
 		break;
 	case MSR_IA32_APICBASE:
-		msr_info->data = kvm_get_apic_base(vcpu);
+		msr_info->data = vcpu->arch.apic_base;
 		break;
 	case APIC_BASE_MSR ... APIC_BASE_MSR + 0xff:
 		return kvm_x2apic_msr_read(vcpu, msr_info->index, &msr_info->data);
@@ -10225,7 +10220,7 @@ static void post_kvm_run_save(struct kvm_vcpu *vcpu)
 
 	kvm_run->if_flag = kvm_x86_call(get_if_flag)(vcpu);
 	kvm_run->cr8 = kvm_get_cr8(vcpu);
-	kvm_run->apic_base = kvm_get_apic_base(vcpu);
+	kvm_run->apic_base = vcpu->arch.apic_base;
 
 	kvm_run->ready_for_interrupt_injection =
 		pic_in_kernel(vcpu->kvm) ||
@@ -11788,7 +11783,7 @@ skip_protected_regs:
 	sregs->cr4 = kvm_read_cr4(vcpu);
 	sregs->cr8 = kvm_get_cr8(vcpu);
 	sregs->efer = vcpu->arch.efer;
-	sregs->apic_base = kvm_get_apic_base(vcpu);
+	sregs->apic_base = vcpu->arch.apic_base;
 }
 
 static void __get_sregs(struct kvm_vcpu *vcpu, struct kvm_sregs *sregs)


### PR DESCRIPTION
Fix various compile issues to make pvVMCS-POC-v6.12 patches compile successfully in Android kernel build environment, applied on top of https://android.googlesource.com/kernel/common/+log/refs/heads/android16-6.12-desktop branch.