### PR TITLE
Align with android16-6.12-desktop branch

### DIFF
--- a/arch/x86/include/asm/kvm_host.h
+++ b/arch/x86/include/asm/kvm_host.h
@@ -1302,6 +1302,7 @@ enum kvm_apicv_inhibit {
 	__APICV_INHIBIT_REASON(SEV),			\
 	__APICV_INHIBIT_REASON(LOGICAL_ID_ALIASED)
 
+#if IS_ENABLED(CONFIG_PKVM_INTEL)
 struct pkvm_memcache {
 	phys_addr_t head;
 	unsigned long nr_pages;
@@ -1339,6 +1340,11 @@ static inline void __free_pkvm_memcache(struct pkvm_memcache *mc,
 		free_fn(pop_pkvm_memcache(mc, to_va), arg);
 }
 
+struct kvm_pinned_page {
+	struct list_head list;
+	struct page *page;
+};
+
 struct kvm_protected_vm {
 	int pkvm_vm_handle;
 
@@ -1350,6 +1356,7 @@ struct kvm_protected_vm {
 	bool finalized;
 	struct mutex finalized_lock;
 };
+#endif /* CONFIG_PKVM_INTEL */
 
 struct kvm_arch {
 	unsigned long n_used_mmu_pages;
@@ -1593,7 +1600,9 @@ struct kvm_arch {
 #define SPLIT_DESC_CACHE_MIN_NR_OBJECTS (SPTE_ENT_PER_PAGE + 1)
 	struct kvm_mmu_memory_cache split_desc_cache;
 
+#if IS_ENABLED(CONFIG_PKVM_INTEL)
 	struct kvm_protected_vm pkvm;
+#endif
 };
 
 struct kvm_vm_stat {
@@ -1934,11 +1943,6 @@ struct kvm_arch_async_pf {
 	unsigned long cr3;
 	bool direct_map;
 	u64 error_code;
-};
-
-struct kvm_pinned_page {
-	struct list_head list;
-	struct page *page;
 };
 
 extern u32 __read_mostly kvm_nr_uret_msrs;

--- a/arch/x86/kvm/mmu/mmu.c
+++ b/arch/x86/kvm/mmu/mmu.c
@@ -4724,6 +4724,17 @@ bool kvm_mmu_may_ignore_guest_pat(void)
 	return shadow_memtype_mask;
 }
 
+static inline int __kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
+{
+#ifdef CONFIG_X86_64
+	if (tdp_mmu_enabled)
+		return kvm_tdp_mmu_page_fault(vcpu, fault);
+#endif
+
+	return direct_page_fault(vcpu, fault);
+}
+
+#if IS_ENABLED(CONFIG_PKVM_INTEL)
 int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
 {
 	struct kvm_pinned_page *ppage = NULL;
@@ -4736,14 +4747,7 @@ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
 			return -ENOMEM;
 	}
 
-#ifdef CONFIG_X86_64
-	if (tdp_mmu_enabled)
-		r = kvm_tdp_mmu_page_fault(vcpu, fault);
-	else
-		r = direct_page_fault(vcpu, fault);
-#else
-	r = direct_page_fault(vcpu, fault);
-#endif
+	r = __kvm_tdp_page_fault(vcpu, fault);
 
 	if (ppage) {
 		if (r == RET_PF_FIXED && (page = kvm_pfn_to_refcounted_page(fault->pfn))) {
@@ -4759,6 +4763,12 @@ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
 
 	return r;
 }
+#else
+int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
+{
+	return __kvm_tdp_page_fault(vcpu, fault);
+}
+#endif
 
 static int kvm_tdp_map_page(struct kvm_vcpu *vcpu, gpa_t gpa, u64 error_code,
 			    u8 *level)

--- a/include/linux/kvm_host.h
+++ b/include/linux/kvm_host.h
@@ -1984,10 +1984,16 @@ struct _kvm_stats_desc {
 	STATS_DESC_LOG_HIST(SCOPE, name, KVM_STATS_UNIT_SECONDS,	       \
 		KVM_STATS_BASE_POW10, -9, sz)
 
+#if IS_ENABLED(CONFIG_PKVM_INTEL)
 #define KVM_GENERIC_VM_STATS()						       \
 	STATS_DESC_COUNTER(VM_GENERIC, remote_tlb_flush),		       \
 	STATS_DESC_COUNTER(VM_GENERIC, remote_tlb_flush_requests),	       \
 	STATS_DESC_COUNTER(VM_GENERIC, remote_tlb_flush_with_range)
+#else
+#define KVM_GENERIC_VM_STATS()						       \
+	STATS_DESC_COUNTER(VM_GENERIC, remote_tlb_flush),		       \
+	STATS_DESC_COUNTER(VM_GENERIC, remote_tlb_flush_requests)
+#endif
 
 #define KVM_GENERIC_VCPU_STATS()					       \
 	STATS_DESC_COUNTER(VCPU_GENERIC, halt_successful_poll),		       \

--- a/include/linux/kvm_types.h
+++ b/include/linux/kvm_types.h
@@ -99,7 +99,9 @@ struct kvm_mmu_memory_cache {
 struct kvm_vm_stat_generic {
 	u64 remote_tlb_flush;
 	u64 remote_tlb_flush_requests;
+#if IS_ENABLED(CONFIG_PKVM_INTEL)
 	u64 remote_tlb_flush_with_range;
+#endif
 };
 
 struct kvm_vcpu_stat_generic {

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -355,7 +355,9 @@ EXPORT_SYMBOL_GPL(kvm_flush_remote_tlbs);
 void kvm_flush_remote_tlbs_range(struct kvm *kvm, gfn_t gfn, u64 nr_pages)
 {
 	if (!kvm_arch_flush_remote_tlbs_range(kvm, gfn, nr_pages)) {
+#if IS_ENABLED(CONFIG_PKVM_INTEL)
 		++kvm->stat.generic.remote_tlb_flush_with_range;
+#endif
 		return;
 	}
 


### PR DESCRIPTION
When pKVM-IA patches were merged into the android16-6.12-desktop kernel branch [1], there were some small differences introduced, to wrap pKVM-IA specific changes in KVM data structures under CONFIG_PKVM_INTEL (in particular, to avoid changing the arm64 ABI). See also [2].

So port those changes back from android16-6.12-desktop to this pvVMCS-POC-v6.12 branch, to make it easier to synchronize the two branches.

[1] https://android.googlesource.com/kernel/common/+/refs/heads/android16-6.12-desktop
[2] https://android-review.googlesource.com/c/kernel/common/+/3539681