### PR TITLE
pkvm-v6.18: Fix worst-case calculation in __pkvm_pgtable_max_pages()

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -262,6 +262,16 @@ static inline unsigned long __pkvm_pgtable_max_pages(unsigned long nr_pages)
 		total += nr_pages;
 	}
 
+	/*
+	 * For each level except the last one, may need an extra page table
+	 * if the VA range is not aligned to the next level's page size.
+	 * For example, range [0x1ff000, 0x201000) consists of just two
+	 * 4K pages, however, not one but two page tables at the first
+	 * level are required for mapping this range, since it crosses the
+	 * 2M boundary.
+	 */
+	total += PKVM_PGTABLE_MAX_LEVELS - 1;
+
 	return total;
 }
 


### PR DESCRIPTION
Another small fix to pKVM-v6.18 branch.