### PR TITLE
Pkvm v6.15: isolate the pkvm hypervisor from the host VM

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -37,6 +37,7 @@ struct pkvm_hyp {
 #define PKVM_PCPU_PAGES		(PAGE_ALIGN(sizeof(struct pkvm_pcpu)) >> PAGE_SHIFT)
 
 enum pkvm_mem_type {
+	PKVM_RESERVED_USED_MEMORY,
 	PKVM_RESERVED_UNUSED_MEMORY,
 	PKVM_TEXT_DATA,
 };

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -71,6 +71,7 @@ extern unsigned long pkvm_sym(phys_base);
 extern struct pkvm_hyp *pkvm_sym(pkvm_hyp);
 extern struct memblock_region pkvm_sym(pkvm_memory)[];
 extern unsigned int pkvm_sym(pkvm_memblock_nr);
+extern struct cpuinfo_x86 pkvm_sym(boot_cpu_data);
 
 u64 pkvm_total_reserve_pages(void);
 PKVM_DECLARE(void *, pkvm_early_alloc_page, (void));

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -3,6 +3,7 @@
 #define _ASM_X86_KVM_PKVM_H
 
 #ifdef CONFIG_PKVM_X86
+#include <linux/memblock.h>
 #include <linux/mm.h>
 #include <linux/memblock.h>
 #include <asm/pkvm_image.h>
@@ -12,6 +13,7 @@
 #define PKVM_STACK_SIZE			SZ_16K
 /* Size of reserved space for private parameter in pkvm stack */
 #define PKVM_STACK_TOP_RESV		16
+#define PKVM_PGTABLE_MAX_LEVELS		5
 
 struct idt_page {
 	gate_desc idt[IDT_ENTRIES];
@@ -100,6 +102,37 @@ static inline unsigned long pkvm_data_pages(unsigned long extra_global,
 static inline unsigned long get_host_stack_top(struct pkvm_pcpu *pcpu)
 {
 	return (unsigned long) &pcpu->stack[sizeof(pcpu->stack)];
+}
+
+static inline unsigned long __pkvm_pgtable_max_pages(unsigned long nr_pages)
+{
+	unsigned long total = 0, i;
+
+	/* Provision the worst case */
+	for (i = 0; i < PKVM_PGTABLE_MAX_LEVELS; i++) {
+		nr_pages = DIV_ROUND_UP(nr_pages, PTRS_PER_PTE);
+		total += nr_pages;
+	}
+
+	return total;
+}
+
+static inline unsigned long __pkvm_pgtable_total_pages(void)
+{
+	unsigned long total = 0, i;
+
+	for (i = 0; i < pkvm_sym(pkvm_memblock_nr); i++) {
+		struct memblock_region *reg = &pkvm_sym(pkvm_memory)[i];
+
+		total += __pkvm_pgtable_max_pages(reg->size >> PAGE_SHIFT);
+	}
+
+	return total;
+}
+
+static inline unsigned long pkvm_hyp_pgtable_pages(void)
+{
+	return __pkvm_pgtable_total_pages();
 }
 
 #endif /* CONFIG_PKVM_X86 */

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -36,6 +36,19 @@ struct pkvm_hyp {
 #define PKVM_HYP_PAGES		(PAGE_ALIGN(sizeof(struct pkvm_hyp)) >> PAGE_SHIFT)
 #define PKVM_PCPU_PAGES		(PAGE_ALIGN(sizeof(struct pkvm_pcpu)) >> PAGE_SHIFT)
 
+enum pkvm_mem_type {
+	PKVM_RESERVED_UNUSED_MEMORY,
+	PKVM_TEXT_DATA,
+};
+
+struct pkvm_mem_info {
+	enum pkvm_mem_type type;
+	unsigned long va;
+	unsigned long pa;
+	unsigned long size;
+	u64 prot;
+};
+
 enum pkvm_fn {
 	__pkvm__init_finalize,
 };
@@ -76,6 +89,10 @@ extern unsigned int pkvm_sym(pkvm_memblock_nr);
 extern struct cpuinfo_x86 pkvm_sym(boot_cpu_data);
 #ifdef CONFIG_DYNAMIC_PHYSICAL_MASK
 extern phys_addr_t pkvm_sym(physical_mask);
+#endif
+extern pteval_t pkvm_sym(__default_kernel_pte_mask);
+#ifdef CONFIG_AMD_MEM_ENCRYPT
+extern u64 pkvm_sym(sme_me_mask);
 #endif
 
 u64 pkvm_total_reserve_pages(void);

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -4,6 +4,7 @@
 
 #ifdef CONFIG_PKVM_X86
 #include <linux/mm.h>
+#include <linux/memblock.h>
 #include <asm/pkvm_image.h>
 #include <asm/desc.h>
 
@@ -68,6 +69,8 @@ extern unsigned long pkvm_sym(page_offset_base);
 #endif
 extern unsigned long pkvm_sym(phys_base);
 extern struct pkvm_hyp *pkvm_sym(pkvm_hyp);
+extern struct memblock_region pkvm_sym(pkvm_memory)[];
+extern unsigned int pkvm_sym(pkvm_memblock_nr);
 
 u64 pkvm_total_reserve_pages(void);
 PKVM_DECLARE(void *, pkvm_early_alloc_page, (void));

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -179,6 +179,28 @@ static inline unsigned long pkvm_vmemmap_pages(size_t vmemmap_entry_size)
 	return total_size >> PAGE_SHIFT;
 }
 
+static inline unsigned long pkvm_host_pgtable_pages(void)
+{
+	/*
+	 * Usually the 2G ~ 4G are used as MMIO hole. As the host mmu should
+	 * contain the mapping for the MMIO, reserve additional memory pages
+	 * for 2GB MMIO size.
+	 *
+	 * MMIO regions also exists in the high-end physical address space which
+	 * is not able to know the size precisely during the early boot.
+	 * Therefore, instead of specifically reserving memory pages for these
+	 * MMIO regions, share the reservation for the 2G ~ 4G MMIO region.
+	 * While this approach cannot guarantee that memory page allocation for
+	 * the required MMIO mappings will always success, it is feasible
+	 * because the reservation for 2G ~ 4G MMIO region is based on the worst
+	 * case (4K page size) while in practice the MMIO region will be mapped
+	 * using the possible largest page size(e.g. 1G/2M), which significantly
+	 * reduces the memory consumption and makes sharing possible.
+	 */
+	return __pkvm_pgtable_total_pages() +
+	       __pkvm_pgtable_max_pages(SZ_2G >> PAGE_SHIFT);
+}
+
 #endif /* CONFIG_PKVM_X86 */
 
 #endif /* _ASM_X86_KVM_PKVM_H */

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -152,6 +152,33 @@ static inline unsigned long pkvm_hyp_pgtable_pages(void)
 	return __pkvm_pgtable_total_pages();
 }
 
+static inline unsigned long __vmemmap_memblock_size(struct memblock_region *reg,
+						    size_t vmemmap_entry_size)
+{
+	unsigned long nr_pages = reg->size >> PAGE_SHIFT;
+	unsigned long start, end;
+
+	/* Translate the pfn to the vmemmap entry */
+	start = (reg->base >> PAGE_SHIFT) * vmemmap_entry_size;
+	end = start + nr_pages * vmemmap_entry_size;
+	start = ALIGN_DOWN(start, PAGE_SIZE);
+	end = ALIGN(end, PAGE_SIZE);
+
+	return end - start;
+}
+
+static inline unsigned long pkvm_vmemmap_pages(size_t vmemmap_entry_size)
+{
+	unsigned long total_size = 0, i;
+
+	for (i = 0; i < pkvm_sym(pkvm_memblock_nr); i++) {
+		total_size += __vmemmap_memblock_size(&pkvm_sym(pkvm_memory)[i],
+						      vmemmap_entry_size);
+	}
+
+	return total_size >> PAGE_SHIFT;
+}
+
 #endif /* CONFIG_PKVM_X86 */
 
 #endif /* _ASM_X86_KVM_PKVM_H */

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -33,6 +33,10 @@ struct pkvm_hyp {
 #define PKVM_HYP_PAGES		(PAGE_ALIGN(sizeof(struct pkvm_hyp)) >> PAGE_SHIFT)
 #define PKVM_PCPU_PAGES		(PAGE_ALIGN(sizeof(struct pkvm_pcpu)) >> PAGE_SHIFT)
 
+enum pkvm_fn {
+	__pkvm__init_finalize,
+};
+
 #define __kvm_call_pkvm_0(f)		kvm_hypercall4(f, 0, 0, 0, 0)
 #define __kvm_call_pkvm_1(f, p1)							\
 	({										\

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -72,6 +72,9 @@ extern struct pkvm_hyp *pkvm_sym(pkvm_hyp);
 extern struct memblock_region pkvm_sym(pkvm_memory)[];
 extern unsigned int pkvm_sym(pkvm_memblock_nr);
 extern struct cpuinfo_x86 pkvm_sym(boot_cpu_data);
+#ifdef CONFIG_DYNAMIC_PHYSICAL_MASK
+extern phys_addr_t pkvm_sym(physical_mask);
+#endif
 
 u64 pkvm_total_reserve_pages(void);
 PKVM_DECLARE(void *, pkvm_early_alloc_page, (void));

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -52,6 +52,20 @@ struct pkvm_mem_info {
 
 enum pkvm_fn {
 	__pkvm__init_finalize,
+
+	/* Below PV interfaces should use kvm_call_pkvm_inout */
+	PKVM_FIRST_INOUT_PV_INTERFACE,
+};
+
+#define PKVM_FN_DATA_LEN		4
+
+union pkvm_fn_data {
+	struct {
+		u64 val1;
+		u64 val2;
+		u64 val3;
+		u64 val4;
+	};
 };
 
 #define __kvm_call_pkvm_0(f)		kvm_hypercall4(f, 0, 0, 0, 0)
@@ -76,8 +90,31 @@ enum pkvm_fn {
 #define CALL_PKVM(f)		CONCATENATE(__pkvm__, f)
 #define kvm_call_pkvm(f, ...)								\
 	({										\
+		BUILD_BUG_ON(CALL_PKVM(f) >= PKVM_FIRST_INOUT_PV_INTERFACE);		\
 		CONCATENATE(__kvm_call_pkvm_,						\
 			    COUNT_ARGS(__VA_ARGS__))(CALL_PKVM(f), ##__VA_ARGS__);	\
+	})
+#define __kvm_call_pkvm_inout_4(f, p1, p2, p3, p4, o)					\
+	({										\
+		int ret;								\
+		asm volatile(KVM_HYPERCALL						\
+			: "=a"(ret), "=b"((o)->val1), "=c"((o)->val2),			\
+			  "=d"((o)->val3), "=S"((o)->val4)				\
+			: "a"(f), "b"(p1), "c"(p2), "d"(p3), "S"(p4)			\
+			: "memory");							\
+		ret;									\
+	})
+#define kvm_call_pkvm_inout(f, inout)							\
+	({										\
+		u64 p1 = (inout)->val1;							\
+		u64 p2 = (inout)->val2;							\
+		u64 p3 = (inout)->val3;							\
+		u64 p4 = (inout)->val4;							\
+		BUILD_BUG_ON(CALL_PKVM(f) < PKVM_FIRST_INOUT_PV_INTERFACE);		\
+		BUILD_BUG_ON(sizeof(union pkvm_fn_data) !=				\
+			     sizeof(u64) * PKVM_FN_DATA_LEN);				\
+		CONCATENATE(__kvm_call_pkvm_inout_,					\
+			    PKVM_FN_DATA_LEN)(CALL_PKVM(f), p1, p2, p3, p4, (inout));	\
 	})
 
 #ifdef CONFIG_DYNAMIC_MEMORY_LAYOUT

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -33,6 +33,32 @@ struct pkvm_hyp {
 #define PKVM_HYP_PAGES		(PAGE_ALIGN(sizeof(struct pkvm_hyp)) >> PAGE_SHIFT)
 #define PKVM_PCPU_PAGES		(PAGE_ALIGN(sizeof(struct pkvm_pcpu)) >> PAGE_SHIFT)
 
+#define __kvm_call_pkvm_0(f)		kvm_hypercall4(f, 0, 0, 0, 0)
+#define __kvm_call_pkvm_1(f, p1)							\
+	({										\
+		kvm_hypercall4(f, (unsigned long)(p1), 0, 0, 0);			\
+	})
+#define __kvm_call_pkvm_2(f, p1, p2)							\
+	({										\
+		kvm_hypercall4(f, (unsigned long)(p1), (unsigned long)(p2), 0, 0);	\
+	})
+#define __kvm_call_pkvm_3(f, p1, p2, p3)						\
+	({										\
+		kvm_hypercall4(f, (unsigned long)(p1), (unsigned long)(p2),		\
+			       (unsigned long)(p3), 0);					\
+	})
+#define __kvm_call_pkvm_4(f, p1, p2, p3, p4)						\
+	({										\
+		kvm_hypercall4(f, (unsigned long)(p1), (unsigned long)(p2),		\
+			       (unsigned long)(p3), (unsigned long)(p4));		\
+	})
+#define CALL_PKVM(f)		CONCATENATE(__pkvm__, f)
+#define kvm_call_pkvm(f, ...)								\
+	({										\
+		CONCATENATE(__kvm_call_pkvm_,						\
+			    COUNT_ARGS(__VA_ARGS__))(CALL_PKVM(f), ##__VA_ARGS__);	\
+	})
+
 #ifdef CONFIG_DYNAMIC_MEMORY_LAYOUT
 extern unsigned long pkvm_sym(page_offset_base);
 #endif

--- a/arch/x86/include/asm/pkvm_image.h
+++ b/arch/x86/include/asm/pkvm_image.h
@@ -45,6 +45,9 @@
 
 #ifdef CONFIG_PKVM_X86
 extern char __pkvm_text_start[], __pkvm_text_end[];
+extern char __pkvm_rodata_start[], __pkvm_rodata_end[];
+extern char __pkvm_data_start[], __pkvm_data_end[];
+extern char __pkvm_bss_start[], __pkvm_bss_end[];
 static inline bool is_pkvm_text(void *addr)
 {
 	return addr >= (void *)__pkvm_text_start && addr < (void *)__pkvm_text_end;

--- a/arch/x86/include/asm/pkvm_image.h
+++ b/arch/x86/include/asm/pkvm_image.h
@@ -26,17 +26,10 @@
 
 #ifdef LINKER_SCRIPT
 
-#define __PKVM_CONCAT(a, b)	a ## b
-#define PKVM_CONCAT(a, b)	__PKVM_CONCAT(a, b)
-
 #define PKVM_SECTION_NAME(NAME)	.pkvm##NAME
 
-#define PKVM_SECTION_SYMBOL_NAME(NAME) \
-	PKVM_CONCAT(__pkvm_section_, PKVM_SECTION_NAME(NAME))
-
 #define BEGIN_PKVM_SECTION(NAME)			\
-	PKVM_SECTION_NAME(NAME) : {			\
-		PKVM_SECTION_SYMBOL_NAME(NAME) = .;
+	PKVM_SECTION_NAME(NAME) : {
 
 #define END_PKVM_SECTION				\
 	}

--- a/arch/x86/kernel/alternative.c
+++ b/arch/x86/kernel/alternative.c
@@ -250,7 +250,7 @@ static void *its_allocate_thunk(void *addr, int reg)
 	 * than using dynamic thunks as the page holding the thunk code belongs
 	 * to the host which will be not accessible to the pkvm after deprivilege.
 	 */
-	if (!is_pkvm_text(addr))
+	if (is_pkvm_text(addr))
 		return NULL;
 
 #ifdef CONFIG_FINEIBT

--- a/arch/x86/kernel/vmlinux.lds.S
+++ b/arch/x86/kernel/vmlinux.lds.S
@@ -141,11 +141,22 @@ PHDRS {
 	. = ALIGN(PAGE_SIZE);						\
 	__pkvm_data_end = .;
 
+#define PKVM_RODATA							\
+	PKVM_SECTION_NAME(.rodata) : 					\
+		AT(ADDR(PKVM_SECTION_NAME(.rodata)) - LOAD_OFFSET) {	\
+	. = ALIGN(PAGE_SIZE);						\
+	__pkvm_rodata_start = .;					\
+	*(PKVM_SECTION_NAME(.rodata))					\
+	*(PKVM_SECTION_NAME(.data..ro_after_init))			\
+	. = ALIGN(PAGE_SIZE);						\
+	__pkvm_rodata_end = .;						\
+	}
 #else
 
 #define PKVM_TEXT
 #define PKVM_BSS
 #define PKVM_DATA
+#define PKVM_RODATA
 
 #endif
 
@@ -238,6 +249,16 @@ SECTIONS
 		/* End of data section */
 		_edata = .;
 	} :data
+
+	/*
+	 * The mark_rodata_ro() function expects to unmap the gaps in the
+	 * text/rodata and rodata/data sections. Placing the pKVM rodata between
+	 * text, rodata and data will lead the mark_rodata_ro() to unmap and
+	 * free the pKVM rodata memory pages, causing the memory accessing
+	 * violation as these pages are protected by the pKVM. Positioning the
+	 * pKVM rodata after the data section.
+	 */
+	PKVM_RODATA
 
 	BUG_TABLE
 

--- a/arch/x86/kvm/.gitignore
+++ b/arch/x86/kvm/.gitignore
@@ -2,3 +2,4 @@
 /kvm-asm-offsets.h
 pkvm.lds
 retpoline.pkvm.S
+pkvm_constants.h

--- a/arch/x86/kvm/Makefile
+++ b/arch/x86/kvm/Makefile
@@ -47,6 +47,13 @@ $(obj)/kvm-asm-offsets.h: $(obj)/kvm-asm-offsets.s FORCE
 
 pkvm-intel-$(CONFIG_PKVM_INTEL)	+= vmx/pkvm_init.o
 
+$(obj)/vmx/pkvm_init.o: $(obj)/pkvm/pkvm_constants.h
+$(obj)/pkvm/pkvm-constants.s: $(src)/pkvm/pkvm_constants.c FORCE
+	$(call if_changed_dep,cc_s_c)
+$(obj)/pkvm/pkvm_constants.h: $(obj)/pkvm/pkvm-constants.s FORCE
+	$(call filechk,offsets,__PKVM_CONSTANTS_H__)
+CFLAGS_vmx/pkvm_init.o    := -iquote $(obj)/pkvm
+
 obj-$(CONFIG_PKVM_X86) += pkvm-intel.o pkvm.o pkvm/
 
 targets += kvm-asm-offsets.s

--- a/arch/x86/kvm/pkvm.c
+++ b/arch/x86/kvm/pkvm.c
@@ -7,7 +7,7 @@
 
 bool __read_mostly enable_pkvm;
 
-static struct memblock_region pkvm_memory[PKVM_MEMBLOCK_REGIONS];
+static struct memblock_region *pkvm_memory = pkvm_sym(pkvm_memory);
 static unsigned int pkvm_memblock_nr;
 
 phys_addr_t pkvm_mem_base;
@@ -42,6 +42,7 @@ static int __init register_memblock_regions(void)
 		pkvm_memblock_nr++;
 	}
 	sort_memblock_regions();
+	pkvm_sym(pkvm_memblock_nr) = pkvm_memblock_nr;
 
 	return 0;
 }

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -13,7 +13,7 @@ asflags-y += -include $(srctree)/arch/x86/kvm/pkvm/undef.h
 cmd_deps			:= $(src)/compiling_cmds.sh
 
 pkvm-hyp-y			:= early_alloc.o pkvm.o memory.o cpu.o \
-				   idt.o entry.o init_finalize.o
+				   idt.o entry.o init_finalize.o pgtable.o
 
 kernel-x86-lib			:= ../../lib
 pkvm-hyp-y			+= $(kernel-x86-lib)/memset_64.o

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -13,7 +13,7 @@ asflags-y += -include $(srctree)/arch/x86/kvm/pkvm/undef.h
 cmd_deps			:= $(src)/compiling_cmds.sh
 
 pkvm-hyp-y			:= early_alloc.o pkvm.o memory.o cpu.o \
-				   idt.o entry.o
+				   idt.o entry.o init_finalize.o
 
 kernel-x86-lib			:= ../../lib
 pkvm-hyp-y			+= $(kernel-x86-lib)/memset_64.o

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -14,7 +14,7 @@ cmd_deps			:= $(src)/compiling_cmds.sh
 
 pkvm-hyp-y			:= early_alloc.o pkvm.o memory.o cpu.o \
 				   idt.o entry.o init_finalize.o pgtable.o \
-				   mmu.o
+				   mmu.o page_alloc.o
 
 kernel-x86-lib			:= ../../lib
 pkvm-hyp-y			+= $(kernel-x86-lib)/memset_64.o

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -34,7 +34,7 @@ kvm				:= ..
 pkvm-hyp-y			+= $(kvm)/x86.o
 
 pkvm-hyp-$(CONFIG_PKVM_INTEL)	+= vmx/host_vmentry.o vmx/host_vmx.o \
-				   $(kvm)/vmx/vmx.o vmx/idt.o
+				   $(kvm)/vmx/vmx.o vmx/idt.o vmx/ept.o
 
 pkvm-obj 			:= $(patsubst %.o,%.pkvm.o,$(pkvm-hyp-y))
 obj-$(CONFIG_PKVM_X86)		+= pkvm.o

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -27,6 +27,9 @@ $(obj)/retpoline.pkvm.S: $(srctree)/arch/x86/lib/retpoline.S $(cmd_deps) FORCE
 quiet_cmd_patch_retpoline = PATCH_RETPOLINE $@
       cmd_patch_retpoline = $(BASH) $(src)/compiling_cmds.sh patch_retpoline $< $@
 
+kernel-lib			:= ../../../../lib
+pkvm-hyp-$(CONFIG_LIST_HARDENED) += $(kernel-lib)/list_debug.o
+
 kvm				:= ..
 pkvm-hyp-y			+= $(kvm)/x86.o
 

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -18,6 +18,7 @@ pkvm-hyp-y			:= early_alloc.o pkvm.o memory.o cpu.o \
 
 kernel-x86-lib			:= ../../lib
 pkvm-hyp-y			+= $(kernel-x86-lib)/memset_64.o
+pkvm-hyp-y			+= $(kernel-x86-lib)/memcpy_64.o
 
 pkvm-hyp-$(CONFIG_MITIGATION_RETPOLINE)	+= retpoline.o
 $(obj)/retpoline.pkvm.o: $(obj)/retpoline.pkvm.S FORCE

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -13,7 +13,8 @@ asflags-y += -include $(srctree)/arch/x86/kvm/pkvm/undef.h
 cmd_deps			:= $(src)/compiling_cmds.sh
 
 pkvm-hyp-y			:= early_alloc.o pkvm.o memory.o cpu.o \
-				   idt.o entry.o init_finalize.o pgtable.o
+				   idt.o entry.o init_finalize.o pgtable.o \
+				   mmu.o
 
 kernel-x86-lib			:= ../../lib
 pkvm-hyp-y			+= $(kernel-x86-lib)/memset_64.o

--- a/arch/x86/kvm/pkvm/cpu.c
+++ b/arch/x86/kvm/pkvm/cpu.c
@@ -16,6 +16,7 @@ DEFINE_PER_CPU_CACHE_HOT(int, cpu_number);
 #ifdef CONFIG_X86_64
 DEFINE_PER_CPU_CACHE_HOT(u64, __x86_call_depth);
 #endif
+struct cpuinfo_x86 boot_cpu_data;
 
 unsigned int pkvm_per_cpu_nr_pages(void)
 {

--- a/arch/x86/kvm/pkvm/cpu.c
+++ b/arch/x86/kvm/pkvm/cpu.c
@@ -6,6 +6,7 @@
 #include <asm/kvm_pkvm.h>
 #include <asm/percpu.h>
 #include <asm/page.h>
+#include "memory.h"
 #include "pkvm.h"
 #include "cpu.h"
 
@@ -38,7 +39,7 @@ int pkvm_setup_per_cpu(int cpu, unsigned long base)
 	if (!vcpu)
 		return -EINVAL;
 
-	__per_cpu_offset[cpu] = (unsigned long)__va(base) -
+	__per_cpu_offset[cpu] = (unsigned long)__pkvm_va(base) -
 				(unsigned long)__per_cpu_start;
 	per_cpu(this_cpu_off, cpu) = __per_cpu_offset[cpu];
 	per_cpu(cpu_number, cpu) = cpu;

--- a/arch/x86/kvm/pkvm/early_alloc.c
+++ b/arch/x86/kvm/pkvm/early_alloc.c
@@ -3,6 +3,7 @@
 #include <asm/kvm_pkvm.h>
 #include <asm/pkvm_spinlock.h>
 #include <asm/string.h>
+#include "early_alloc.h"
 #include "pgtable.h"
 
 static unsigned long base;
@@ -62,4 +63,9 @@ void pkvm_early_alloc_init(void *virt, unsigned long size)
 {
 	base = cur = (unsigned long)virt;
 	end = base + size;
+}
+
+unsigned long pkvm_early_alloc_nr_used_pages(void)
+{
+	return (cur - base) >> PAGE_SHIFT;
 }

--- a/arch/x86/kvm/pkvm/early_alloc.c
+++ b/arch/x86/kvm/pkvm/early_alloc.c
@@ -3,6 +3,7 @@
 #include <asm/kvm_pkvm.h>
 #include <asm/pkvm_spinlock.h>
 #include <asm/string.h>
+#include "pgtable.h"
 
 static unsigned long base;
 static unsigned long end;
@@ -37,6 +38,25 @@ void *pkvm_early_alloc_page(void)
 {
 	return pkvm_early_alloc_contig(1);
 }
+
+static void pkvm_early_alloc_get_page(void *addr) {}
+static void pkvm_early_alloc_put_page(void *addr) {}
+static int pkvm_early_page_count(void *vaddr)
+{
+	/*
+	 * The early alloc managed pages cannot be freed thus it doesn't need
+	 * to support get_page/put_page. The page count is also meaningless.
+	 * So always return a non-zero value.
+	 */
+	return INT_MAX;
+}
+
+const struct pkvm_pgtable_mm_ops pkvm_early_alloc_mm_ops = {
+	.zalloc_page = pkvm_early_alloc_page,
+	.get_page = pkvm_early_alloc_get_page,
+	.put_page = pkvm_early_alloc_put_page,
+	.page_count = pkvm_early_page_count,
+};
 
 void pkvm_early_alloc_init(void *virt, unsigned long size)
 {

--- a/arch/x86/kvm/pkvm/early_alloc.h
+++ b/arch/x86/kvm/pkvm/early_alloc.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __PKVM_EARLY_ALLOC_H
+#define __PKVM_EARLY_ALLOC_H
+
+#include "pgtable.h"
+
+extern const struct pkvm_pgtable_mm_ops pkvm_early_alloc_mm_ops;
+
+#endif /* __PKVM_EARLY_ALLOC_H */

--- a/arch/x86/kvm/pkvm/early_alloc.h
+++ b/arch/x86/kvm/pkvm/early_alloc.h
@@ -6,4 +6,6 @@
 
 extern const struct pkvm_pgtable_mm_ops pkvm_early_alloc_mm_ops;
 
+unsigned long pkvm_early_alloc_nr_used_pages(void);
+
 #endif /* __PKVM_EARLY_ALLOC_H */

--- a/arch/x86/kvm/pkvm/gfp.h
+++ b/arch/x86/kvm/pkvm/gfp.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __PKVM_X86_GFP_H
+#define __PKVM_X86_GFP_H
+
+#include <linux/mmzone.h>
+#include <linux/list.h>
+#include <asm/pkvm_spinlock.h>
+#include "memory.h"
+
+#define PKVM_NO_ORDER	USHRT_MAX
+
+struct pkvm_pool {
+	/*
+	 * Spinlock protecting concurrent changes to the memory pool as well as
+	 * the struct pkvm_page of the pool's pages until we have a proper atomic
+	 * API.
+	 */
+	pkvm_spinlock_t lock;
+	struct list_head free_area[NR_PAGE_ORDERS];
+	phys_addr_t range_start;
+	phys_addr_t range_end;
+	unsigned short max_order;
+};
+
+/* Allocation */
+void *pkvm_alloc_pages(struct pkvm_pool *pool, u8 order);
+void pkvm_split_page(struct pkvm_page *page);
+void pkvm_get_page(struct pkvm_pool *pool, void *addr);
+void pkvm_put_page(struct pkvm_pool *pool, void *addr);
+
+/* Used pages cannot be freed */
+int pkvm_pool_init(struct pkvm_pool *pool, u64 pfn, unsigned int nr_pages,
+		   unsigned int reserved_pages);
+
+#endif /* __PKVM_X86_GFP_H */

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -1,7 +1,44 @@
 // SPDX-License-Identifier: GPL-2.0
+#include <asm/kvm_pkvm.h>
 #include "init_finalize.h"
+#include "memory.h"
 
-int pkvm_init_finalize(void)
+static void *hyp_pgt_base;
+
+static int divide_memory_pool(phys_addr_t phys, unsigned long size)
 {
+	unsigned long nr_pages;
+
+	pkvm_early_alloc_init(__pkvm_va(phys), size);
+
+	nr_pages = pkvm_hyp_pgtable_pages();
+	hyp_pgt_base = pkvm_early_alloc_contig(nr_pages);
+	if (!hyp_pgt_base)
+		return -ENOMEM;
+
+	return 0;
+}
+
+static int finalize_global(phys_addr_t mem_base, unsigned long mem_size)
+{
+	if (!PAGE_ALIGNED(mem_base) || !mem_size)
+		return -EINVAL;
+
+	return divide_memory_pool(mem_base, mem_size);
+}
+
+int pkvm_init_finalize(phys_addr_t mem_base, unsigned long mem_size)
+{
+	static bool global_finalized;
+
+	if (!global_finalized) {
+		int ret = finalize_global(mem_base, mem_size);
+
+		if (ret)
+			return ret;
+
+		global_finalized = true;
+	}
+
 	return 0;
 }

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -94,6 +94,8 @@ static int finalize_global(struct pkvm_mem_info infos[], int nr_infos)
 int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
 		       struct pkvm_init_ops *init_ops)
 {
+	hyp_mmu_finalize_fn_t hyp_mmu_finalize_fn = init_ops ? init_ops->hyp_mmu_finalize :
+							       NULL;
 	static bool global_finalized;
 
 	if (!global_finalized) {
@@ -105,5 +107,5 @@ int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
 		global_finalized = true;
 	}
 
-	return 0;
+	return pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn);
 }

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "init_finalize.h"
+
+int pkvm_init_finalize(void)
+{
+	return 0;
+}

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -91,7 +91,8 @@ static int finalize_global(struct pkvm_mem_info infos[], int nr_infos)
 	return create_hyp_mmu(infos, nr_infos);
 }
 
-int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos)
+int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
+		       struct pkvm_init_ops *init_ops)
 {
 	static bool global_finalized;
 

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -7,6 +7,7 @@
 #include "mmu.h"
 
 static void *hyp_pgt_base;
+static void *pkvm_vmemmap_base;
 
 static int divide_memory_pool(phys_addr_t phys, unsigned long size)
 {
@@ -18,6 +19,62 @@ static int divide_memory_pool(phys_addr_t phys, unsigned long size)
 	hyp_pgt_base = pkvm_early_alloc_contig(nr_pages);
 	if (!hyp_pgt_base)
 		return -ENOMEM;
+
+	nr_pages = pkvm_vmemmap_pages(sizeof(struct pkvm_page));
+	pkvm_vmemmap_base = pkvm_early_alloc_contig(nr_pages);
+	if (!pkvm_vmemmap_base)
+		return -ENOMEM;
+
+	return 0;
+}
+
+static int back_vmemmap(phys_addr_t back_pa)
+{
+	unsigned long start_va, size, end_va = 0;
+	struct memblock_region *reg;
+	unsigned int i;
+	int ret;
+
+	/* vmemmap region map to virtual address 0 */
+	__pkvm_vmemmap = 0;
+
+	for (i = 0; i < pkvm_memblock_nr; i++) {
+		reg = &pkvm_memory[i];
+		/* Translate a range of memory to vmemmap range */
+		start_va = ALIGN_DOWN((unsigned long)pkvm_phys_to_page(reg->base),
+				      PAGE_SIZE);
+		/*
+		 * The beginning of the pkvm_vmemmap region for the current
+		 * memblock may already be backed by the page backing the end
+		 * of the previous region, so avoid mapping it twice.
+		 */
+		start_va = max(start_va, end_va);
+
+		end_va = ALIGN((unsigned long)pkvm_phys_to_page(reg->base + reg->size),
+				PAGE_SIZE);
+		/*
+		 * The vmemmap va shall below PAGE_OFFSET to avoid overlapping
+		 * with the pkvm direct mapping
+		 */
+		if (end_va >= PAGE_OFFSET)
+			return -ENOMEM;
+		if (start_va >= end_va)
+			continue;
+
+		size = end_va - start_va;
+		/*
+		 * Create mapping for vmemmap virtual address
+		 * [start_va, start_va+size) to physical address
+		 * [back_pa, back_pa+size).
+		 */
+		ret = pkvm_hyp_mmu_map(start_va, back_pa, size,
+				       (u64)pgprot_val(PAGE_KERNEL));
+		if (ret)
+			return ret;
+
+		memset(__pkvm_va(back_pa), 0, size);
+		back_pa += size;
+	}
 
 	return 0;
 }
@@ -61,7 +118,7 @@ static int create_hyp_mmu(const struct pkvm_mem_info infos[], int nr_infos)
 		}
 	}
 
-	return 0;
+	return back_vmemmap(__pkvm_pa(pkvm_vmemmap_base));
 }
 
 static int finalize_global(struct pkvm_mem_info infos[], int nr_infos)

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -135,6 +135,40 @@ static int create_hyp_mmu(const struct pkvm_mem_info infos[], int nr_infos)
 	return pkvm_hyp_mmu_switch_to_buddy(hyp_pgt_base, nr_pages);
 }
 
+static int create_host_mmu(host_mmu_init_fn_t host_mmu_init_fn)
+{
+	struct memblock_region *reg;
+	unsigned long phys = 0;
+	unsigned int i;
+	int ret;
+
+	ret = pkvm_host_mmu_init(host_pgt_base, pkvm_host_pgtable_pages(),
+				 host_mmu_init_fn);
+	if (ret)
+		return ret;
+
+	/* Map memory blocks with RWX permissions */
+	for (i = 0; i < pkvm_memblock_nr; i++) {
+		reg = &pkvm_memory[i];
+		ret = pkvm_host_mmu_map((unsigned long)reg->base,
+					(unsigned long)reg->size,
+					true, true, true, false);
+		if (ret)
+			return ret;
+	}
+
+	/* Map holes between memblocks as MMIO with RWX permissions */
+	for (i = 0; i < pkvm_memblock_nr; i++, phys = reg->base + reg->size) {
+		reg = &pkvm_memory[i];
+		ret = pkvm_host_mmu_map(phys, (unsigned long)reg->base - phys,
+					true, true, true, true);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 static int finalize_global(struct pkvm_mem_info infos[], int nr_infos,
 			   struct pkvm_init_ops *init_ops)
 {
@@ -165,8 +199,7 @@ static int finalize_global(struct pkvm_mem_info infos[], int nr_infos,
 	if (ret)
 		return ret;
 
-	return pkvm_host_mmu_init(host_pgt_base, pkvm_host_pgtable_pages(),
-				  host_mmu_init_fn);
+	return create_host_mmu(host_mmu_init_fn);
 }
 
 int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -118,7 +118,15 @@ static int create_hyp_mmu(const struct pkvm_mem_info infos[], int nr_infos)
 		}
 	}
 
-	return back_vmemmap(__pkvm_pa(pkvm_vmemmap_base));
+	ret = back_vmemmap(__pkvm_pa(pkvm_vmemmap_base));
+	if (ret)
+		return ret;
+
+	/* Load pkvm hypervisor's MMU to use pkvm vmemmap */
+	pkvm_hyp_mmu_load();
+
+	/* Update the pkvm mmu to use pkvm buddy allocator */
+	return pkvm_hyp_mmu_switch_to_buddy(hyp_pgt_base, nr_pages);
 }
 
 static int finalize_global(struct pkvm_mem_info infos[], int nr_infos)
@@ -162,6 +170,13 @@ int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
 			return ret;
 
 		global_finalized = true;
+	} else {
+		/*
+		 * The pkvm hypervisor's MMU was already loaded on the first
+		 * finalized CPU during the global finalize. Need to load it
+		 * on all the other CPUs as well.
+		 */
+		pkvm_hyp_mmu_load();
 	}
 
 	return pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn);

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -230,11 +230,13 @@ int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
 {
 	hyp_mmu_finalize_fn_t hyp_mmu_finalize_fn = init_ops ? init_ops->hyp_mmu_finalize :
 							       NULL;
+	host_mmu_finalize_fn_t host_mmu_finalize_fn = init_ops ? init_ops->host_mmu_finalize :
+								 NULL;
 	static bool global_finalized;
+	int ret;
 
 	if (!global_finalized) {
-		int ret = finalize_global(infos, nr_infos, init_ops);
-
+		ret = finalize_global(infos, nr_infos, init_ops);
 		if (ret)
 			return ret;
 
@@ -248,5 +250,9 @@ int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
 		pkvm_hyp_mmu_load();
 	}
 
-	return pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn);
+	ret = pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn);
+	if (ret)
+		return ret;
+
+	return pkvm_host_mmu_finalize(host_mmu_finalize_fn);
 }

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -7,6 +7,7 @@
 #include "mmu.h"
 
 static void *hyp_pgt_base;
