### PR TITLE
pkvm: vmx: Disable ipiv via setting enable_ipiv to false

### DIFF
--- a/arch/x86/kvm/pkvm/vmx/vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/vmx.c
@@ -7024,12 +7024,9 @@ int vmx_vcpu_create(struct kvm_vcpu *vcpu)
 #endif
 	}
 
-	/* TODO: support ipiv in the pkvm hypervisor */
-#ifndef __PKVM_HYP__
 	if (vmx_can_use_ipiv(vcpu))
 		WRITE_ONCE(to_kvm_vmx(vcpu->kvm)->pid_table[vcpu->vcpu_id],
 			   __pa(&vmx->pi_desc) | PID_TABLE_ENTRY_VALID);
-#endif
 
 #ifdef __PKVM_HYP__
 	err = pkvm_init_shadow_vcpu(vcpu);
@@ -8087,6 +8084,9 @@ int setup_vmx(void)
 	 * to mark the dirty page.
 	 */
 	enable_pml = 0;
+
+	/* FIXME: Enable ipiv */
+	enable_ipiv = false;
 
 	for_each_possible_cpu(cpu)
 		INIT_LIST_HEAD(&per_cpu(loaded_vmcss_on_cpu, cpu));

--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -8545,6 +8545,11 @@ __init int vmx_hardware_setup(void)
 	if (!enable_apicv || !cpu_has_vmx_ipiv())
 		enable_ipiv = false;
 
+#if IS_ENABLED(CONFIG_PKVM_INTEL)
+	if (enable_pkvm)
+		enable_ipiv = false;
+#endif
+
 	if (cpu_has_vmx_tsc_scaling())
 		kvm_caps.has_tsc_control = true;
 


### PR DESCRIPTION
The ipiv feature is not supported by the pkvm hypervisor, but was not disabled properly. Fix this.