### PR TITLE
pKVM: x86: Add KVM_X86_SW_PROTECTED_VM as supported vm_types in pKVM

### DIFF
--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -542,6 +542,8 @@ int pkvm_x86_vendor_init(struct kvm_x86_init_ops *ops)
 
 	kvm_caps.supported_vm_types = BIT(KVM_X86_DEFAULT_VM) |
 				      BIT(KVM_X86_PKVM_PROTECTED_VM);
+	if (IS_ENABLED(CONFIG_KVM_SW_PROTECTED_VM))
+		kvm_caps.supported_vm_types |= BIT(KVM_X86_SW_PROTECTED_VM);
 	kvm_caps.supported_mce_cap = MCG_CTL_P | MCG_SER_P;
 
 	if (boot_cpu_has(X86_FEATURE_XSAVE)) {


### PR DESCRIPTION
KVM_X86_SW_PROTECTED_VM is for development and testing purpose. It won't break the related path if pKVM is enabled. The host side reports this vm_type is supported, also add it to the pKVM side to make it consistent.

This also fix some kselftest failures, e.g., guest_memfd_test.