+static void *host_pgt_base;
 static void *pkvm_vmemmap_base;
 
 static int divide_memory_pool(phys_addr_t phys, unsigned long size)
@@ -18,6 +19,11 @@ static int divide_memory_pool(phys_addr_t phys, unsigned long size)
 	nr_pages = pkvm_hyp_pgtable_pages();
 	hyp_pgt_base = pkvm_early_alloc_contig(nr_pages);
 	if (!hyp_pgt_base)
+		return -ENOMEM;
+
+	nr_pages = pkvm_host_pgtable_pages();
+	host_pgt_base = pkvm_early_alloc_contig(nr_pages);
+	if (!host_pgt_base)
 		return -ENOMEM;
 
 	nr_pages = pkvm_vmemmap_pages(sizeof(struct pkvm_page));
@@ -129,8 +135,10 @@ static int create_hyp_mmu(const struct pkvm_mem_info infos[], int nr_infos)
 	return pkvm_hyp_mmu_switch_to_buddy(hyp_pgt_base, nr_pages);
 }
 
-static int finalize_global(struct pkvm_mem_info infos[], int nr_infos)
+static int finalize_global(struct pkvm_mem_info infos[], int nr_infos,
+			   struct pkvm_init_ops *init_ops)
 {
+	host_mmu_init_fn_t host_mmu_init_fn = init_ops ? init_ops->host_mmu_init : NULL;
 	phys_addr_t mem_base = INVALID_PAGE;
 	unsigned long mem_size = 0;
 	int i, ret;
@@ -153,7 +161,12 @@ static int finalize_global(struct pkvm_mem_info infos[], int nr_infos)
 	if (ret)
 		return ret;
 
-	return create_hyp_mmu(infos, nr_infos);
+	ret = create_hyp_mmu(infos, nr_infos);
+	if (ret)
+		return ret;
+
+	return pkvm_host_mmu_init(host_pgt_base, pkvm_host_pgtable_pages(),
+				  host_mmu_init_fn);
 }
 
 int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
