### PR TITLE
[minor] Remove extra printk in CPU deprivilege

### DIFF
--- a/arch/x86/kvm/vmx/pkvm/pkvm_host.c
+++ b/arch/x86/kvm/vmx/pkvm/pkvm_host.c
@@ -902,7 +902,6 @@ static noinline int local_deprivilege_cpu(struct pkvm_host_vcpu *hvcpu)
 		: "=m"(ret)
 		: "i"(GUEST_RIP), "i"(-EINVAL), "i"(GUEST_RFLAGS), "i"(GUEST_RSP)
 		: "rax", "rdx", "memory");
-	printk(KERN_INFO "pKVM: Deprivileged ret=%x vcpu=%px\n", ret, hvcpu);
 
 	return ret;
 }


### PR DESCRIPTION
This printk seems redundant, since we already have more informative debugs "CPU%d in guest mode" and "failed to deprivilege CPU%d" in pkvm_host_deprivilege_cpu().