### PR TITLE
kvm: pkvm: Check and set the LAM in the kvm governed features

### DIFF
--- a/arch/x86/kvm/vmx/pkvm_high.c
+++ b/arch/x86/kvm/vmx/pkvm_high.c
@@ -1764,6 +1764,8 @@ static void pkvm_vcpu_after_set_cpuid(struct kvm_vcpu *vcpu)
 	void *entries;
 	size_t size;
 
+	kvm_governed_feature_check_and_set(vcpu, X86_FEATURE_LAM);
+
 	if (vcpu->arch.guest_state_protected || !e2 || !nent)
 		return;
 


### PR DESCRIPTION
Set the kvm governed features for the LAM in the vcpu_after_set_cpuid callback if the guest has this feature in its CPUID. This will be used by the host to calculate the untagged guest virtual address when emulate the LAM.