@@ -164,7 +177,7 @@ int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,
 	static bool global_finalized;
 
 	if (!global_finalized) {
-		int ret = finalize_global(infos, nr_infos);
+		int ret = finalize_global(infos, nr_infos, init_ops);
 
 		if (ret)
 			return ret;

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
+#include <linux/kvm_host.h>
 #include <asm/kvm_pkvm.h>
 #include "init_finalize.h"
+#include "early_alloc.h"
 #include "memory.h"
+#include "mmu.h"
 
 static void *hyp_pgt_base;
 
@@ -19,20 +22,81 @@ static int divide_memory_pool(phys_addr_t phys, unsigned long size)
 	return 0;
 }
 
-static int finalize_global(phys_addr_t mem_base, unsigned long mem_size)
+static int create_hyp_mmu(const struct pkvm_mem_info infos[], int nr_infos)
 {
+	unsigned long nr_pages = pkvm_hyp_pgtable_pages();
+	struct memblock_region *reg;
+	unsigned int i;
+	int ret;
+
+	ret = pkvm_hyp_mmu_init(hyp_pgt_base, nr_pages);
+	if (ret)
+		return ret;
+
+	/*
+	 * Create mapping for the memory in memblocks, which includes all
+	 * the memory host kernel can see, as well as the reserved memory
+	 * for the pkvm hypervisor.
+	 *
+	 * The virtual address is the same with the kernel direct mapping.
+	 */
+	for (i = 0; i < pkvm_memblock_nr; i++) {
+		reg = &pkvm_memory[i];
+		ret = pkvm_hyp_mmu_map((unsigned long)__pkvm_va(reg->base), reg->base,
+				       reg->size, (u64)pgprot_val(PAGE_KERNEL));
+		if (ret)
+			return ret;
+	}
+
+	/*
+	 * Map pkvm's TEXT/DATA memory. The virtual address is the same
+	 * with the kernel symbol mapping.
+	 */
+	for (i = 0; i < nr_infos; i++) {
+		if (infos[i].type == PKVM_TEXT_DATA) {
+			ret = pkvm_hyp_mmu_map(infos[i].va, infos[i].pa,
+					       infos[i].size, infos[i].prot);
+			if (ret)
+				return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int finalize_global(struct pkvm_mem_info infos[], int nr_infos)
+{
+	phys_addr_t mem_base = INVALID_PAGE;
+	unsigned long mem_size = 0;
+	int i, ret;
+
+	if (!infos || !nr_infos)
+		return -EINVAL;
+
+	for (i = 0; i < nr_infos; i++) {
+		if (infos[i].type == PKVM_RESERVED_UNUSED_MEMORY) {
+			mem_base = infos[i].pa;
+			mem_size = infos[i].size;
+			break;
+		}
+	}
+
 	if (!PAGE_ALIGNED(mem_base) || !mem_size)
 		return -EINVAL;
 
-	return divide_memory_pool(mem_base, mem_size);
+	ret = divide_memory_pool(mem_base, mem_size);
+	if (ret)
+		return ret;
+
+	return create_hyp_mmu(infos, nr_infos);
 }
 
-int pkvm_init_finalize(phys_addr_t mem_base, unsigned long mem_size)
+int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos)
 {
 	static bool global_finalized;
 
 	if (!global_finalized) {
-		int ret = finalize_global(mem_base, mem_size);
+		int ret = finalize_global(infos, nr_infos);
 
 		if (ret)
 			return ret;

--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -135,7 +135,8 @@ static int create_hyp_mmu(const struct pkvm_mem_info infos[], int nr_infos)
 	return pkvm_hyp_mmu_switch_to_buddy(hyp_pgt_base, nr_pages);
 }
 
-static int create_host_mmu(host_mmu_init_fn_t host_mmu_init_fn)
+static int create_host_mmu(const struct pkvm_mem_info infos[], int nr_infos,
+			   host_mmu_init_fn_t host_mmu_init_fn)
 {
 	struct memblock_region *reg;
 	unsigned long phys = 0;
@@ -166,13 +167,26 @@ static int create_host_mmu(host_mmu_init_fn_t host_mmu_init_fn)
 			return ret;
 	}
 
+	/*
+	 * Unmap the memory range in the pkvm_mem_info, which includes the pkvm
+	 * TEXT/DATA and its reserved memory, to protect the pKVM hypervisor
+	 * from the host VM.
+	 */
+	for (i = 0; i < nr_infos; i++) {
+		ret = pkvm_host_mmu_unmap(infos[i].pa, infos[i].size);
+		if (ret)
+			return ret;
+	}
+
 	return 0;
 }
 
+#define TMP_NR_INFOS	16
 static int finalize_global(struct pkvm_mem_info infos[], int nr_infos,
 			   struct pkvm_init_ops *init_ops)
 {
 	host_mmu_init_fn_t host_mmu_init_fn = init_ops ? init_ops->host_mmu_init : NULL;
+	struct pkvm_mem_info tmp_infos[TMP_NR_INFOS];
 	phys_addr_t mem_base = INVALID_PAGE;
 	unsigned long mem_size = 0;
 	int i, ret;
@@ -180,12 +194,21 @@ static int finalize_global(struct pkvm_mem_info infos[], int nr_infos,
 	if (!infos || !nr_infos)
 		return -EINVAL;
 
+	if (nr_infos > TMP_NR_INFOS)
+		return -ENOMEM;
+
+	/*
+	 * The passed in parameter infos[] is in linux kernel's stack which
+	 * may use VMAP_STACK. It will not be accessible to the pkvm hypervisor
+	 * after switching to use its own mmu. Copy the infos[] to tmp_infos[]
+	 * which is in its own stack.
+	 */
 	for (i = 0; i < nr_infos; i++) {
 		if (infos[i].type == PKVM_RESERVED_UNUSED_MEMORY) {
 			mem_base = infos[i].pa;
 			mem_size = infos[i].size;
-			break;
 		}
+		tmp_infos[i] = infos[i];
 	}
 
 	if (!PAGE_ALIGNED(mem_base) || !mem_size)
@@ -199,7 +222,7 @@ static int finalize_global(struct pkvm_mem_info infos[], int nr_infos,
 	if (ret)
 		return ret;
 
-	return create_host_mmu(host_mmu_init_fn);
+	return create_host_mmu(tmp_infos, nr_infos, host_mmu_init_fn);
 }
 
 int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_infos,

--- a/arch/x86/kvm/pkvm/init_finalize.h
+++ b/arch/x86/kvm/pkvm/init_finalize.h
@@ -2,6 +2,8 @@
 #ifndef __PKVM_X86_INIT_FINALIZE_H
 #define __PKVM_X86_INIT_FINALIZE_H
 
-int pkvm_init_finalize(phys_addr_t mem_base, unsigned long mem_size);
+#include <asm/kvm_pkvm.h>
+
+int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_info);
 
 #endif /* __PKVM_X86_INIT_FINALIZE_H */

--- a/arch/x86/kvm/pkvm/init_finalize.h
+++ b/arch/x86/kvm/pkvm/init_finalize.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __PKVM_X86_INIT_FINALIZE_H
+#define __PKVM_X86_INIT_FINALIZE_H
+
+int pkvm_init_finalize(void);
+
+#endif /* __PKVM_X86_INIT_FINALIZE_H */

--- a/arch/x86/kvm/pkvm/init_finalize.h
+++ b/arch/x86/kvm/pkvm/init_finalize.h
@@ -2,6 +2,6 @@
 #ifndef __PKVM_X86_INIT_FINALIZE_H
 #define __PKVM_X86_INIT_FINALIZE_H
 
-int pkvm_init_finalize(void);
+int pkvm_init_finalize(phys_addr_t mem_base, unsigned long mem_size);
 
 #endif /* __PKVM_X86_INIT_FINALIZE_H */

--- a/arch/x86/kvm/pkvm/init_finalize.h
+++ b/arch/x86/kvm/pkvm/init_finalize.h
@@ -8,6 +8,7 @@
 typedef int (*hyp_mmu_finalize_fn_t)(struct pkvm_pgtable *pgt);
 typedef int (*host_mmu_init_fn_t)(struct pkvm_pgtable *pgt, void *pool_base,
 				  unsigned long pool_pages);
+typedef int (*host_mmu_finalize_fn_t)(struct pkvm_pgtable *pgt);
 
 /**
  * pkvm_init_ops - The platform vendor specific pkvm finalize operations used by
@@ -16,10 +17,12 @@ typedef int (*host_mmu_init_fn_t)(struct pkvm_pgtable *pgt, void *pool_base,
  *
  * @hyp_mmu_finalize:	Finalize the hypervisor mmu.
  * @host_mmu_init:	Initialize the host mmu.
+ * @host_mmu_finalize:	Finalize the host mmu.
  */
 struct pkvm_init_ops {
 	hyp_mmu_finalize_fn_t		hyp_mmu_finalize;
 	host_mmu_init_fn_t		host_mmu_init;
+	host_mmu_finalize_fn_t		host_mmu_finalize;
 };
 
 int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_info,

--- a/arch/x86/kvm/pkvm/init_finalize.h
+++ b/arch/x86/kvm/pkvm/init_finalize.h
@@ -6,6 +6,8 @@
 #include "pgtable.h"
 
 typedef int (*hyp_mmu_finalize_fn_t)(struct pkvm_pgtable *pgt);
+typedef int (*host_mmu_init_fn_t)(struct pkvm_pgtable *pgt, void *pool_base,
+				  unsigned long pool_pages);
 
 /**
  * pkvm_init_ops - The platform vendor specific pkvm finalize operations used by
@@ -13,9 +15,11 @@ typedef int (*hyp_mmu_finalize_fn_t)(struct pkvm_pgtable *pgt);
  *		   not necessary.
  *
  * @hyp_mmu_finalize:	Finalize the hypervisor mmu.
+ * @host_mmu_init:	Initialize the host mmu.
  */
 struct pkvm_init_ops {
 	hyp_mmu_finalize_fn_t		hyp_mmu_finalize;
+	host_mmu_init_fn_t		host_mmu_init;
 };
 
 int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_info,

--- a/arch/x86/kvm/pkvm/init_finalize.h
+++ b/arch/x86/kvm/pkvm/init_finalize.h
@@ -4,6 +4,13 @@
 
 #include <asm/kvm_pkvm.h>
 
-int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_info);
+/**
+ * pkvm_init_ops - The platform vendor specific pkvm finalize operations used by
+ *		   the pkvm_init_finalize.
+ */
+struct pkvm_init_ops {};
+
+int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_info,
+		       struct pkvm_init_ops *init_ops);
 
 #endif /* __PKVM_X86_INIT_FINALIZE_H */

--- a/arch/x86/kvm/pkvm/init_finalize.h
+++ b/arch/x86/kvm/pkvm/init_finalize.h
@@ -3,12 +3,20 @@
 #define __PKVM_X86_INIT_FINALIZE_H
 
 #include <asm/kvm_pkvm.h>
+#include "pgtable.h"
+
+typedef int (*hyp_mmu_finalize_fn_t)(struct pkvm_pgtable *pgt);
 
 /**
  * pkvm_init_ops - The platform vendor specific pkvm finalize operations used by
- *		   the pkvm_init_finalize.
+ *		   the pkvm_init_finalize. Some operation could be NULL if it is
+ *		   not necessary.
+ *
+ * @hyp_mmu_finalize:	Finalize the hypervisor mmu.
  */
-struct pkvm_init_ops {};
+struct pkvm_init_ops {
+	hyp_mmu_finalize_fn_t		hyp_mmu_finalize;
+};
 
 int pkvm_init_finalize(struct pkvm_mem_info infos[], int nr_info,
 		       struct pkvm_init_ops *init_ops);

--- a/arch/x86/kvm/pkvm/memory.c
+++ b/arch/x86/kvm/pkvm/memory.c
@@ -10,6 +10,10 @@ unsigned long phys_base;
 #ifdef CONFIG_DYNAMIC_PHYSICAL_MASK
 phys_addr_t physical_mask;
 #endif
+pteval_t __default_kernel_pte_mask;
+#ifdef CONFIG_AMD_MEM_ENCRYPT
+u64 sme_me_mask;
+#endif
 
 struct memblock_region pkvm_memory[PKVM_MEMBLOCK_REGIONS];
 unsigned int pkvm_memblock_nr;

--- a/arch/x86/kvm/pkvm/memory.c
+++ b/arch/x86/kvm/pkvm/memory.c
@@ -2,6 +2,7 @@
 #include <linux/types.h>
 #include <linux/cache.h>
 #include <asm/kvm_pkvm.h>
+#include "memory.h"
 
 #ifdef CONFIG_DYNAMIC_MEMORY_LAYOUT
 unsigned long page_offset_base __ro_after_init;
@@ -17,6 +18,50 @@ u64 sme_me_mask;
 
 struct memblock_region pkvm_memory[PKVM_MEMBLOCK_REGIONS];
 unsigned int pkvm_memblock_nr;
+
+/**
+ * pkvm_find_addr_range - Find out the addr range for the given physical addr.
+ * @phys:	The physical address to check.
+ * @range:	The structure to return the address range which contains the
+ *		@phys.
+ *
+ * A binary search is performed to find out the address range which contains
+ * @phys and this address range is returned via @range. The returned address
+ * range would be either a memory range if @phys is memory, or a hole (which is
+ * between memory ranges and usually can be used as the MMIO) range if @phys is
+ * not memory, which is indicated by the return value.
+ *
+ * Return true if @phys is memory. Otherwise, return false.
+ */
+bool pkvm_find_addr_range(unsigned long phys, struct range *range)
+{
+	int cur, left = 0, right = pkvm_memblock_nr;
+	struct memblock_region *reg;
+	unsigned long end;
+
+	range->start = 0;
+	range->end = ULONG_MAX;
+
+	/* The list of memblock regions is sorted, binary search it */
+	while (left < right) {
+		cur = (left + right) >> 1;
+		reg = &pkvm_memory[cur];
+		end = reg->base + reg->size;
+		if (phys < reg->base) {
+			right = cur;
+			range->end = reg->base;
+		} else if (phys >= end) {
+			left = cur + 1;
+			range->start = end;
+		} else {
+			range->start = reg->base;
+			range->end = end;
+			return true;
+		}
+	}
+
+	return false;
+}
 
 /*
  * Ensure that __kcfi_typeid_ symbols are emitted for functions that may

--- a/arch/x86/kvm/pkvm/memory.c
+++ b/arch/x86/kvm/pkvm/memory.c
@@ -17,3 +17,9 @@ u64 sme_me_mask;
 
 struct memblock_region pkvm_memory[PKVM_MEMBLOCK_REGIONS];
 unsigned int pkvm_memblock_nr;
+
+/*
+ * Ensure that __kcfi_typeid_ symbols are emitted for functions that may
+ * not be indirectly called with all configurations.
+ */
+__ADDRESSABLE(__memcpy)

--- a/arch/x86/kvm/pkvm/memory.c
+++ b/arch/x86/kvm/pkvm/memory.c
@@ -7,6 +7,9 @@
 unsigned long page_offset_base __ro_after_init;
 #endif
 unsigned long phys_base;
+#ifdef CONFIG_DYNAMIC_PHYSICAL_MASK
+phys_addr_t physical_mask;
+#endif
 
 struct memblock_region pkvm_memory[PKVM_MEMBLOCK_REGIONS];
 unsigned int pkvm_memblock_nr;

--- a/arch/x86/kvm/pkvm/memory.c
+++ b/arch/x86/kvm/pkvm/memory.c
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <linux/types.h>
 #include <linux/cache.h>
+#include <asm/kvm_pkvm.h>
 
 #ifdef CONFIG_DYNAMIC_MEMORY_LAYOUT
 unsigned long page_offset_base __ro_after_init;
 #endif
 unsigned long phys_base;
+
+struct memblock_region pkvm_memory[PKVM_MEMBLOCK_REGIONS];
+unsigned int pkvm_memblock_nr;

--- a/arch/x86/kvm/pkvm/memory.h
+++ b/arch/x86/kvm/pkvm/memory.h
@@ -3,6 +3,7 @@
 #define __PKVM_X86_MEMORY_H
 
 #include <linux/types.h>
+#include <linux/range.h>
 #include <vdso/limits.h>
 #include <asm/page.h>
 
@@ -62,5 +63,7 @@ static inline void pkvm_set_page_refcounted(struct pkvm_page *p)
 	BUG_ON(p->refcount);
 	p->refcount = 1;
 }
+
+bool pkvm_find_addr_range(unsigned long phys, struct range *range);
 
 #endif /* __PKVM_X86_MEMORY_H */

--- a/arch/x86/kvm/pkvm/memory.h
+++ b/arch/x86/kvm/pkvm/memory.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __PKVM_X86_MEMORY_H
+#define __PKVM_X86_MEMORY_H
+
+#include <asm/page.h>
+
+#define __pkvm_pa		__pa
+#define __pkvm_va		__va
+
+#endif /* __PKVM_X86_MEMORY_H */

--- a/arch/x86/kvm/pkvm/memory.h
+++ b/arch/x86/kvm/pkvm/memory.h
@@ -2,9 +2,65 @@
 #ifndef __PKVM_X86_MEMORY_H
 #define __PKVM_X86_MEMORY_H
 
+#include <linux/types.h>
+#include <vdso/limits.h>
 #include <asm/page.h>
 
 #define __pkvm_pa		__pa
 #define __pkvm_va		__va
+
+struct pkvm_page {
+	unsigned short refcount;
+	unsigned short order;
+};
+
+extern u64 __pkvm_vmemmap;
+#define pkvm_vmemmap ((struct pkvm_page *)__pkvm_vmemmap)
+
+#define pkvm_phys_to_pfn(phys)	((phys) >> PAGE_SHIFT)
+#define pkvm_pfn_to_phys(pfn)	((phys_addr_t)((pfn) << PAGE_SHIFT))
+#define pkvm_phys_to_page(phys)	(&pkvm_vmemmap[pkvm_phys_to_pfn(phys)])
+#define pkvm_virt_to_page(virt)	pkvm_phys_to_page(__pkvm_pa(virt))
+#define pkvm_virt_to_pfn(virt)	pkvm_phys_to_pfn(__pkvm_pa(virt))
+
+#define pkvm_page_to_pfn(page)	((struct pkvm_page *)(page) - pkvm_vmemmap)
+#define pkvm_page_to_phys(page)  pkvm_pfn_to_phys((pkvm_page_to_pfn(page)))
+#define pkvm_page_to_virt(page)	__pkvm_va(pkvm_page_to_phys(page))
+#define pkvm_page_to_pool(page)	(((struct pkvm_page *)page)->pool)
+
+/*
+ * Refcounting for 'struct pkvm_page'.
+ * pkvm_pool::lock must be held if atomic access to the refcount is required.
+ */
+static inline int pkvm_page_count(void *addr)
+{
+	struct pkvm_page *p = pkvm_virt_to_page(addr);
+
+	return p->refcount;
+}
+
+static inline void pkvm_page_ref_inc(struct pkvm_page *p)
+{
+	BUG_ON(p->refcount == USHRT_MAX);
+	p->refcount++;
+}
+
+static inline void pkvm_page_ref_dec(struct pkvm_page *p)
+{
+	BUG_ON(!p->refcount);
+	p->refcount--;
+}
+
+static inline int pkvm_page_ref_dec_and_test(struct pkvm_page *p)
+{
+	pkvm_page_ref_dec(p);
+	return (p->refcount == 0);
+}
+
+static inline void pkvm_set_page_refcounted(struct pkvm_page *p)
+{
+	BUG_ON(p->refcount);
+	p->refcount = 1;
+}
 
 #endif /* __PKVM_X86_MEMORY_H */

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -247,3 +247,9 @@ int pkvm_host_mmu_map(unsigned long phys, unsigned long size,
 	/* The vaddr == phys for the host MMU */
 	return pkvm_pgtable_map(&host_mmu, phys, phys, size, prot);
 }
