### PR TITLE
pkvm-v6.18 fixes and improvements

### DIFF
--- a/arch/x86/kvm/pkvm/mem_protect.h
+++ b/arch/x86/kvm/pkvm/mem_protect.h
@@ -75,7 +75,7 @@ enum pkvm_owner_id {
 #define PKVM_OWNER_ID_BITS		bits_per(PKVM_MAX_ID - 1)
 
 int pkvm_host_donate_hyp(unsigned long phys, unsigned long size, bool clear);
-int pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear);
+void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear);
 int pkvm_hyp_donate_host_mmio_locked(unsigned long phys, unsigned long size);
 int pkvm_host_share_hyp(unsigned long phys, unsigned long size);
 void pkvm_host_unshare_hyp(unsigned long phys, unsigned long size);

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -715,18 +715,18 @@ void pkvm_host_unshare_hyp(unsigned long phys, unsigned long size)
 {
 	unsigned long end = PAGE_ALIGN(phys + size);
 	struct pkvm_page *page;
+	int ret;
 
-	BUG_ON(size == 0);
+	if (size == 0) {
+		ret = -EINVAL;
+		goto out;
+	}
 
 	pkvm_host_mmu_lock();
 
-	/*
-	 * The input range [phys, phys + size) is from the pKVM hypervisor which
-	 * is a trusted source, and suppose the pKVM hypervisor will only unshare
-	 * a memory range which was shared via pkvm_host_share_hyp(), thus the
-	 * page states should be shared-owned. Otherwise it means a pKVM bug.
-	 */
-	BUG_ON(check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_OWNED));
+	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_OWNED);
+	if (ret)
+		goto unlock;
 
 	for (phys = PAGE_ALIGN_DOWN(phys); phys < end; phys += PAGE_SIZE) {
 		page = pkvm_phys_to_page(phys);
@@ -744,6 +744,14 @@ void pkvm_host_unshare_hyp(unsigned long phys, unsigned long size)
 
 		page->host_state = PKVM_PAGE_OWNED;
 	}
-
+unlock:
 	pkvm_host_mmu_unlock();
+out:
+	/*
+	 * pkvm_host_unshare_hyp() is only used by the pKVM hypervisor itself,
+	 * not on the host behalf, so it is supposed to be called with correct
+	 * parameters, and only for pages that are known to be shared with the
+	 * hypervisor. So any error here means a pKVM bug.
+	 */
+	BUG_ON(ret);
 }

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -538,18 +538,18 @@ unlock:
  * permission and WB memory type in the host mmu, with the page states being
  * updated to PKVM_PAGE_OWNED to indicate the ownership has been transferred to
  * the host.
- *
- * Returns: 0 on success, or a negative error code on failure.
  */
-int pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
+void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
 {
 	u64 prot = host_mmu.pgt_ops->calc_pte_perm(true, true, true) |
 		   host_mmu.pgt_ops->calc_pte_memtype(false);
 	void *va = __pkvm_va(phys);
 	int ret;
 
-	if (!PAGE_ALIGNED(phys) || !PAGE_ALIGNED(size) || size == 0)
-		return -EINVAL;
+	if (!PAGE_ALIGNED(phys) || !PAGE_ALIGNED(size) || size == 0) {
+		ret = -EINVAL;
+		goto out;
+	}
 
 	if (clear)
 		pkvm_clear_memory(va, size);
@@ -578,8 +578,14 @@ int pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
 	set_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED);
 unlock:
 	pkvm_host_mmu_unlock();
-
-	return ret;
+out:
+	/*
+	 * pkvm_hyp_donate_host() is only used by the pKVM hypervisor itself,
+	 * not on the host behalf, so it is supposed to be called with correct
+	 * parameters, and only for pages that are known to be owned by the
+	 * hypervisor. So any error here means a pKVM bug.
+	 */
+	BUG_ON(ret);
 }
 
 /**

--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -8603,12 +8603,14 @@ void vmx_vm_destroy(struct kvm *kvm)
 #ifndef __PKVM_HYP__
 	free_pages((unsigned long)kvm_vmx->pid_table, vmx_get_pid_table_order(kvm));
 #else
-	/*
-	 * No need to clear the pid_table as its contents is following the SDM
-	 * which is not a secret.
-	 */
-	pkvm_hyp_donate_host(__pkvm_pa(kvm_vmx->pid_table),
-			     PAGE_SIZE << vmx_get_pid_table_order(kvm), false);
+	if (kvm_vmx->pid_table) {
+		/*
+		 * No need to clear the pid_table as its contents is following the SDM
+		 * which is not a secret.
+		 */
+		pkvm_hyp_donate_host(__pkvm_pa(kvm_vmx->pid_table),
+				     PAGE_SIZE << vmx_get_pid_table_order(kvm), false);
+	}
 #endif
 }
 


### PR DESCRIPTION
- Make pkvm_hyp_donate_host() void and let it BUG_ON in case of any error, similarly to pkvm_host_unshare_hyp(), to facilitate catching bugs with incorrect usage of pkvm_hyp_donate_host() in pKVM code.
- Fix one such bug: when IPIv is disabled, pid_table is not allocated and not donated to pKVM, but we still try to undonate it when destroying the VM.