+
+int pkvm_host_mmu_unmap(unsigned long vaddr, unsigned long size)
+{
+	/* The vaddr == phys for the host MMU */
+	return pkvm_pgtable_unmap(&host_mmu, vaddr, vaddr, size);
+}

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -120,6 +120,11 @@ int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages)
 	return pkvm_pgtable_init(&hyp_mmu, cap, &pkvm_early_alloc_mm_ops, &hyp_mmu_pgt_ops);
 }
 
+int pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn_t fn)
+{
+	return fn ? fn(&hyp_mmu) : 0;
+}
+
 int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 		     unsigned long size, u64 prot)
 {

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -119,3 +119,9 @@ int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages)
 
 	return pkvm_pgtable_init(&hyp_mmu, cap, &pkvm_early_alloc_mm_ops, &hyp_mmu_pgt_ops);
 }
+
+int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
+		     unsigned long size, u64 prot)
+{
+	return pkvm_pgtable_map(&hyp_mmu, vaddr, phys, size, prot);
+}

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/pgtable.h>
+#include <linux/kvm_host.h>
+#include <asm/kvm_pkvm.h>
+#include "early_alloc.h"
+#include "pgtable.h"
+#include "mmu.h"
+
+static struct pkvm_pgtable hyp_mmu;
+
+static bool hyp_mmu_pte_present(void *ptep)
+{
+	return pte_present(*(pte_t *)ptep);
+}
+
+static bool hyp_mmu_pte_huge(void *ptep)
+{
+	return pte_huge(*(pte_t *)ptep);
+}
+
+static void hyp_mmu_pte_mkhuge(void *ptep)
+{
+	pte_t *ptep_ptr = (pte_t *)ptep;
+
+	*ptep_ptr = pte_mkhuge(*ptep_ptr);
+}
+
+static unsigned long hyp_mmu_pte_to_phys(void *ptep)
+{
+	return native_pte_val(*(pte_t *)ptep) & PTE_PFN_MASK;
+}
+
+static u64 hyp_mmu_pte_to_prot(void *ptep)
+{
+	return (u64)pte_flags(pte_clear_flags(*(pte_t *)ptep, _PAGE_PSE));
+}
+
+static int hyp_mmu_vaddr_to_index(unsigned long vaddr, int level)
+{
+	return (vaddr >> page_level_shift(level)) & ((1UL << PTE_SHIFT) - 1);
+}
+
+static unsigned long hyp_mmu_level_to_size(int level)
+{
+	return page_level_size(level);
+}
+
+static u64 hyp_mmu_level_to_mask(int level)
+{
+	return page_level_mask(level);
+}
+
+static bool hyp_mmu_pte_is_leaf(void *ptep, int level)
+{
+	return level == PG_LEVEL_4K || !hyp_mmu_pte_present(ptep) || hyp_mmu_pte_huge(ptep);
+}
+
+static int hyp_mmu_pte_size(int level)
+{
+	return PAGE_SIZE / PTRS_PER_PTE;
+}
+
+static int hyp_mmu_pte_count(int level)
+{
+	return PTRS_PER_PTE;
+}
+
+static void hyp_mmu_pte_set(void *ptep, u64 pte)
+{
+	native_set_pte((pte_t *)ptep, native_make_pte(pte));
+}
+
+static u64 hyp_mmu_pte_get(void *ptep)
+{
+	return READ_ONCE(*(pte_t *)ptep).pte;
+}
+
+static void hyp_mmu_flush_tlb(struct pkvm_pgtable *pgt,
+			      unsigned long vaddr, unsigned long size)
+{
+	/*
+	 * The pkvm hypervisor will map all valid memory in its MMU during the
+	 * finalize phase and won't change or unmap at the running time. So
+	 * there is no usages to change a present leaf in the hyp_mmu. Put a
+	 * BUG here in case anything is missed.
+	 */
+	BUG();
+}
+
+static const struct pkvm_pgtable_ops hyp_mmu_pgt_ops = {
+	.pte_present = hyp_mmu_pte_present,
+	.pte_huge = hyp_mmu_pte_huge,
+	.pte_mkhuge = hyp_mmu_pte_mkhuge,
+	.pte_to_phys = hyp_mmu_pte_to_phys,
+	.pte_to_prot = hyp_mmu_pte_to_prot,
+	.vaddr_to_index = hyp_mmu_vaddr_to_index,
+	.level_to_size = hyp_mmu_level_to_size,
+	.level_to_mask = hyp_mmu_level_to_mask,
+	.pte_is_leaf = hyp_mmu_pte_is_leaf,
+	.pte_size = hyp_mmu_pte_size,
+	.pte_count = hyp_mmu_pte_count,
+	.pte_set = hyp_mmu_pte_set,
+	.pte_get = hyp_mmu_pte_get,
+	.flush_tlb = hyp_mmu_flush_tlb,
+};
+
+int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages)
+{
+	struct pkvm_pgtable_cap cap = {
+		.level = pgtable_l5_enabled() ? 5 : 4,
+		.allowed_pgsz = (1 << PG_LEVEL_2M) | (1 << PG_LEVEL_4K),
+		.table_prot = (u64)_KERNPG_TABLE_NOENC,
+	};
+
+	if (boot_cpu_has(X86_FEATURE_GBPAGES))
+		cap.allowed_pgsz |= 1 << PG_LEVEL_1G;
+
+	pkvm_early_alloc_init(pool_base, pool_pages << PAGE_SHIFT);
+
+	return pkvm_pgtable_init(&hyp_mmu, cap, &pkvm_early_alloc_mm_ops, &hyp_mmu_pgt_ops);
+}

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -11,6 +11,7 @@ static struct pkvm_pgtable hyp_mmu;
 static struct pkvm_pool hyp_mmu_pool;
 
 static struct pkvm_pgtable host_mmu;
+pkvm_spinlock_t host_mmu_lock;
 
 static void *hyp_mmu_zalloc_page(void)
 {
@@ -235,6 +236,8 @@ int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 
 int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages, host_mmu_init_fn_t fn)
 {
+	pkvm_spin_lock_init(&host_mmu_lock);
+
 	return fn ? fn(&host_mmu, pool_base, pool_pages) : 0;
 }
 

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -10,6 +10,8 @@
 static struct pkvm_pgtable hyp_mmu;
 static struct pkvm_pool hyp_mmu_pool;
 
+static struct pkvm_pgtable host_mmu;
+
 static void *hyp_mmu_zalloc_page(void)
 {
 	return pkvm_alloc_pages(&hyp_mmu_pool, 0);
@@ -229,4 +231,9 @@ int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 		     unsigned long size, u64 prot)
 {
 	return pkvm_pgtable_map(&hyp_mmu, vaddr, phys, size, prot);
+}
+
+int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages, host_mmu_init_fn_t fn)
+{
+	return fn ? fn(&host_mmu, pool_base, pool_pages) : 0;
 }

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -5,8 +5,37 @@
 #include "early_alloc.h"
 #include "pgtable.h"
 #include "mmu.h"
+#include "gfp.h"
 
 static struct pkvm_pgtable hyp_mmu;
+static struct pkvm_pool hyp_mmu_pool;
+
+static void *hyp_mmu_zalloc_page(void)
+{
+	return pkvm_alloc_pages(&hyp_mmu_pool, 0);
+}
+
+static void hyp_mmu_get_page(void *vaddr)
+{
+	pkvm_get_page(&hyp_mmu_pool, vaddr);
+}
+
+static void hyp_mmu_put_page(void *vaddr)
+{
+	pkvm_put_page(&hyp_mmu_pool, vaddr);
+}
+
+static int hyp_mmu_page_count(void *vaddr)
+{
+	return pkvm_page_count(vaddr);
+}
+
+static const struct pkvm_pgtable_mm_ops hyp_mmu_mm_ops = {
+	.zalloc_page = hyp_mmu_zalloc_page,
+	.get_page = hyp_mmu_get_page,
+	.put_page = hyp_mmu_put_page,
+	.page_count = hyp_mmu_page_count,
+};
 
 static bool hyp_mmu_pte_present(void *ptep)
 {
@@ -104,6 +133,41 @@ static const struct pkvm_pgtable_ops hyp_mmu_pgt_ops = {
 	.flush_tlb = hyp_mmu_flush_tlb,
 };
 
+static int fix_hyp_mmu_refcnt_walker(struct pkvm_pgtable_visit_ctx *ctx,
+				     unsigned long walk_flags,
+				     void *const arg)
+{
+	if (!ctx->pgt->pgt_ops->pte_present(ctx->ptep))
+		return 0;
+
+	/*
+	 * Fix-up the refcount for the page-table pages as the early allocator
+	 * was unable to access the pkvm_vmemmap and so the buddy allocator has
+	 * initialized the refcount to '1'.
+	 */
+	hyp_mmu_get_page(ctx->ptep);
+
+	return 0;
+}
+
+static int fix_hyp_mmu_page_refcnt(void)
+{
+	struct pkvm_pgtable_walker walker = {
+		.cb = fix_hyp_mmu_refcnt_walker,
+		.arg = NULL,
+		.walk_flags = PKVM_PGTABLE_WALK_LEAF | PKVM_PGTABLE_WALK_TABLE_POST,
+	};
+	unsigned long size;
+
+	/*
+	 * Calculate the max address space, then walk the [0, size) address
+	 * range to fixup refcount of every page-table page.
+	 */
+	size = hyp_mmu.pgt_ops->level_to_size(hyp_mmu.cap.level + 1);
+
+	return pkvm_pgtable_walk(&hyp_mmu, 0, size, &walker);
+}
+
 int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages)
 {
 	struct pkvm_pgtable_cap cap = {
@@ -118,6 +182,42 @@ int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages)
 	pkvm_early_alloc_init(pool_base, pool_pages << PAGE_SHIFT);
 
 	return pkvm_pgtable_init(&hyp_mmu, cap, &pkvm_early_alloc_mm_ops, &hyp_mmu_pgt_ops);
+}
+
+int pkvm_hyp_mmu_switch_to_buddy(void *pool_base, unsigned long pool_pages)
+{
+	unsigned long reserved_pages;
+	int ret;
+
+	/* Get the early alloc used pages and reserve them in hyp_mmu_pool */
+	if (hyp_mmu.mm_ops != &pkvm_early_alloc_mm_ops)
+		return -EINVAL;
+
+	reserved_pages = pkvm_early_alloc_nr_used_pages();
+	/* Enable buddy allocator */
+	ret = pkvm_pool_init(&hyp_mmu_pool, __pkvm_pa(pool_base) >> PAGE_SHIFT,
+			     pool_pages, reserved_pages);
+	if (ret)
+		return ret;
+
+	if (reserved_pages) {
+		/*
+		 * As the early alloc mm_ops was used to allocate mmu
+		 * page-table pages, the refcount of each page-table pages
+		 * was not maintained at that time. This should be fixed.
+		 */
+		ret = fix_hyp_mmu_page_refcnt();
+		if (ret)
+			return ret;
+	}
+
+	hyp_mmu.mm_ops = &hyp_mmu_mm_ops;
+	return 0;
+}
+
+void pkvm_hyp_mmu_load(void)
+{
+	native_write_cr3(hyp_mmu.root_pa);
 }
 
 int pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn_t fn)

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -241,6 +241,11 @@ int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages, host_mmu_init_
 	return fn ? fn(&host_mmu, pool_base, pool_pages) : 0;
 }
 
+int pkvm_host_mmu_finalize(host_mmu_finalize_fn_t fn)
+{
+	return fn ? fn(&host_mmu) : 0;
+}
+
 int pkvm_host_mmu_map(unsigned long phys, unsigned long size,
 		      bool read, bool write, bool exec, bool mmio)
 {

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -237,3 +237,13 @@ int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages, host_mmu_init_
 {
 	return fn ? fn(&host_mmu, pool_base, pool_pages) : 0;
 }
+
+int pkvm_host_mmu_map(unsigned long phys, unsigned long size,
+		      bool read, bool write, bool exec, bool mmio)
+{
+	u64 prot = host_mmu.pgt_ops->calc_pte_perm(read, write, exec) |
+		   host_mmu.pgt_ops->calc_pte_memtype(mmio);
+
+	/* The vaddr == phys for the host MMU */
+	return pkvm_pgtable_map(&host_mmu, phys, phys, size, prot);
+}

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -2,7 +2,10 @@
 #ifndef __PKVM_X86_MMU_H
 #define __PKVM_X86_MMU_H
 
+#include <asm/pkvm_spinlock.h>
 #include "init_finalize.h"
+
+extern pkvm_spinlock_t host_mmu_lock;
 
 int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages);
 int pkvm_hyp_mmu_switch_to_buddy(void *pool_base, unsigned long pool_pages);
@@ -16,5 +19,15 @@ int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages,
 int pkvm_host_mmu_map(unsigned long phys, unsigned long size, bool read,
 		      bool write, bool exec, bool mmio);
 int pkvm_host_mmu_unmap(unsigned long vaddr, unsigned long size);
+
+static inline void pkvm_host_mmu_lock(void)
+{
+	pkvm_spin_lock(&host_mmu_lock);
+}
+
+static inline void pkvm_host_mmu_unlock(void)
+{
+	pkvm_spin_unlock(&host_mmu_lock);
+}
 
 #endif /* __PKVM_X86_MMU_H */

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -16,6 +16,7 @@ int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 
 int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages,
 		       host_mmu_init_fn_t fn);
+int pkvm_host_mmu_finalize(host_mmu_finalize_fn_t fn);
 int pkvm_host_mmu_map(unsigned long phys, unsigned long size, bool read,
 		      bool write, bool exec, bool mmio);
 int pkvm_host_mmu_unmap(unsigned long vaddr, unsigned long size);

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -15,5 +15,6 @@ int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages,
 		       host_mmu_init_fn_t fn);
 int pkvm_host_mmu_map(unsigned long phys, unsigned long size, bool read,
 		      bool write, bool exec, bool mmio);
+int pkvm_host_mmu_unmap(unsigned long vaddr, unsigned long size);
 
 #endif /* __PKVM_X86_MMU_H */

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -3,5 +3,7 @@
 #define __PKVM_X86_MMU_H
 
 int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages);
+int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
+		     unsigned long size, u64 prot);
 
 #endif /* __PKVM_X86_MMU_H */

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -2,7 +2,10 @@
 #ifndef __PKVM_X86_MMU_H
 #define __PKVM_X86_MMU_H
 
+#include "init_finalize.h"
+
 int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages);
+int pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn_t fn);
 int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 		     unsigned long size, u64 prot);
 

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -11,4 +11,7 @@ int pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn_t fn);
 int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 		     unsigned long size, u64 prot);
 
+int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages,
+		       host_mmu_init_fn_t fn);
+
 #endif /* __PKVM_X86_MMU_H */

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __PKVM_X86_MMU_H
+#define __PKVM_X86_MMU_H
+
+int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages);
+
+#endif /* __PKVM_X86_MMU_H */

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -5,6 +5,8 @@
 #include "init_finalize.h"
 
 int pkvm_hyp_mmu_init(void *pool_base, unsigned long pool_pages);
+int pkvm_hyp_mmu_switch_to_buddy(void *pool_base, unsigned long pool_pages);
+void pkvm_hyp_mmu_load(void);
 int pkvm_hyp_mmu_finalize(hyp_mmu_finalize_fn_t fn);
 int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 		     unsigned long size, u64 prot);

--- a/arch/x86/kvm/pkvm/mmu.h
+++ b/arch/x86/kvm/pkvm/mmu.h
@@ -13,5 +13,7 @@ int pkvm_hyp_mmu_map(unsigned long vaddr, unsigned long phys,
 
 int pkvm_host_mmu_init(void *pool_base, unsigned long pool_pages,
 		       host_mmu_init_fn_t fn);
+int pkvm_host_mmu_map(unsigned long phys, unsigned long size, bool read,
+		      bool write, bool exec, bool mmio);
 
 #endif /* __PKVM_X86_MMU_H */

--- a/arch/x86/kvm/pkvm/page_alloc.c
+++ b/arch/x86/kvm/pkvm/page_alloc.c
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * This file is copied from arch/arm64/kvm/hyp/nvhe/page_alloc.c with
+ * renaming some code to keep consistent with the naming usage in the
+ * pkvm.
+ *
+ * Copyright (C) 2020 Google LLC
+ * Author: Quentin Perret <qperret@google.com>
+ */
+
+#include "gfp.h"
+
+u64 __pkvm_vmemmap;
+
+/*
+ * Index the pkvm_vmemmap to find a potential buddy page, but make no assumption
+ * about its current state.
+ *
+ * Example buddy-tree for a 4-pages physically contiguous pool:
+ *
+ *                 o : Page 3
+ *                /
+ *               o-o : Page 2
+ *              /
+ *             /   o : Page 1
+ *            /   /
+ *           o---o-o : Page 0
+ *    Order  2   1 0
+ *
+ * Example of requests on this pool:
+ *   __find_buddy_nocheck(pool, page 0, order 0) => page 1
+ *   __find_buddy_nocheck(pool, page 0, order 1) => page 2
+ *   __find_buddy_nocheck(pool, page 1, order 0) => page 0
+ *   __find_buddy_nocheck(pool, page 2, order 0) => page 3
+ */
+static struct pkvm_page *__find_buddy_nocheck(struct pkvm_pool *pool,
+					      struct pkvm_page *p,
+					      u8 order)
+{
+	phys_addr_t addr = pkvm_page_to_phys(p);
+
+	addr ^= (PAGE_SIZE << order);
+
+	/*
+	 * Don't return a page outside the pool range -- it belongs to
+	 * something else and may not be mapped in pkvm_vmemmap.
+	 */
+	if (addr < pool->range_start || addr >= pool->range_end)
+		return NULL;
+
+	return pkvm_phys_to_page(addr);
+}
+
+/* Find a buddy page currently available for allocation */
+static struct pkvm_page *__find_buddy_avail(struct pkvm_pool *pool,
+					    struct pkvm_page *p,
+					    u8 order)
+{
+	struct pkvm_page *buddy = __find_buddy_nocheck(pool, p, order);
+
+	if (!buddy || buddy->order != order || buddy->refcount)
+		return NULL;
+
+	return buddy;
+
+}
+
+/*
+ * Pages that are available for allocation are tracked in free-lists, so we use
+ * the pages themselves to store the list nodes to avoid wasting space. As the
+ * allocator always returns zeroed pages (which are zeroed on the pkvm_put_page()
+ * path to optimize allocation speed), we also need to clean-up the list node in
+ * each page when we take it out of the list.
+ */
+static inline void page_remove_from_list(struct pkvm_page *p)
+{
+	struct list_head *node = pkvm_page_to_virt(p);
+
+	__list_del_entry(node);
+	memset(node, 0, sizeof(*node));
+}
+
+static inline void page_add_to_list(struct pkvm_page *p, struct list_head *head)
+{
+	struct list_head *node = pkvm_page_to_virt(p);
+
+	INIT_LIST_HEAD(node);
+	list_add_tail(node, head);
+}
+
+static inline struct pkvm_page *node_to_page(struct list_head *node)
+{
+	return pkvm_virt_to_page(node);
+}
+
+static void __pkvm_attach_page(struct pkvm_pool *pool,
+			       struct pkvm_page *p)
+{
+	phys_addr_t phys = pkvm_page_to_phys(p);
+	u8 order = p->order;
+	struct pkvm_page *buddy;
+
+	memset(pkvm_page_to_virt(p), 0, PAGE_SIZE << p->order);
+
+	/* Skip coalescing for 'external' pages being freed into the pool. */
+	if (phys < pool->range_start || phys >= pool->range_end)
+		goto insert;
+
+	/*
+	 * Only the first struct pkvm_page of a high-order page (otherwise known
+	 * as the 'head') should have p->order set. The non-head pages should
+	 * have p->order = PKVM_NO_ORDER. Here @p may no longer be the head
+	 * after coalescing, so make sure to mark it PKVM_NO_ORDER proactively.
+	 */
+	p->order = PKVM_NO_ORDER;
+	for (; (order + 1) <= pool->max_order; order++) {
+		buddy = __find_buddy_avail(pool, p, order);
+		if (!buddy)
+			break;
+
+		/* Take the buddy out of its list, and coalesce with @p */
+		page_remove_from_list(buddy);
+		buddy->order = PKVM_NO_ORDER;
+		p = min(p, buddy);
+	}
+
+insert:
+	/* Mark the new head, and insert it */
+	p->order = order;
+	page_add_to_list(p, &pool->free_area[order]);
+}
+
+static struct pkvm_page *__pkvm_extract_page(struct pkvm_pool *pool,
+					     struct pkvm_page *p,
+					     u8 order)
+{
+	struct pkvm_page *buddy;
+
+	page_remove_from_list(p);
+	while (p->order > order) {
+		/*
+		 * The buddy of order n - 1 currently has PKVM_NO_ORDER as it
+		 * is covered by a higher-level page (whose head is @p). Use
+		 * __find_buddy_nocheck() to find it and inject it in the
+		 * free_list[n - 1], effectively splitting @p in half.
+		 */
+		p->order--;
+		buddy = __find_buddy_nocheck(pool, p, p->order);
+		buddy->order = p->order;
+		page_add_to_list(buddy, &pool->free_area[buddy->order]);
+	}
+
+	return p;
+}
+
+static void __pkvm_put_page(struct pkvm_pool *pool, struct pkvm_page *p)
+{
+	if (pkvm_page_ref_dec_and_test(p))
+		__pkvm_attach_page(pool, p);
+}
+
+/*
+ * Changes to the buddy tree and page refcounts must be done with the pkvm_pool
+ * lock held. If a refcount change requires an update to the buddy tree (e.g.
+ * pkvm_put_page()), both operations must be done within the same critical
+ * section to guarantee transient states (e.g. a page with null refcount but
+ * not yet attached to a free list) can't be observed by well-behaved readers.
+ */
+void pkvm_put_page(struct pkvm_pool *pool, void *addr)
+{
+	struct pkvm_page *p = pkvm_virt_to_page(addr);
+
+	pkvm_spin_lock(&pool->lock);
+	__pkvm_put_page(pool, p);
+	pkvm_spin_unlock(&pool->lock);
+}
+
+void pkvm_get_page(struct pkvm_pool *pool, void *addr)
+{
+	struct pkvm_page *p = pkvm_virt_to_page(addr);
+
+	pkvm_spin_lock(&pool->lock);
+	pkvm_page_ref_inc(p);
+	pkvm_spin_unlock(&pool->lock);
+}
+
+void pkvm_split_page(struct pkvm_page *p)
+{
+	u8 order = p->order;
+	unsigned int i;
+
+	p->order = 0;
+	for (i = 1; i < (1 << order); i++) {
+		struct pkvm_page *tail = p + i;
+
+		tail->order = 0;
+		pkvm_set_page_refcounted(tail);
+	}
+}
+
+void *pkvm_alloc_pages(struct pkvm_pool *pool, u8 order)
+{
+	struct pkvm_page *p;
+	u8 i = order;
+
+	pkvm_spin_lock(&pool->lock);
+
+	/* Look for a high-enough-order page */
+	while (i <= pool->max_order && list_empty(&pool->free_area[i]))
+		i++;
+	if (i > pool->max_order) {
+		pkvm_spin_unlock(&pool->lock);
+		return NULL;
+	}
+
+	/* Extract it from the tree at the right order */
+	p = node_to_page(pool->free_area[i].next);
+	p = __pkvm_extract_page(pool, p, order);
+
+	pkvm_set_page_refcounted(p);
+	pkvm_spin_unlock(&pool->lock);
+
+	return pkvm_page_to_virt(p);
+}
+
+int pkvm_pool_init(struct pkvm_pool *pool, u64 pfn, unsigned int nr_pages,
+		   unsigned int reserved_pages)
+{
+	phys_addr_t phys = pkvm_pfn_to_phys(pfn);
+	struct pkvm_page *p;
+	int i;
+
+	pkvm_spin_lock_init(&pool->lock);
+	pool->max_order = min(MAX_PAGE_ORDER,
+			      get_order(nr_pages << PAGE_SHIFT));
+	for (i = 0; i <= pool->max_order; i++)
+		INIT_LIST_HEAD(&pool->free_area[i]);
+	pool->range_start = phys;
+	pool->range_end = phys + (nr_pages << PAGE_SHIFT);
+
+	/* Init the vmemmap portion */
+	p = pkvm_phys_to_page(phys);
+	for (i = 0; i < nr_pages; i++)
+		pkvm_set_page_refcounted(&p[i]);
+
+	/* Attach the unused pages to the buddy tree */
+	for (i = reserved_pages; i < nr_pages; i++)
+		__pkvm_put_page(pool, &p[i]);
+
+	return 0;
+}

--- a/arch/x86/kvm/pkvm/pgtable.c
+++ b/arch/x86/kvm/pkvm/pgtable.c
@@ -5,6 +5,8 @@
 #include "memory.h"
 #include "pgtable.h"
 
+#define PGTABLE_WALK_DONE      1
+
 static void *pgtable_alloc_page(const struct pkvm_pgtable_mm_ops *mm_ops)
 {
 	return mm_ops->zalloc_page();
@@ -312,6 +314,33 @@ static int unmap_walker(struct pkvm_pgtable_visit_ctx *ctx, unsigned long walk_f
 	return 0;
 }
 
+struct pgt_lookup_data {
+	unsigned long vaddr;
+	unsigned long phys;
+	u64 prot;
+	int level;
+};
+
+static int lookup_walker(struct pkvm_pgtable_visit_ctx *ctx, unsigned long walk_flags,
+			 void *const arg)
+{
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	u64 pte = pgt_ops->pte_get(ctx->ptep);
+	struct pgt_lookup_data *data = arg;
+	int level = ctx->level;
+
+	data->level = level;
+
+	if (pgt_ops->pte_present(&pte)) {
+		unsigned long offset = data->vaddr & ~pgt_ops->level_to_mask(level);
+
+		data->phys = pgt_ops->pte_to_phys(&pte) + offset;
+		data->prot = pgt_ops->pte_to_prot(&pte);
+	}
+
+	return PGTABLE_WALK_DONE;
+}
+
 struct pgt_walk_data {
 	struct pkvm_pgtable *pgt;
 	unsigned long addr;
@@ -545,4 +574,47 @@ int pkvm_pgtable_unmap(struct pkvm_pgtable *pgt, unsigned long vaddr,
 	};
 
 	return pkvm_pgtable_walk(pgt, vaddr, size, &walker);
+}
+
+/*
+ * pkvm_pgtable_lookup() - Lookup the mapping information of a virtual address
+ *			   in a page table.
+ * @pgt:	The page table to lookup.
+ * @vaddr:	The virtual address of the lookup mapping.
+ * @phys:	To return the physical address bits in the present leaf entry.
+ * @prot:	To return the property bits in the present leaf entry.
+ * @level:	To return page table level of the leaf entry.
+ *
+ * @vaddr is aligned down to the PAGE_SIZE, and the lookup size is PAGE_SIZE.
+ *
+ * The page table is walked based on @vaddr to look up for the leaf entry. If
+ * the leaf entry is present, will return physical address + the offset within
+ * a page via @phys, property bits via @prot and the present leaf entry level
+ * via @level. If the leaf entry is non-present, will return INVALID_PAGE via
+ * @phys, 0 via @prot and the non-present leaf entry level via @level. So @level
+ * always contains a valid number, regardless the leaf entry is present or not.
+ */
+void pkvm_pgtable_lookup(struct pkvm_pgtable *pgt, unsigned long vaddr,
+			 unsigned long *phys, u64 *prot, int *level)
+{
+	struct pgt_lookup_data data = {
+		.vaddr = vaddr,
+		.phys = INVALID_PAGE,
+		.prot = 0,
+		.level = pgt->cap.level,
+	};
+	struct pkvm_pgtable_walker walker = {
+		.cb = lookup_walker,
+		.arg = &data,
+		.walk_flags = PKVM_PGTABLE_WALK_LEAF,
+	};
+
+	pkvm_pgtable_walk(pgt, vaddr, PAGE_SIZE, &walker);
+
+	if (phys)
+		*phys = data.phys;
+	if (prot)
+		*prot = data.prot;
+	if (level)
+		*level = data.level;
 }

--- a/arch/x86/kvm/pkvm/pgtable.c
+++ b/arch/x86/kvm/pkvm/pgtable.c
@@ -10,6 +10,203 @@ static void *pgtable_alloc_page(const struct pkvm_pgtable_mm_ops *mm_ops)
 	return mm_ops->zalloc_page();
 }
 
+static bool leaf_in_addr_range(unsigned long leaf_size,
+			       unsigned long addr,
+			       unsigned long end)
+{
+	if (!IS_ALIGNED(addr, leaf_size))
+		return false;
+
+	if (leaf_size > (end - addr))
+		return false;
+
+	return true;
+}
+
+struct pgt_map_data {
+	unsigned long phys;
+	u64 prot;
+};
+
+static bool leaf_mapping_changed(struct pkvm_pgtable_visit_ctx *ctx,
+				 struct pgt_map_data *data)
+{
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	unsigned long leaf_size, mapped_phys, new_phys;
+
+	/* Property bits are changed */
+	if (data->prot != pgt_ops->pte_to_prot(ctx->ptep))
+		return true;
+
+	leaf_size = pgt_ops->level_to_size(ctx->level);
+	mapped_phys = pgt_ops->pte_to_phys(ctx->ptep);
+	new_phys = data->phys + (ctx->addr - ctx->start);
+	/*
+	 * The new physical address is not covered by the old mapped range
+	 * [mapped_phys, mapped_phys + leaf_size).
+	 */
+	if (!((new_phys >= mapped_phys) && new_phys < (mapped_phys + leaf_size)))
+		return true;
+
+	return false;
+}
+
+static bool leaf_mapping_allowed(struct pkvm_pgtable_visit_ctx *ctx,
+				 struct pgt_map_data *data)
+{
+	unsigned long leaf_size = ctx->pgt->pgt_ops->level_to_size(ctx->level);
+
+	if (!leaf_in_addr_range(leaf_size, ctx->addr, ctx->end))
+		return false;
+
+	if (!((1 << ctx->level) & ctx->pgt->cap.allowed_pgsz))
+		return false;
+
+	return IS_ALIGNED(data->phys + (ctx->addr - ctx->start), leaf_size);
+}
+
+static void pgtable_split(struct pkvm_pgtable_visit_ctx *ctx, void *child_ptep)
+{
+	const struct pkvm_pgtable_mm_ops *mm_ops = ctx->pgt->mm_ops;
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	unsigned long phys, phys_end, step_size;
+	int i = 0, entry_size, child_level;
+	u64 prot;
+
+	BUG_ON(ctx->level <= PG_LEVEL_4K);
+
+	/* Reuse the large mapping's prot. */
+	prot = pgt_ops->pte_to_prot(ctx->ptep);
+	child_level = ctx->level - 1;
+	if (child_level > PG_LEVEL_4K)
+		pgt_ops->pte_mkhuge(&prot);
+
+	phys = pgt_ops->pte_to_phys(ctx->ptep);
+	phys_end = phys + pgt_ops->level_to_size(ctx->level);
+	step_size = pgt_ops->level_to_size(child_level);
+	entry_size = pgt_ops->pte_size(child_level);
+
+	for (i = 0; phys < phys_end; phys += step_size, i++) {
+		pgt_ops->pte_set(child_ptep + i * entry_size, phys | prot);
+		mm_ops->get_page(child_ptep);
+	}
+}
+
+static int pgtable_try_map_leaf(struct pkvm_pgtable_visit_ctx *ctx,
+				struct pgt_map_data *data)
+{
+	const struct pkvm_pgtable_mm_ops *mm_ops = ctx->pgt->mm_ops;
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	bool flush_tlb, was_present, is_present;
+	void *ptep = ctx->ptep;
+	u64 new, old;
+
+	if (!leaf_mapping_changed(ctx, data))
+		return 0;
+
+	if (!leaf_mapping_allowed(ctx, data)) {
+		/*
+		 * 4K mapping should always be allowed, since the start and end
+		 * addresses are aligned to PAGE_SIZE.
+		 */
+		BUG_ON(ctx->level == PG_LEVEL_4K);
+		/*
+		 * For the other levels, goes down to the next level to try
+		 * if the mapping would be allowed by returning -E2BIG.
+		 */
+		return -E2BIG;
+	}
+
+	was_present = pgt_ops->pte_present(ptep);
+	new = (data->phys + (ctx->addr - ctx->start)) | data->prot;
+	old = pgt_ops->pte_to_phys(ptep) | pgt_ops->pte_to_prot(ptep);
+	/*
+	 * Need to flush TLB when the previous mapping was present and the new
+	 * mapping changes either physical address or property bits. Otherwise
+	 * no need to flush TLB.
+	 */
+	flush_tlb = was_present && new != old;
+
+	if (ctx->level != PG_LEVEL_4K)
+		pgt_ops->pte_mkhuge(&new);
+
+	pgt_ops->pte_set(ptep, new);
+
+	is_present = pgt_ops->pte_present(ptep);
+	/*
+	 * Need to increment the page table page refcnt when installs a present
+	 * leaf if the refcnt was not already incremented by the previous one.
+	 *
+	 * Similarly need to decrement the page table page refcnt when removes a
+	 * present leaf if the refcnt was incremented by the previous one.
+	 */
+	if (is_present && !was_present)
+		mm_ops->get_page(ptep);
+	else if (!is_present && was_present)
+		mm_ops->put_page(ptep);
+
+	if (flush_tlb)
+		pgt_ops->flush_tlb(ctx->pgt, ctx->addr,
+				   pgt_ops->level_to_size(ctx->level));
+
+	return 0;
+}
+
+static int __map_walker(struct pkvm_pgtable_visit_ctx *ctx,
+			struct pgt_map_data *data)
+{
+	const struct pkvm_pgtable_mm_ops *mm_ops = ctx->pgt->mm_ops;
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	void *ptep = ctx->ptep;
+	void *page;
+	int ret;
+
+	/* Try to create leaf page mapping on current level */
+	ret = pgtable_try_map_leaf(ctx, data);
+	if (ret != -E2BIG)
+		return ret;
+
+	/*
+	 * The mapping needs be done at the next level or even smaller.
+	 * Allocate a new page as the next level page table page.
+	 */
+	page = pgtable_alloc_page(mm_ops);
+	if (!page)
+		return -ENOMEM;
+
+	/*
+	 * If a huge mapping already exists at the current level, split it into
+	 * smaller ones.
+	 */
+	if (pgt_ops->pte_huge(ptep)) {
+		/* Split doesn't change the translation so no need to flush tlb. */
+		mm_ops->put_page(ptep);
+		pgtable_split(ctx, page);
+	}
+
+	mm_ops->get_page(ptep);
+	pgt_ops->pte_set(ptep, ctx->pgt->cap.table_prot | __pkvm_pa(page));
+
+	return 0;
+}
+
+/* TODO: Support merging small entries into a huge entry. */
+static int map_walker(struct pkvm_pgtable_visit_ctx *ctx, unsigned long walk_flags,
+		      void *const arg)
+{
+	struct pgt_map_data *data = arg;
+
+	switch (walk_flags) {
+	case PKVM_PGTABLE_WALK_LEAF:
+		return __map_walker(ctx, data);
+	case PKVM_PGTABLE_WALK_TABLE_PRE:
+	case PKVM_PGTABLE_WALK_TABLE_POST:
+		break;
+	}
+
+	return -EINVAL;
+}
+
 struct pgt_walk_data {
 	struct pkvm_pgtable *pgt;
 	unsigned long addr;
@@ -159,4 +356,44 @@ int pkvm_pgtable_walk(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		return 0;
 
 	return _pgtable_walk(&data, __pkvm_va(pgt->root_pa), pgt->cap.level);
+}
+
+/**
+ * pkvm_pgtable_map() - Install virtual addr to physical addr mappings in a pkvm
+ *			pgtable.
+ * @pgt:	The page table to install mappings.
+ * @vaddr:	The virtual address of the installed mapping.
+ * @phys:	The physical address to map.
+ * @size:	The memory size to map.
+ * @prot:	The property bits to create the mapping.
+ *
+ * The mapped range is the minimum PAGE_SIZE-aligned range covering
+ * [@vaddr, @vaddr + @size), and @phys is aligned down to the PAGE_SIZE.
+ *
+ * The mappings for @vaddr to @phys in [@vaddr, @vaddr + @size) are installed
+ * to the page table, with the same @prot. If the mapping already exists at a
+ * higher level, the huge mapping will be split into smaller ones and a new
+ * mapping will be installed at the proper level. If the mapping already exists
+ * at the same level but with different physical address or property bits, it
+ * will be replaced with the new one and TLB will be flushed.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int pkvm_pgtable_map(struct pkvm_pgtable *pgt, unsigned long vaddr,
+		     unsigned long phys, unsigned long size, u64 prot)
+{
+	struct pgt_map_data data = {
+		.prot = prot,
+	};
+	struct pkvm_pgtable_walker walker = {
+		.cb = map_walker,
+		.arg = &data,
+		.walk_flags = PKVM_PGTABLE_WALK_LEAF,
+	};
+
+	if (!VALID_PAGE(phys))
+		return -EINVAL;
+
+	data.phys = ALIGN_DOWN(phys, PAGE_SIZE);
+	return pkvm_pgtable_walk(pgt, vaddr, size, &walker);
 }

--- a/arch/x86/kvm/pkvm/pgtable.c
+++ b/arch/x86/kvm/pkvm/pgtable.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/errno.h>
+#include <linux/kvm_host.h>
+#include <vdso/page.h>
+#include "memory.h"
+#include "pgtable.h"
+
+static void *pgtable_alloc_page(const struct pkvm_pgtable_mm_ops *mm_ops)
+{
+	return mm_ops->zalloc_page();
+}
+
+/**
+ * pkvm_pgtable_init() - Initialize a pkvm page table.
+ * @pgt:	The page table to be initialized.
+ * @cap:	The capability to initialize this page table.
+ * @mm_ops:	The memory management ops for this page table.
+ * @pgt_ops:	The page table ops for this page table.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int pkvm_pgtable_init(struct pkvm_pgtable *pgt,
+		      struct pkvm_pgtable_cap cap,
+		      const struct pkvm_pgtable_mm_ops *mm_ops,
+		      const struct pkvm_pgtable_ops *pgt_ops)
+{
+	void *root;
+
+	if (!pgt || !mm_ops || !pgt_ops)
+		return -EINVAL;
+
+	root = pgtable_alloc_page(mm_ops);
+	if (!root)
+		return -ENOMEM;
+
+	pgt->root_pa = __pkvm_pa(root);
+	pgt->cap = cap;
+	pgt->mm_ops = mm_ops;
+	pgt->pgt_ops = pgt_ops;
+
+	return 0;
+}

--- a/arch/x86/kvm/pkvm/pgtable.c
+++ b/arch/x86/kvm/pkvm/pgtable.c
@@ -207,6 +207,111 @@ static int map_walker(struct pkvm_pgtable_visit_ctx *ctx, unsigned long walk_fla
 	return -EINVAL;
 }
 
+struct pgt_unmap_data {
+	unsigned long phys;
+};
+
+static int pgtable_try_unmap_leaf(struct pkvm_pgtable_visit_ctx *ctx,
+				  struct pgt_unmap_data *data)
+{
+	const struct pkvm_pgtable_mm_ops *mm_ops = ctx->pgt->mm_ops;
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	void *ptep = ctx->ptep;
+	unsigned long size;
+	bool was_present;
+
+	size = pgt_ops->level_to_size(ctx->level);
+	/*
+	 * Unmap the page if:
+	 * - 4K PTE entry
+	 * - a fully covered huge page
+	 * Otherwise return -E2BIG to go to the next level.
+	 */
+	if (!(ctx->level == PG_LEVEL_4K ||
+	      (pgt_ops->pte_huge(ptep) && leaf_in_addr_range(size, ctx->addr, ctx->end))))
+		return -E2BIG;
+
+	was_present = pgt_ops->pte_present(ptep);
+	if (VALID_PAGE(data->phys) && was_present) {
+		/*
+		 * The user can request to check if the unmapped physical
+		 * address is the desired memory page or not. Panic the
+		 * hypervisor if unexpected result happens.
+		 */
+		BUG_ON(pgt_ops->pte_to_phys(ptep) != data->phys + (ctx->addr - ctx->start));
+	}
+
+	pgt_ops->pte_set(ptep, 0);
+	mm_ops->put_page(ptep);
+
+	/*
+	 * Flush TLB if a present entry is changed to
+	 * non-present.
+	 */
+	if (was_present)
+		pgt_ops->flush_tlb(ctx->pgt, ctx->addr, size);
+
+	return 0;
+}
+
+static void pgtable_free_child(struct pkvm_pgtable_visit_ctx *ctx)
+{
+	const struct pkvm_pgtable_mm_ops *mm_ops = ctx->pgt->mm_ops;
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	void *child, *ptep = ctx->ptep;
+
+	/*
+	 * Check the child pte page refcount. Put the child pte page if
+	 * it doesn't contain any other PTEs.
+	 */
+	child = __pkvm_va(pgt_ops->pte_to_phys(ptep));
+	if (mm_ops->page_count(child) == 1) {
+		pgt_ops->pte_set(ptep, 0);
+		/* Flush TLB before release the child table page */
+		pgt_ops->flush_tlb(ctx->pgt, ctx->addr,
+				   pgt_ops->level_to_size(ctx->level));
+		mm_ops->put_page(child);
+		mm_ops->put_page(ptep);
+	}
+}
+
+static int unmap_walker(struct pkvm_pgtable_visit_ctx *ctx, unsigned long walk_flags,
+			void *const arg)
+{
+	const struct pkvm_pgtable_mm_ops *mm_ops = ctx->pgt->mm_ops;
+	const struct pkvm_pgtable_ops *pgt_ops = ctx->pgt->pgt_ops;
+	void *ptep = ctx->ptep;
+	int ret;
+
+	if (!pgt_ops->pte_present(ptep))
+		return 0;
+
+	ret = pgtable_try_unmap_leaf(ctx, (struct pgt_unmap_data *)arg);
+	if (ret != -E2BIG)
+		return ret;
+
+	/*
+	 * If a huge mapping already exists at the current level, split it into
+	 * smaller ones.
+	 */
+	if (pgt_ops->pte_huge(ptep)) {
+		void *page;
+
+		page = pgtable_alloc_page(mm_ops);
+		if (!page)
+			return -ENOMEM;
+
+		/* Split doesn't change the translation so no need to flush tlb. */
+		pgtable_split(ctx, page);
+		pgt_ops->pte_set(ptep, ctx->pgt->cap.table_prot | __pkvm_pa(page));
+	} else {
+		/* Not a huge entry means it is a table entry */
+		pgtable_free_child(ctx);
+	}
+
+	return 0;
+}
+
 struct pgt_walk_data {
 	struct pkvm_pgtable *pgt;
 	unsigned long addr;
@@ -395,5 +500,49 @@ int pkvm_pgtable_map(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		return -EINVAL;
 
 	data.phys = ALIGN_DOWN(phys, PAGE_SIZE);
+	return pkvm_pgtable_walk(pgt, vaddr, size, &walker);
+}
+
+/**
+ * pkvm_pgtable_unmap() - Remove virtual addr to physical addr mappings from a
+ *			  pkvm pgtable.
+ * @pgt:	The page table to remove mapping.
+ * @vaddr:	The virtual address of the mapping to be removed.
+ * @phys:	The desired physical address for the unmap walker to verify.
+ * @size:	The memory size to unmap.
+ *
+ * The unmapped range is the minimum PAGE_SIZE-aligned range covering
+ * [@vaddr, @vaddr + @size), and @phys is aligned down to the PAGE_SIZE if @phys
+ * is not INVALID_PAGE.
+ *
+ * All the mappings for the memory pages in [@vaddr, @vaddr + @size) are removed
+ * from the page table. Each leaf entry in the range is visited by the unmap
+ * walker, to unmap the present ones, followed by the TLB flushing. If the range
+ * represented by a present leaf overlaps with the unmapped range, the leaf will
+ * be split into smaller ones for the unmap walker to walk down to the next
+ * level to remove. If all the mappings in a page table page are removed then
+ * this page table page will be freed after the TLB flushing.
+ *
+ * When @phys is not INVALID_PAGE, the unmap walker will verify if the physical
+ * addresses in the removed mappings in range [@vaddr, @vaddr + @size) match
+ * with [@phys, @phys + @size) or not. The pkvm hypervisor will panic if the
+ * verification for any of the removed mapping is failed. If @phys is
+ * INVALID_PAGE, then the verification will not be performed.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int pkvm_pgtable_unmap(struct pkvm_pgtable *pgt, unsigned long vaddr,
+		       unsigned long phys, unsigned long size)
+{
+	struct pgt_unmap_data data = {
+		.phys = VALID_PAGE(phys) ? ALIGN_DOWN(phys, PAGE_SIZE) :
+					   INVALID_PAGE,
+	};
+	struct pkvm_pgtable_walker walker = {
+		.cb = unmap_walker,
+		.arg = &data,
+		.walk_flags = PKVM_PGTABLE_WALK_LEAF | PKVM_PGTABLE_WALK_TABLE_POST,
+	};
+
 	return pkvm_pgtable_walk(pgt, vaddr, size, &walker);
 }

--- a/arch/x86/kvm/pkvm/pgtable.c
+++ b/arch/x86/kvm/pkvm/pgtable.c
@@ -10,6 +10,86 @@ static void *pgtable_alloc_page(const struct pkvm_pgtable_mm_ops *mm_ops)
 	return mm_ops->zalloc_page();
 }
 
+struct pgt_walk_data {
+	struct pkvm_pgtable *pgt;
+	unsigned long addr;
+	const unsigned long start;
+	const unsigned long end;
+	struct pkvm_pgtable_walker *walker;
+};
+
+static int _pgtable_walk(struct pgt_walk_data *data, void *ptep, int level);
+static int pgtable_visit(struct pgt_walk_data *data, void *ptep, int level)
+{
+	const struct pkvm_pgtable_ops *pgt_ops = data->pgt->pgt_ops;
+	struct pkvm_pgtable_walker *walker = data->walker;
+	bool leaf = pgt_ops->pte_is_leaf(ptep, level);
+	unsigned long walk_flags = walker->walk_flags;
+	struct pkvm_pgtable_visit_ctx ctx = {
+		.pgt = data->pgt,
+		.start = data->start,
+		.end = data->end,
+		.addr = data->addr,
+		.level = level,
+		.ptep = ptep,
+	};
+	void *child_ptep;
+	int ret = 0;
+
+	if (!leaf && (walk_flags & PKVM_PGTABLE_WALK_TABLE_PRE))
+		ret = walker->cb(&ctx, PKVM_PGTABLE_WALK_TABLE_PRE, walker->arg);
+
+	if (leaf && (walk_flags & PKVM_PGTABLE_WALK_LEAF)) {
+		ret = walker->cb(&ctx, PKVM_PGTABLE_WALK_LEAF, walker->arg);
+		/*
+		 * The ptep may be updated by the walker->cb. Revisit the ptep
+		 * to see if it is still leaf or not.
+		 */
+		leaf = pgt_ops->pte_is_leaf(ptep, level);
+	}
+
+	if (ret)
+		return ret;
+
+	if (leaf) {
+		unsigned long size = pgt_ops->level_to_size(level);
+
+		data->addr = ALIGN_DOWN(data->addr, size);
+		data->addr += size;
+		return ret;
+	}
+
+	child_ptep = __pkvm_va(pgt_ops->pte_to_phys(ptep));
+	ret = _pgtable_walk(data, child_ptep, level - 1);
+	if (ret)
+		return ret;
+
+	if (walk_flags & PKVM_PGTABLE_WALK_TABLE_POST)
+		ret = walker->cb(&ctx, PKVM_PGTABLE_WALK_TABLE_POST, walker->arg);
+
+	return ret;
+}
+
+static int _pgtable_walk(struct pgt_walk_data *data, void *ptep, int level)
+{
+	const struct pkvm_pgtable_ops *pgt_ops = data->pgt->pgt_ops;
+	int idx = pgt_ops->vaddr_to_index(data->addr, level);
+	int entry_size = pgt_ops->pte_size(level);
+	int entries = pgt_ops->pte_count(level);
+	int ret;
+
+	for (; idx < entries; idx++) {
+		if (data->addr >= data->end)
+			break;
+
+		ret = pgtable_visit(data, (ptep + idx * entry_size), level);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 /**
  * pkvm_pgtable_init() - Initialize a pkvm page table.
  * @pgt:	The page table to be initialized.
@@ -39,4 +119,44 @@ int pkvm_pgtable_init(struct pkvm_pgtable *pgt,
 	pgt->pgt_ops = pgt_ops;
 
 	return 0;
+}
+
+/**
+ * pkvm_pgtable_walk() - Walk a pkvm page table
+ * @pgt:	The page table to walk.
+ * @vaddr:	The virtual address for the start of the walk.
+ * @size:	The walk range size.
+ * @walker:	The callback descriptor which will be executed
+ *		during the walk.
+ *
+ * The walked range is the minimum PAGE_SIZE-aligned range covering
+ * [@vaddr, @vaddr + @size).
+ *
+ * Each page table entry within the memory range [@vaddr, @vaddr + @size) is
+ * visited during the walk, including present leaves, non-present leaves, and
+ * present non-leaves. The callback in @walker is executed on leaves based on
+ * the walk_flags in @walker. If the callback returns zero, the walk will
+ * continue to the next entry. If the callback returns a non-zero, the walk will
+ * be terminated immediately and return that value.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int pkvm_pgtable_walk(struct pkvm_pgtable *pgt, unsigned long vaddr,
+		      unsigned long size, struct pkvm_pgtable_walker *walker)
+{
+	struct pgt_walk_data data = {
+		.pgt = pgt,
+		.addr = ALIGN_DOWN(vaddr, PAGE_SIZE),
+		.start = ALIGN_DOWN(vaddr, PAGE_SIZE),
+		.end = ALIGN(vaddr + size, PAGE_SIZE),
+		.walker = walker,
+	};
+
+	if (!pgt->root_pa)
+		return -EINVAL;
+
+	if (data.start == data.end)
+		return 0;
+
+	return _pgtable_walk(&data, __pkvm_va(pgt->root_pa), pgt->cap.level);
 }

--- a/arch/x86/kvm/pkvm/pgtable.h
+++ b/arch/x86/kvm/pkvm/pgtable.h
@@ -125,5 +125,7 @@ int pkvm_pgtable_walk(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		      unsigned long size, struct pkvm_pgtable_walker *walker);
 int pkvm_pgtable_map(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		     unsigned long phys, unsigned long size, u64 prot);
+int pkvm_pgtable_unmap(struct pkvm_pgtable *pgt, unsigned long vaddr,
+		       unsigned long phys, unsigned long size);
 
 #endif /* __PKVM_X86_PGTABLE_H */

--- a/arch/x86/kvm/pkvm/pgtable.h
+++ b/arch/x86/kvm/pkvm/pgtable.h
@@ -77,9 +77,51 @@ struct pkvm_pgtable {
 	const struct pkvm_pgtable_ops *pgt_ops;
 };
 
+struct pkvm_pgtable_visit_ctx {
+	struct pkvm_pgtable *pgt;
+	const unsigned long start;
+	const unsigned long end;
+	unsigned long addr;
+	int level;
+	void *ptep;
+};
+
+typedef int (*pgtable_visit_fn_t)(struct pkvm_pgtable_visit_ctx *ctx,
+				  unsigned long walk_flags, void *const arg);
+
+/**
+ * enum pkvm_pgtable_walk_flags - Flags to control page table walk.
+ * @PKVM_PGTABLE_WALK_TABLE_PRE:	Execute the callback on a non-leaf
+ *					entry before visiting its children.
+ * @PKVM_PGTABLE_WALK_LEAF:		Execute the callback on a leaf entry
+ *					(either present or non-present).
+ * @PKVM_PGTABLE_WALK_TABLE_POST:	Execute the callback on a non-leaf
+ *					entry after visiting its children.
+ */
+enum pkvm_pgtable_walk_flags {
+	PKVM_PGTABLE_WALK_TABLE_PRE	= BIT(0),
+	PKVM_PGTABLE_WALK_LEAF		= BIT(1),
+	PKVM_PGTABLE_WALK_TABLE_POST	= BIT(2),
+};
+
+/**
+ * struct pkvm_pgtable_walker - The page table walk callback descriptor.
+ * @cb:		The callback executed during the page table walking.
+ * @arg:	The argument passed to the callback.
+ * @walk_flags:	A bitwise-or of enum pkvm_pgtable_walk_flags to indicate the
+ *		walking behaviors.
+ */
+struct pkvm_pgtable_walker {
+	const pgtable_visit_fn_t cb;
+	void *const arg;
+	const unsigned long walk_flags;
+};
+
 int pkvm_pgtable_init(struct pkvm_pgtable *pgt,
 		      struct pkvm_pgtable_cap cap,
 		      const struct pkvm_pgtable_mm_ops *mm_ops,
 		      const struct pkvm_pgtable_ops *pgt_ops);
+int pkvm_pgtable_walk(struct pkvm_pgtable *pgt, unsigned long vaddr,
+		      unsigned long size, struct pkvm_pgtable_walker *walker);
 
 #endif /* __PKVM_X86_PGTABLE_H */

--- a/arch/x86/kvm/pkvm/pgtable.h
+++ b/arch/x86/kvm/pkvm/pgtable.h
@@ -127,5 +127,7 @@ int pkvm_pgtable_map(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		     unsigned long phys, unsigned long size, u64 prot);
 int pkvm_pgtable_unmap(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		       unsigned long phys, unsigned long size);
+void pkvm_pgtable_lookup(struct pkvm_pgtable *pgt, unsigned long vaddr,
+			 unsigned long *phys, u64 *prot, int *level);
 
 #endif /* __PKVM_X86_PGTABLE_H */

--- a/arch/x86/kvm/pkvm/pgtable.h
+++ b/arch/x86/kvm/pkvm/pgtable.h
@@ -123,5 +123,7 @@ int pkvm_pgtable_init(struct pkvm_pgtable *pgt,
 		      const struct pkvm_pgtable_ops *pgt_ops);
 int pkvm_pgtable_walk(struct pkvm_pgtable *pgt, unsigned long vaddr,
 		      unsigned long size, struct pkvm_pgtable_walker *walker);
+int pkvm_pgtable_map(struct pkvm_pgtable *pgt, unsigned long vaddr,
+		     unsigned long phys, unsigned long size, u64 prot);
 
 #endif /* __PKVM_X86_PGTABLE_H */

--- a/arch/x86/kvm/pkvm/pgtable.h
+++ b/arch/x86/kvm/pkvm/pgtable.h
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __PKVM_X86_PGTABLE_H
+#define __PKVM_X86_PGTABLE_H
+
+#include <linux/types.h>
+
+struct pkvm_pgtable;
+
+/**
+ * struct pkvm_pgtable_mm_ops - Page table memory management callbacks.
+ * @zalloc_page:	Allocate a page with clearing its contents.
+ * @get_page:		Increment the reference count of a given page.
+ * @put_page:		Decrement the reference count of a given page.
+ * @page_count:		Get the reference count of a given page.
+ */
+struct pkvm_pgtable_mm_ops {
+	void *(*zalloc_page)(void);
+	void (*get_page)(void *vaddr);
+	void (*put_page)(void *vaddr);
+	int (*page_count)(void *vaddr);
+};
+
+/**
+ * struct pkvm_pgtable_ops - Page table operation callbacks.
+ * @pte_present:	Detect a present pte.
+ * @pte_huge:		Detect a huge pte.
+ * @pte_mkhuge:		Set huge for the given pte.
+ * @pte_to_phys:	Decode the physical address from pte.
+ * @pte_to_prot:	Decode the property bits from pte.
+ * @calc_pte_perm:	Calculate the pte permission bits according to the
+ *			read/write/exec permissions.
+ * @calc_pte_memtype:	Calculate the pte memory type bits for either memory or
+ *			MMIO.
+ * @vaddr_to_index:	Calculate the entry index for a virtual address
+ *			according to the given page table level.
+ * @level_to_size:	Calculate the page size at a page table level.
+ * @level_to_mask:	Calculate the page size mask at a page table level.
+ * @pte_is_leaf:	Detect a leaf pte.
+ * @pte_size:		Calculate the pte size in bytes at a given page table
+ *			level.
+ * @pte_count:		Calculate the number of ptes at a given page table
+ *			level.
+ * @pte_set:		Set a pte to a given raw value.
+ * @pte_get:		Get the raw value stored in the pte.
+ * @flush_tlb:		Flush the TLB for a virtual address range.
+ */
+struct pkvm_pgtable_ops {
+	bool (*pte_present)(void *ptep);
+	bool (*pte_huge)(void *ptep);
+	void (*pte_mkhuge)(void *ptep);
+	unsigned long (*pte_to_phys)(void *ptep);
+	u64 (*pte_to_prot)(void *ptep);
+	u64 (*calc_pte_perm)(bool read, bool write, bool exec);
+	u64 (*calc_pte_memtype)(bool mmio);
+	int (*vaddr_to_index)(unsigned long vaddr, int level);
+	unsigned long (*level_to_size)(int level);
+	u64 (*level_to_mask)(int level);
+	bool (*pte_is_leaf)(void *ptep, int level);
+	int (*pte_size)(int level);
+	int (*pte_count)(int level);
+	void (*pte_set)(void *ptep, u64 val);
+	u64 (*pte_get)(void *ptep);
+	void (*flush_tlb)(struct pkvm_pgtable *pgt,
+			  unsigned long vaddr, unsigned long size);
+};
+
+struct pkvm_pgtable_cap {
+	int level;
+	int allowed_pgsz;
+	u64 table_prot;
+};
+
+struct pkvm_pgtable {
+	unsigned long root_pa;
+	struct pkvm_pgtable_cap cap;
+	const struct pkvm_pgtable_mm_ops *mm_ops;
+	const struct pkvm_pgtable_ops *pgt_ops;
+};
+
+int pkvm_pgtable_init(struct pkvm_pgtable *pgt,
+		      struct pkvm_pgtable_cap cap,
+		      const struct pkvm_pgtable_mm_ops *mm_ops,
+		      const struct pkvm_pgtable_ops *pgt_ops);
+
+#endif /* __PKVM_X86_PGTABLE_H */

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <linux/types.h>
+#include <linux/kvm_host.h>
 #include "init_finalize.h"
 #include "pkvm.h"
 
@@ -15,11 +16,29 @@ struct pkvm_hyp *pkvm_hyp;
 DEFINE_PER_CPU(struct pkvm_pcpu *, phys_cpu);
 DEFINE_PER_CPU(struct kvm_vcpu *, host_vcpu);
 
+static int pkvm_handle_kvm_call_inout(unsigned long func, unsigned long a0,
+				      unsigned long a1, unsigned long a2,
+				      unsigned long a3)
+{
+	struct kvm_vcpu *hvcpu = this_cpu_read(host_vcpu);
+	union pkvm_fn_data data = { 0 };
+
+	hvcpu->arch.regs[VCPU_REGS_RBX] = data.val1;
+	hvcpu->arch.regs[VCPU_REGS_RCX] = data.val2;
+	hvcpu->arch.regs[VCPU_REGS_RDX] = data.val3;
+	hvcpu->arch.regs[VCPU_REGS_RSI] = data.val4;
+
+	return -EINVAL;
+}
+
 int pkvm_handle_kvm_call(unsigned long func, unsigned long a0,
 			 unsigned long a1, unsigned long a2,
 			 unsigned long a3)
 {
 	int ret;
+
+	if (func >= PKVM_FIRST_INOUT_PV_INTERFACE)
+		return pkvm_handle_kvm_call_inout(func, a0, a1, a2, a3);
 
 	switch (func) {
 	case __pkvm__init_finalize:

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -23,7 +23,7 @@ int pkvm_handle_kvm_call(unsigned long func, unsigned long a0,
 
 	switch (func) {
 	case __pkvm__init_finalize:
-		ret = pkvm_init_finalize(a0, a1);
+		ret = pkvm_init_finalize((struct pkvm_mem_info *)a0, a1);
 		break;
 	default:
 		ret = -EINVAL;

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <linux/types.h>
+#include "init_finalize.h"
 #include "pkvm.h"
 
 /*
@@ -13,3 +14,21 @@ __visible bool kvm_rebooting;
 struct pkvm_hyp *pkvm_hyp;
 DEFINE_PER_CPU(struct pkvm_pcpu *, phys_cpu);
 DEFINE_PER_CPU(struct kvm_vcpu *, host_vcpu);
+
+int pkvm_handle_kvm_call(unsigned long func, unsigned long a0,
+			 unsigned long a1, unsigned long a2,
+			 unsigned long a3)
+{
+	int ret;
+
+	switch (func) {
+	case __pkvm__init_finalize:
+		ret = pkvm_init_finalize();
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -23,7 +23,8 @@ int pkvm_handle_kvm_call(unsigned long func, unsigned long a0,
 
 	switch (func) {
 	case __pkvm__init_finalize:
-		ret = pkvm_init_finalize((struct pkvm_mem_info *)a0, a1);
+		ret = pkvm_init_finalize((struct pkvm_mem_info *)a0, a1,
+					 (struct pkvm_init_ops *)a2);
 		break;
 	default:
 		ret = -EINVAL;

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -23,7 +23,7 @@ int pkvm_handle_kvm_call(unsigned long func, unsigned long a0,
 
 	switch (func) {
 	case __pkvm__init_finalize:
-		ret = pkvm_init_finalize();
+		ret = pkvm_init_finalize(a0, a1);
 		break;
 	default:
 		ret = -EINVAL;

--- a/arch/x86/kvm/pkvm/pkvm.h
+++ b/arch/x86/kvm/pkvm/pkvm.h
@@ -7,4 +7,8 @@
 DECLARE_PER_CPU(struct pkvm_pcpu *, phys_cpu);
 DECLARE_PER_CPU(struct kvm_vcpu *, host_vcpu);
 
+int pkvm_handle_kvm_call(unsigned long func, unsigned long a0,
+			 unsigned long a1, unsigned long a2,
+			 unsigned long a3);
+
 #endif /* __PKVM_X86_PKVM_H */

--- a/arch/x86/kvm/pkvm/pkvm.lds.S
+++ b/arch/x86/kvm/pkvm/pkvm.lds.S
@@ -14,6 +14,7 @@ SECTIONS {
 	 */
 	PKVM_SECTION(.text)
 	PKVM_SECTION(.noinstr.text)
+	PKVM_SECTION(.rodata)
 	/*
 	 * .pkvm.data..percpu needs to be defined before .data section
 	 * as .pkvm.data section will include all sections started with

--- a/arch/x86/kvm/pkvm/pkvm_constants.c
+++ b/arch/x86/kvm/pkvm/pkvm_constants.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/kbuild.h>
+#include "memory.h"
+
+int main(void)
+{
+	DEFINE(PKVM_VMEMMAP_ENTRY_SIZE, sizeof(struct pkvm_page));
+	return 0;
+}

--- a/arch/x86/kvm/pkvm/vmx/ept.c
+++ b/arch/x86/kvm/pkvm/vmx/ept.c
@@ -2,8 +2,10 @@
 #include <linux/kvm_host.h>
 #include <asm/vmx.h>
 #include <vmx/capabilities.h>
+#include <vmx/vmx_ops.h>
 #include <mmu/spte.h>
 #include <vmx/vmx.h>
+#include "pkvm/mmu.h"
 #include "gfp.h"
 #include "ept.h"
 
@@ -177,4 +179,66 @@ int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
 
 	host_ept = pgt;
 	return 0;
+}
+
+int pkvm_handle_host_ept_violation(void)
+{
+	struct range range, cur;
+	int level, ret = -EPERM;
+	unsigned long hpa, gpa;
+
+	BUG_ON(!host_ept);
+
+	gpa = vmcs_read64(GUEST_PHYSICAL_ADDRESS);
+	/*
+	 * All the memory and MMIO holes have already been mapped in the host
+	 * EPT when finalize, except for the MMIO in the high-end address.
+	 * Handle the MMIO only.
+	 */
+	if (pkvm_find_addr_range(gpa, &range))
+		return ret;
+
+	pkvm_host_mmu_lock();
+
+	pkvm_pgtable_lookup(host_ept, gpa, &hpa, NULL, &level);
+	if (VALID_PAGE(hpa)) {
+		/*
+		 * Some other CPU has just mapped in the host EPT. Vmenter
+		 * the host VM and retry.
+		 */
+		pkvm_host_mmu_unlock();
+		return 0;
+	}
+
+	BUG_ON(level > host_ept->cap.level);
+	/*
+	 * Based on the looked up level, find out the possible maximum page-size
+	 * aligned address range which contains the GPA address for installing
+	 * the MMIO mapping, to minimize the memory consumption.
+	 */
+	for (; level > PG_LEVEL_NONE; level--) {
+		unsigned long size;
+
+		if (!((1 << level) & host_ept->cap.allowed_pgsz))
+			continue;
+
+		size = ept_level_to_size(level);
+		cur.start = ALIGN_DOWN(gpa, size);
+		cur.end = cur.start + size - 1;
+
+		if (range_contains(&range, &cur)) {
+			/*
+			 * TODO: In case the host mmu free pages are not
+			 * enough, -ENOMEM will be returned. This could be
+			 * handled by unmaping some other MMIO mapped for the
+			 * host VM to reclaim some mmu pages and try again.
+			 */
+			ret = pkvm_host_mmu_map(cur.start, size, true, true,
+						true, true);
+			break;
+		}
+	}
+
+	pkvm_host_mmu_unlock();
+	return ret;
 }

--- a/arch/x86/kvm/pkvm/vmx/ept.c
+++ b/arch/x86/kvm/pkvm/vmx/ept.c
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/kvm_host.h>
+#include <asm/vmx.h>
+#include <vmx/capabilities.h>
+#include <mmu/spte.h>
+#include <vmx/vmx.h>
+#include "gfp.h"
+#include "ept.h"
+
+static struct pkvm_pgtable *host_ept;
+static struct pkvm_pool host_ept_pool;
+
+static void *host_ept_zalloc_page(void)
+{
+	return pkvm_alloc_pages(&host_ept_pool, 0);
+}
+
+static void host_ept_get_page(void *vaddr)
+{
+	pkvm_get_page(&host_ept_pool, vaddr);
+}
+
+static void host_ept_put_page(void *vaddr)
+{
+	pkvm_put_page(&host_ept_pool, vaddr);
+}
+
+static int host_ept_page_count(void *vaddr)
+{
+	return pkvm_page_count(vaddr);
+}
+
+static const struct pkvm_pgtable_mm_ops host_ept_mm_ops = {
+	.zalloc_page = host_ept_zalloc_page,
+	.get_page = host_ept_get_page,
+	.put_page = host_ept_put_page,
+	.page_count = host_ept_page_count,
+};
+
+static bool ept_pte_present(void *ptep)
+{
+	u64 val = *(u64 *)ptep;
+
+	return !!(val & VMX_EPT_RWX_MASK);
+}
+
+static bool ept_pte_huge(void *ptep)
+{
+	return is_large_pte(*(u64 *)ptep);
+}
+
+static void ept_pte_mkhuge(void *ptep)
+{
+	*(u64 *)ptep |= PT_PAGE_SIZE_MASK;
+}
+
+static unsigned long ept_pte_to_phys(void *ptep)
+{
+	return *(u64 *)ptep & SPTE_BASE_ADDR_MASK;
+}
+
+static u64 ept_pte_to_prot(void *ptep)
+{
+	u64 prot = *(u64 *)ptep & ~(SPTE_BASE_ADDR_MASK);
+
+	return prot & ~PT_PAGE_SIZE_MASK;
+}
+
+static u64 ept_calc_pte_perm(bool read, bool write, bool exec)
+{
+	u64 prot = 0;
+
+	if (read)
+		prot |= VMX_EPT_READABLE_MASK;
+	if (write)
+		prot |= VMX_EPT_WRITABLE_MASK;
+	if (exec)
+		prot |= VMX_EPT_EXECUTABLE_MASK;
+
+	return prot;
+}
+
+static u64 ept_calc_pte_memtype(bool mmio)
+{
+	return mmio ? X86_MEMTYPE_UC << VMX_EPT_MT_EPTE_SHIFT :
+		      X86_MEMTYPE_WB << VMX_EPT_MT_EPTE_SHIFT;
+}
+
+static int ept_pte_to_index(unsigned long vaddr, int level)
+{
+	return SPTE_INDEX(vaddr, level);
+}
+
+static unsigned long ept_level_to_size(int level)
+{
+	return KVM_HPAGE_SIZE(level);
+}
+
+static u64 ept_level_to_mask(int level)
+{
+	return (~((1UL << SPTE_LEVEL_SHIFT(level)) - 1));
+}
+
+static bool ept_pte_is_leaf(void *ptep, int level)
+{
+	return level == PG_LEVEL_4K || !ept_pte_present(ptep) || ept_pte_huge(ptep);
+}
+
+static int ept_pte_size(int level)
+{
+	return PAGE_SIZE / SPTE_ENT_PER_PAGE;
+}
+
+static int ept_pte_count(int level)
+{
+	return SPTE_ENT_PER_PAGE;
+}
+
+static void ept_pte_set(void *ptep, u64 spte)
+{
+	WRITE_ONCE(*(u64 *)ptep, spte);
+}
+
+static u64 ept_pte_get(void *ptep)
+{
+	return READ_ONCE(*(u64 *)ptep);
+}
+
+static void host_ept_flush_tlb(struct pkvm_pgtable *pgt,
+			       unsigned long vaddr, unsigned long size)
+{
+	/* TODO: Flush TLB for the host EPT */
+}
+
+static const struct pkvm_pgtable_ops host_ept_pgt_ops = {
+	.pte_present = ept_pte_present,
+	.pte_huge = ept_pte_huge,
+	.pte_mkhuge = ept_pte_mkhuge,
+	.pte_to_phys = ept_pte_to_phys,
+	.pte_to_prot = ept_pte_to_prot,
+	.calc_pte_perm = ept_calc_pte_perm,
+	.calc_pte_memtype = ept_calc_pte_memtype,
+	.vaddr_to_index = ept_pte_to_index,
+	.level_to_size = ept_level_to_size,
+	.level_to_mask = ept_level_to_mask,
+	.pte_is_leaf = ept_pte_is_leaf,
+	.pte_size = ept_pte_size,
+	.pte_count = ept_pte_count,
+	.pte_set = ept_pte_set,
+	.pte_get = ept_pte_get,
+	.flush_tlb = host_ept_flush_tlb,
+};
+
+int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
+		       unsigned long pool_pages)
+{
+	unsigned long pfn = __pkvm_pa(pool_base) >> PAGE_SHIFT;
+	struct pkvm_pgtable_cap cap = {
+		.level = cpu_has_vmx_ept_5levels() ? 5 : 4,
+		.allowed_pgsz = 1 << PG_LEVEL_4K,
+		.table_prot = VMX_EPT_RWX_MASK,
+	};
+	int ret;
+
+	ret = pkvm_pool_init(&host_ept_pool, pfn, pool_pages, 0);
+	if (ret)
+		return ret;
+
+	if (cpu_has_vmx_ept_2m_page())
+		cap.allowed_pgsz |=  1 << PG_LEVEL_2M;
+	if (cpu_has_vmx_ept_1g_page())
+		cap.allowed_pgsz |=  1 << PG_LEVEL_1G;
+
+	ret = pkvm_pgtable_init(pgt, cap, &host_ept_mm_ops, &host_ept_pgt_ops);
+	if (ret)
+		return ret;
+
+	host_ept = pgt;
+	return 0;
+}

--- a/arch/x86/kvm/pkvm/vmx/ept.c
+++ b/arch/x86/kvm/pkvm/vmx/ept.c
@@ -6,6 +6,7 @@
 #include <mmu/spte.h>
 #include <vmx/vmx.h>
 #include "pkvm/mmu.h"
+#include "pkvm.h"
 #include "gfp.h"
 #include "ept.h"
 
@@ -153,6 +154,15 @@ static const struct pkvm_pgtable_ops host_ept_pgt_ops = {
 	.flush_tlb = host_ept_flush_tlb,
 };
 
+static inline u64 construct_host_eptp(struct pkvm_pgtable *pgt)
+{
+	u64 eptp = pgt->root_pa | VMX_EPTP_MT_WB;
+
+	eptp |= (pgt->cap.level == 5) ? VMX_EPTP_PWL_5 : VMX_EPTP_PWL_4;
+
+	return eptp;
+}
+
 int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
 		       unsigned long pool_pages)
 {
@@ -178,6 +188,45 @@ int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
 		return ret;
 
 	host_ept = pgt;
+	return 0;
+}
+
+int pkvm_host_ept_finalize(struct pkvm_pgtable *pgt)
+{
+	struct kvm_vcpu *hvcpu = this_cpu_read(host_vcpu);
+
+	/* The EPT finalizing should be done after EPT initialization */
+	if (!host_ept || pgt != host_ept)
+		return -EINVAL;
+
+	secondary_exec_controls_setbit(to_vmx(hvcpu), SECONDARY_EXEC_ENABLE_EPT);
+	vmcs_write64(EPT_POINTER, construct_host_eptp(host_ept));
+
+	/* enable vpid */
+	if ((host_vmcs_config.cpu_based_2nd_exec_ctrl & SECONDARY_EXEC_ENABLE_VPID) &&
+	    (cpu_has_vmx_invvpid_single() || cpu_has_vmx_invvpid_global()) &&
+	    cpu_has_vmx_invvpid()) {
+		/* Derive vpid from vcpu_id by adding 1 to ensure vpid is non-zero */
+		int vpid = hvcpu->vcpu_id + 1;
+
+		if (vpid > 0 && vpid < VMX_NR_VPIDS) {
+			/*
+			 * Fixed VPIDs for the host vCPUs, which implies that it
+			 * could conflict with VPIDs from guest VMs.
+			 *
+			 * It's safe because cached mappings used in non-root
+			 * mode are associated with EPTRTA, and the host's EPT
+			 * root never changes and is different from any guest's
+			 * EPT root.
+			 */
+			vmcs_write16(VIRTUAL_PROCESSOR_ID, vpid);
+			secondary_exec_controls_setbit(to_vmx(hvcpu),
+						       SECONDARY_EXEC_ENABLE_VPID);
+		}
+	}
+
+	ept_sync_global();
+
 	return 0;
 }
 

--- a/arch/x86/kvm/pkvm/vmx/ept.h
+++ b/arch/x86/kvm/pkvm/vmx/ept.h
@@ -6,6 +6,7 @@
 
 int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
 		       unsigned long pool_pages);
+int pkvm_host_ept_finalize(struct pkvm_pgtable *pgt);
 int pkvm_handle_host_ept_violation(void);
 
 #endif /* __PKVM_VMX_EPT_H */

--- a/arch/x86/kvm/pkvm/vmx/ept.h
+++ b/arch/x86/kvm/pkvm/vmx/ept.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __PKVM_VMX_EPT_H
+#define __PKVM_VMX_EPT_H
+
+#include "pgtable.h"
+
+int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
+		       unsigned long pool_pages);
+
+#endif /* __PKVM_VMX_EPT_H */

--- a/arch/x86/kvm/pkvm/vmx/ept.h
+++ b/arch/x86/kvm/pkvm/vmx/ept.h
@@ -6,5 +6,6 @@
 
 int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
 		       unsigned long pool_pages);
+int pkvm_handle_host_ept_violation(void);
 
 #endif /* __PKVM_VMX_EPT_H */

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -29,6 +29,7 @@ static int vmx_hyp_mmu_finalize(struct pkvm_pgtable *pgt)
 static struct pkvm_init_ops vmx_init_ops = {
 	.hyp_mmu_finalize = vmx_hyp_mmu_finalize,
 	.host_mmu_init = pkvm_host_ept_init,
+	.host_mmu_finalize = pkvm_host_ept_finalize,
 };
 
 static void skip_emulated_instruction(void)

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -11,6 +11,8 @@
 #define CR4			4
 #define MOV_TO_CR		0
 
+struct vmcs_config host_vmcs_config;
+
 static struct pkvm_init_ops vmx_init_ops;
 void *pkvm_vmx_init_ops = &vmx_init_ops;
 

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -6,6 +6,7 @@
 #include "init_finalize.h"
 #include "host_vmx.h"
 #include "pkvm.h"
+#include "ept.h"
 
 #define CR4			4
 #define MOV_TO_CR		0
@@ -25,6 +26,7 @@ static int vmx_hyp_mmu_finalize(struct pkvm_pgtable *pgt)
 
 static struct pkvm_init_ops vmx_init_ops = {
 	.hyp_mmu_finalize = vmx_hyp_mmu_finalize,
+	.host_mmu_init = pkvm_host_ept_init,
 };
 
 static void skip_emulated_instruction(void)

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -4,6 +4,7 @@
 #include <kvm_emulate.h>
 #include <vmx/x86_ops.h>
 #include "host_vmx.h"
+#include "pkvm.h"
 
 #define CR4			4
 #define MOV_TO_CR		0
@@ -38,6 +39,19 @@ static void handle_cpuid(struct kvm_vcpu *vcpu)
 	vcpu->arch.regs[VCPU_REGS_RBX] = ebx;
 	vcpu->arch.regs[VCPU_REGS_RCX] = ecx;
 	vcpu->arch.regs[VCPU_REGS_RDX] = edx;
+}
+
+static void handle_vmcall(struct kvm_vcpu *vcpu)
+{
+	u64 func, a0, a1, a2, a3;
+
+	func = vcpu->arch.regs[VCPU_REGS_RAX];
+	a0 = vcpu->arch.regs[VCPU_REGS_RBX];
+	a1 = vcpu->arch.regs[VCPU_REGS_RCX];
+	a2 = vcpu->arch.regs[VCPU_REGS_RDX];
+	a3 = vcpu->arch.regs[VCPU_REGS_RSI];
+
+	vcpu->arch.regs[VCPU_REGS_RAX] = pkvm_handle_kvm_call(func, a0, a1, a2, a3);
 }
 
 static void handle_cr(struct kvm_vcpu *vcpu)
@@ -179,6 +193,10 @@ void pkvm_host_vmexit_main(struct vcpu_vmx *vmx)
 		break;
 	case EXIT_REASON_CPUID:
 		handle_cpuid(vcpu);
+		skip_instruction = true;
+		break;
+	case EXIT_REASON_VMCALL:
+		handle_vmcall(vcpu);
 		skip_instruction = true;
 		break;
 	case EXIT_REASON_CR_ACCESS:

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -3,11 +3,29 @@
 #include <linux/kvm_types.h>
 #include <kvm_emulate.h>
 #include <vmx/x86_ops.h>
+#include "init_finalize.h"
 #include "host_vmx.h"
 #include "pkvm.h"
 
 #define CR4			4
 #define MOV_TO_CR		0
+
+static struct pkvm_init_ops vmx_init_ops;
+void *pkvm_vmx_init_ops = &vmx_init_ops;
+
+static int vmx_hyp_mmu_finalize(struct pkvm_pgtable *pgt)
+{
+	if (!pgt)
+		return -EINVAL;
+
+	vmcs_writel(HOST_CR3, pgt->root_pa);
+
+	return 0;
+}
+
+static struct pkvm_init_ops vmx_init_ops = {
+	.hyp_mmu_finalize = vmx_hyp_mmu_finalize,
+};
 
 static void skip_emulated_instruction(void)
 {

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -231,6 +231,14 @@ void pkvm_host_vmexit_main(struct vcpu_vmx *vmx)
 		if (handle_write_msr(vcpu) == X86EMUL_CONTINUE)
 			skip_instruction = true;
 		break;
+	case EXIT_REASON_EPT_VIOLATION:
+		/*
+		 * Inject #GP to the host VM if its EPT violation
+		 * cannot be handled.
+		 */
+		if (pkvm_handle_host_ept_violation())
+			kvm_inject_gp(vcpu, 0);
+		break;
 	case EXIT_REASON_PREEMPTION_TIMER:
 		handle_preemption_timer(vcpu);
 		break;

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -35,6 +35,7 @@ u64 pkvm_total_reserve_pages(void)
 	u64 total = pkvm_vmx_data_pages();
 
 	total += pkvm_hyp_pgtable_pages();
+	total += pkvm_host_pgtable_pages();
 	total += pkvm_vmemmap_pages(PKVM_VMEMMAP_ENTRY_SIZE);
 
 	return total;

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -4,6 +4,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <asm/pkvm_image.h>
+#include "pkvm_constants.h"
 #include "vmx.h"
 
 static int __init early_pkvm_parse_cmdline(char *buf)
@@ -34,6 +35,7 @@ u64 pkvm_total_reserve_pages(void)
 	u64 total = pkvm_vmx_data_pages();
 
 	total += pkvm_hyp_pgtable_pages();
+	total += pkvm_vmemmap_pages(PKVM_VMEMMAP_ENTRY_SIZE);
 
 	return total;
 }

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -686,8 +686,8 @@ static void do_pkvm_finalize(void *data)
 			.prot	= pgprot_val(PAGE_KERNEL),
 		},
 	};
-	int ret = kvm_call_pkvm(init_finalize, (unsigned long)infos,
-				ARRAY_SIZE(infos), NULL);
+	int ret = kvm_call_pkvm(init_finalize, (unsigned long)infos, ARRAY_SIZE(infos),
+				(unsigned long)pkvm_sym(pkvm_vmx_init_ops));
 
 	if (data)
 		*(int *)data = ret;

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -45,6 +45,12 @@ static __init void pkvm_setup_syms(void)
 	pkvm_sym(page_offset_base) = page_offset_base;
 #endif
 	pkvm_sym(phys_base) = phys_base;
+
+	/*
+	 * For the pkvm hypervisor to leverage the boot_cpu_has macro to check
+	 * if a specific feature is supported or not.
+	 */
+	memcpy(&pkvm_sym(boot_cpu_data), &boot_cpu_data, sizeof(struct cpuinfo_x86));
 }
 
 static __init int pkvm_setup_host_vmcs_config(void)

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -625,6 +625,31 @@ static __init int pkvm_host_deprivilege_cpus(struct pkvm_hyp *pkvm)
 	return ret ? ret : p.ret;
 }
 
+static void do_pkvm_finalize(void *data)
+{
+	int ret = kvm_call_pkvm(init_finalize);
+
+	if (data)
+		*(int *)data = ret;
+}
+
+static __init int pkvm_init_finalize(void)
+{
+	int ret, cpu, finalize_ret;
+
+	for_each_possible_cpu(cpu) {
+		ret = smp_call_function_single(cpu, do_pkvm_finalize,
+					       &finalize_ret, 1);
+		if (ret || finalize_ret) {
+			pr_err("Failed to finalize CPU%d: smp_call %d, finalize: %d\n",
+			       cpu, ret, finalize_ret);
+			break;
+		}
+	}
+
+	return ret ? ret : finalize_ret;
+}
+
 int __init vmx_pkvm_init(void)
 {
 	unsigned long nr_pages;
@@ -682,7 +707,13 @@ int __init vmx_pkvm_init(void)
 		goto out;
 	}
 
-	pr_info("All cpus are in guest mode!\n");
+	ret = pkvm_init_finalize();
+	if (ret) {
+		/* TODO: Re-privilege the deprivileged CPUs */
+		goto out;
+	}
+
+	pr_info("Hypervisor is up and running!\n");
 	return 0;
 out:
 	/*

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -248,6 +248,7 @@ static __init int pkvm_setup_pcpu(struct pkvm_hyp *pkvm, int cpu)
 
 static __init int pkvm_setup_host_vcpu(struct pkvm_hyp *pkvm, int cpu)
 {
+	struct kvm *kvm = pkvm->host_kvm;
 	struct vcpu_vmx *vmx;
 
 	if (cpu >= CONFIG_NR_CPUS) {
@@ -274,7 +275,9 @@ static __init int pkvm_setup_host_vcpu(struct pkvm_hyp *pkvm, int cpu)
 	}
 
 	vmx->vcpu.cpu = cpu;
-	vmx->vcpu.kvm = pkvm->host_kvm;
+	vmx->vcpu.vcpu_id = kvm->created_vcpus;
+	vmx->vcpu.kvm = kvm;
+	kvm->created_vcpus++;
 	pkvm->host_vcpus[cpu] = &vmx->vcpu;
 
 	return 0;

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -51,6 +51,11 @@ static __init void pkvm_setup_syms(void)
 	 * if a specific feature is supported or not.
 	 */
 	memcpy(&pkvm_sym(boot_cpu_data), &boot_cpu_data, sizeof(struct cpuinfo_x86));
+
+#ifdef CONFIG_DYNAMIC_PHYSICAL_MASK
+	/* For pkvm hypervisor to decode the valid physical address bits */
+	pkvm_sym(physical_mask) = physical_mask;
+#endif
 }
 
 static __init int pkvm_setup_host_vmcs_config(void)

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -61,6 +61,11 @@ static __init void pkvm_setup_syms(void)
 	/* For pkvm hypervisor to decode the valid physical address bits */
 	pkvm_sym(physical_mask) = physical_mask;
 #endif
+	/* For the pkvm hypervisor to leverage pgprot_val macro */
+	pkvm_sym(__default_kernel_pte_mask) = __default_kernel_pte_mask;
+#ifdef CONFIG_AMD_MEM_ENCRYPT
+	pkvm_sym(sme_me_mask) = sme_me_mask;
+#endif
 }
 
 static __init int pkvm_setup_host_vmcs_config(void)
@@ -644,10 +649,46 @@ static __init int pkvm_host_deprivilege_cpus(struct pkvm_hyp *pkvm)
 static void do_pkvm_finalize(void *data)
 {
 	unsigned long data_size = data_pages << PAGE_SHIFT;
-	int ret;
+	struct pkvm_mem_info infos[] = {
+		{
+			.type	= PKVM_RESERVED_UNUSED_MEMORY,
+			.va	= (unsigned long)__va(pkvm_mem_base + data_size),
+			.pa	= pkvm_mem_base + data_size,
+			.size	= pkvm_mem_size - data_size,
+			.prot	= pgprot_val(PAGE_KERNEL),
+		},
+		{
+			.type	= PKVM_TEXT_DATA,
+			.va	= (unsigned long)__pkvm_text_start,
+			.pa	= __pa_symbol(__pkvm_text_start),
+			.size	= __pkvm_text_end - __pkvm_text_start,
+			.prot	= pgprot_val(PAGE_KERNEL_EXEC),
+		},
+		{
+			.type	= PKVM_TEXT_DATA,
+			.va	= (unsigned long)__pkvm_rodata_start,
+			.pa	= __pa_symbol(__pkvm_rodata_start),
+			.size	= __pkvm_rodata_end - __pkvm_rodata_start,
+			.prot	= pgprot_val(PAGE_KERNEL_RO),
+		},
+		{
+			.type	= PKVM_TEXT_DATA,
+			.va	= (unsigned long)__pkvm_data_start,
+			.pa	= __pa_symbol(__pkvm_data_start),
+			.size	= __pkvm_data_end - __pkvm_data_start,
+			.prot	= pgprot_val(PAGE_KERNEL),
+		},
+		{
+			.type	= PKVM_TEXT_DATA,
+			.va	= (unsigned long)__pkvm_bss_start,
+			.pa	= __pa_symbol(__pkvm_bss_start),
+			.size	= __pkvm_bss_end - __pkvm_bss_start,
+			.prot	= pgprot_val(PAGE_KERNEL),
+		},
+	};
+	int ret = kvm_call_pkvm(init_finalize, (unsigned long)infos,
+				ARRAY_SIZE(infos));
 
-	ret = kvm_call_pkvm(init_finalize, pkvm_mem_base + data_size,
-			    pkvm_mem_size - data_size);
 	if (data)
 		*(int *)data = ret;
 }

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -687,7 +687,7 @@ static void do_pkvm_finalize(void *data)
 		},
 	};
 	int ret = kvm_call_pkvm(init_finalize, (unsigned long)infos,
-				ARRAY_SIZE(infos));
+				ARRAY_SIZE(infos), NULL);
 
 	if (data)
 		*(int *)data = ret;

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -501,7 +501,7 @@ static __init void init_execution_control(struct vcpu_vmx *vmx)
 	/*
 	 * Set the VMXE bit in CR4_READ_SHADOW so that the host VM will see the
 	 * consistent values between "native" cr4 and its cached cpu_tlbstate.cr4
-	 * (which is set when turns on VMX via kvm_vcpu_vmxon).
+	 * (which is set when turns on VMX via kvm_cpu_vmxon).
 	 */
 	vmcs_writel(CR4_READ_SHADOW, X86_CR4_VMXE);
 }
@@ -683,13 +683,7 @@ int __init vmx_pkvm_init(void)
 	}
 
 	pr_info("All cpus are in guest mode!\n");
-	/*
-	 * TODO: Return -EFAULT to abort KVM init if the host has been
-	 * successfully deprivileged to prevent the host using vmx
-	 * instructions which are not supported by the pkvm hypervisor
-	 * until the pvVMCS is added.
-	 */
-	return -EFAULT;
+	return 0;
 out:
 	/*
 	 * As the reserved memory at the pkvm_mem_base will not be

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -14,6 +14,7 @@ early_param("kvm-intel.pkvm", early_pkvm_parse_cmdline);
 
 static struct vmcs_config host_vmcs_config;
 static DEFINE_PER_CPU(struct vmcs *, pkvm_vmxarea);
+static unsigned long data_pages;
 
 struct pkvm_deprivilege_param {
 	struct pkvm_hyp *pkvm;
@@ -30,7 +31,11 @@ static struct gdt_page pkvm_gdt_page = {
 
 u64 pkvm_total_reserve_pages(void)
 {
-	return pkvm_vmx_data_pages();
+	u64 total = pkvm_vmx_data_pages();
+
+	total += pkvm_hyp_pgtable_pages();
+
+	return total;
 }
 
 static __init void pkvm_setup_syms(void)
@@ -638,8 +643,11 @@ static __init int pkvm_host_deprivilege_cpus(struct pkvm_hyp *pkvm)
 
 static void do_pkvm_finalize(void *data)
 {
-	int ret = kvm_call_pkvm(init_finalize);
+	unsigned long data_size = data_pages << PAGE_SHIFT;
+	int ret;
 
+	ret = kvm_call_pkvm(init_finalize, pkvm_mem_base + data_size,
+			    pkvm_mem_size - data_size);
 	if (data)
 		*(int *)data = ret;
 }
@@ -663,7 +671,6 @@ static __init int pkvm_init_finalize(void)
 
 int __init vmx_pkvm_init(void)
 {
-	unsigned long nr_pages;
 	struct pkvm_hyp *pkvm;
 	int ret, cpu;
 
@@ -676,8 +683,8 @@ int __init vmx_pkvm_init(void)
 		goto out;
 	}
 
-	nr_pages = pkvm_vmx_data_pages();
-	pkvm_sym(pkvm_early_alloc_init)(__va(pkvm_mem_base), nr_pages << PAGE_SHIFT);
+	data_pages = pkvm_vmx_data_pages();
+	pkvm_sym(pkvm_early_alloc_init)(__va(pkvm_mem_base), data_pages << PAGE_SHIFT);
 
 	pkvm = pkvm_sym(pkvm_hyp) = pkvm_sym(pkvm_early_alloc_contig)(PKVM_HYP_PAGES);
 	if (!pkvm) {

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -654,6 +654,13 @@ static void do_pkvm_finalize(void *data)
 	unsigned long data_size = data_pages << PAGE_SHIFT;
 	struct pkvm_mem_info infos[] = {
 		{
+			.type	= PKVM_RESERVED_USED_MEMORY,
+			.va	= (unsigned long)__va(pkvm_mem_base),
+			.pa	= pkvm_mem_base,
+			.size	= data_size,
+			.prot	= pgprot_val(PAGE_KERNEL),
+		},
+		{
 			.type	= PKVM_RESERVED_UNUSED_MEMORY,
 			.va	= (unsigned long)__va(pkvm_mem_base + data_size),
 			.pa	= pkvm_mem_base + data_size,

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -13,7 +13,6 @@ static int __init early_pkvm_parse_cmdline(char *buf)
 }
 early_param("kvm-intel.pkvm", early_pkvm_parse_cmdline);
 
-static struct vmcs_config host_vmcs_config;
 static DEFINE_PER_CPU(struct vmcs *, pkvm_vmxarea);
 static unsigned long data_pages;
 
@@ -73,7 +72,7 @@ static __init void pkvm_setup_syms(void)
 
 static __init int pkvm_setup_host_vmcs_config(void)
 {
-	struct vmcs_config *vmcs_config = &host_vmcs_config;
+	struct vmcs_config *vmcs_config = &pkvm_sym(host_vmcs_config);
 	struct vmx_capability *vmx_cap = &pkvm_sym(vmx_capability);
 	struct vmcs_config_setting setting = {
 		.cpu_based_vm_exec_ctrl_req =
@@ -157,7 +156,8 @@ static struct vmcs *pkvm_alloc_vmcs(void)
 	if (!PAGE_ALIGNED(__pa(vmcs)))
 		return NULL;
 
-	vmcs->hdr.revision_id = vmx_basic_vmcs_revision_id(host_vmcs_config.basic);
+	vmcs->hdr.revision_id = vmx_basic_vmcs_revision_id(pkvm_sym(host_vmcs_config).basic);
+
 	return vmcs;
 }
 
@@ -480,7 +480,7 @@ static __init void init_host_state_area(struct vcpu_vmx *vmx, struct pkvm_hyp *p
 static __init void init_execution_control(struct vcpu_vmx *vmx)
 {
 	/* Preemption timer is toggled dynamically */
-	pin_controls_set(vmx, host_vmcs_config.pin_based_exec_ctrl &
+	pin_controls_set(vmx, pkvm_sym(host_vmcs_config).pin_based_exec_ctrl &
 			      ~PIN_BASED_VMX_PREEMPTION_TIMER);
 
 	/*
@@ -489,13 +489,13 @@ static __init void init_execution_control(struct vcpu_vmx *vmx)
 	 * passthrough to the host VM.
 	 * INTR WINDOW EXITING is toggled dynamically.
 	 */
-	exec_controls_set(vmx, host_vmcs_config.cpu_based_exec_ctrl &
+	exec_controls_set(vmx, pkvm_sym(host_vmcs_config).cpu_based_exec_ctrl &
 			       ~(CPU_BASED_CR3_LOAD_EXITING |
 				 CPU_BASED_CR3_STORE_EXITING |
 				 CPU_BASED_INTR_WINDOW_EXITING));
 
 	/* Disable EPT/VPID first, enable after EPT pgtable created */
-	secondary_exec_controls_set(vmx, host_vmcs_config.cpu_based_2nd_exec_ctrl &
+	secondary_exec_controls_set(vmx, pkvm_sym(host_vmcs_config).cpu_based_2nd_exec_ctrl &
 					 ~(SECONDARY_EXEC_ENABLE_EPT |
 					   SECONDARY_EXEC_ENABLE_VPID));
 	/*
@@ -532,13 +532,13 @@ static __init void init_execution_control(struct vcpu_vmx *vmx)
 
 static __init void init_vmexit_control(struct vcpu_vmx *vmx)
 {
-	vm_exit_controls_set(vmx, host_vmcs_config.vmexit_ctrl);
+	vm_exit_controls_set(vmx, pkvm_sym(host_vmcs_config).vmexit_ctrl);
 	vmcs_write32(VM_EXIT_MSR_STORE_COUNT, 0);
 }
 
 static __init void init_vmentry_control(struct vcpu_vmx *vmx)
 {
-	vm_entry_controls_set(vmx, host_vmcs_config.vmentry_ctrl);
+	vm_entry_controls_set(vmx, pkvm_sym(host_vmcs_config).vmentry_ctrl);
 	vmcs_write32(VM_ENTRY_INTR_INFO_FIELD, 0);
 	vmcs_write32(VM_ENTRY_MSR_LOAD_COUNT, 0);
 	vmcs_write32(VM_ENTRY_INTR_INFO_FIELD, 0);

--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -8737,31 +8737,19 @@ static void __exit vmx_exit(void)
 module_exit(vmx_exit);
 
 #ifdef CONFIG_PKVM_INTEL
-static int __init do_vmx_pkvm_init(void)
+static void __init do_vmx_pkvm_init(void)
 {
 	int r;
 
 #if IS_ENABLED(CONFIG_HYPERV)
 	if (enlightened_vmcs && enable_pkvm) {
 		pr_warn("pKVM cannot be enabled due to conflict with enlightened_vmcs!\n");
-		return 0;
+		return;
 	}
 #endif
 	r = vmx_pkvm_init();
-	if (r == -EFAULT) {
-		/*
-		 * As some kind of pkvm initialization failures are harmless to
-		 * the host, e.g., failures related with the pkvm reserved
-		 * memory, allow the KVM subsystem continue to run and only stop
-		 * it specifically for the error -EFAULT.
-		 */
-		pr_err("pKVM init fatal error. Abort KVM init\n");
-		return r;
-	} else if (r) {
-		pr_warn("pKVM init failed with non-fatal error %d. Continue KVM init\n", r);
-	}
-
-	return 0;
+	if (r)
+		pr_warn("pKVM init failed with error %d. Continue KVM init\n", r);
 }
 #endif
 
@@ -8779,9 +8767,7 @@ static int __init vmx_init(void)
 	hv_init_evmcs();
 
 #ifdef CONFIG_PKVM_INTEL
-	r = do_vmx_pkvm_init();
-	if (r)
-		return r;
+	do_vmx_pkvm_init();
 #endif
 
 	r = kvm_x86_vendor_init(&vt_init_ops);

--- a/arch/x86/kvm/vmx/vmx.h
+++ b/arch/x86/kvm/vmx/vmx.h
@@ -797,6 +797,7 @@ int __init vmx_pkvm_init(void);
 PKVM_DECLARE(void, pkvm_host_vmexit_entry, (void));
 PKVM_DECLARE(void, pkvm_vmx_register_excp_handlers, (void));
 extern struct vmx_capability pkvm_sym(vmx_capability);
+extern struct vmcs_config pkvm_sym(host_vmcs_config);
 extern void *pkvm_sym(pkvm_vmx_init_ops);
 
 #endif /* CONFIG_PKVM_INTEL */

--- a/arch/x86/kvm/vmx/vmx.h
+++ b/arch/x86/kvm/vmx/vmx.h
@@ -797,6 +797,7 @@ int __init vmx_pkvm_init(void);
 PKVM_DECLARE(void, pkvm_host_vmexit_entry, (void));
 PKVM_DECLARE(void, pkvm_vmx_register_excp_handlers, (void));
 extern struct vmx_capability pkvm_sym(vmx_capability);
+extern void *pkvm_sym(pkvm_vmx_init_ops);
 
 #endif /* CONFIG_PKVM_INTEL */
 


### PR DESCRIPTION
This serial focuses on isolating the pkvm hypervisor from the host VM. Thus introduced the pkvm page table support, pkvm mmu and the host EPT.

The first 2 patches may be reorganized to the deprivilege serial after the review.