### PR TITLE
pkvm v6.18 fix MSR_CORE_PERF_GLOBAL_CTRL emulation and improve exception table sorting

### DIFF
--- a/arch/x86/kvm/pkvm/init_finalize.c
+++ b/arch/x86/kvm/pkvm/init_finalize.c
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <linux/kvm_host.h>
-#include <linux/extable.h>
 #include <asm/kvm_pkvm.h>
 #include "early_alloc.h"
 #include "fpu.h"
@@ -226,17 +225,6 @@ static int finalize_global(struct pkvm_mem_info infos[], int nr_infos,
 
 	if (!PAGE_ALIGNED(mem_base) || !mem_size)
 		return -EINVAL;
-
-	/*
-	 * The exception table is in the pKVM's rodata section. Once switch
-	 * to the pKVM's MMU, the rodata section is mapped with read-only thus
-	 * sorting the exception table cannot be done as it requires read-write
-	 * permission. So sorting the exception table with the host MMU which
-	 * still maps the pKVM's rodata section with read-write permission
-	 * before switching to the pKVM's MMU.
-	 */
-	if (&__stop___ex_table > &__start___ex_table)
-		sort_extable(__start___ex_table, __stop___ex_table);
 
 	ret = divide_memory_pool(mem_base, mem_size);
 	if (ret)

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -149,6 +149,11 @@ static int handle_write_msr(struct kvm_vcpu *vcpu)
 		struct kvm_pmu *pmu = vcpu_to_pmu(vcpu);
 		struct vcpu_vmx *vmx = to_vmx(vcpu);
 
+		if (!kvm_pmu_has_perf_global_ctrl(pmu)) {
+			ret = X86EMUL_UNHANDLEABLE;
+			break;
+		}
+
 		if (pmu->global_ctrl == val)
 			break;
 

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -190,12 +190,14 @@ static int handle_write_msr(struct kvm_vcpu *vcpu)
 		 */
 		BUG_ON(is_msr_in_bitmap_range(msr));
 
-		if (wrmsr_safe(msr, low, high)) {
-			kvm_inject_gp(vcpu, 0);
+		if (wrmsr_safe(msr, low, high))
 			ret = X86EMUL_UNHANDLEABLE;
-		}
+
 		break;
 	}
+
+	if (ret == X86EMUL_UNHANDLEABLE)
+		kvm_inject_gp(vcpu, 0);
 
 	return ret;
 }

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -3,6 +3,7 @@
 
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/extable.h>
 #include <asm/pkvm_image.h>
 #include "pkvm_constants.h"
 #include "vmx.h"
@@ -1025,6 +1026,16 @@ static __init int pkvm_host_deprivilege_cpus(struct pkvm_hyp *pkvm)
 	int cpu, ret = 0;
 
 	pkvm_sym(pkvm_vmx_register_excp_handlers)();
+
+	/*
+	 * The pKVM hypervisor's IDT will be programmed into VMCS before
+	 * deprivileging the CPU. Once deprivileging is done and the CPU
+	 * enters to the root mode, the pKVM's exception handlers should be
+	 * functional. So before that, sort pKVM's exception table to make
+	 * sure the exception fixup working as expected.
+	 */
+	if (&pkvm_sym(__stop___ex_table) > &pkvm_sym(__start___ex_table))
+		sort_extable(pkvm_sym(__start___ex_table), pkvm_sym(__stop___ex_table));
 
 	for_each_possible_cpu(cpu) {
 		ret = smp_call_function_single(cpu, pkvm_host_deprivilege_cpu, &p, 1);

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -714,7 +714,11 @@ static __init void init_guest_state_area_from_native(struct vcpu_vmx *vmx)
 
 	if (!rdmsrq_safe(MSR_CORE_PERF_GLOBAL_CTRL, &msrq)) {
 		struct kvm_pmu *pmu = vcpu_to_pmu(&vmx->vcpu);
+		union cpuid10_eax eax = {
+			.full = native_cpuid_eax(10),
+		};
 
+		pmu->version = eax.split.version_id;
 		pmu->global_ctrl = msrq;
 		vmcs_write64(GUEST_IA32_PERF_GLOBAL_CTRL, msrq);
 	}


### PR DESCRIPTION
The first two patches fixed the MSR_CORE_PERF_GLOBAL_CTRL emulation if it is not supported.

The last patch sorts the exception table before deprivileging. Previous the sorting is done during pkvm_init_finalize. As excpetion fixup doesn't rely on the initialization done by the pkvm_init_finalize, sort the exception table can be done earlier. Move it to the deprivilege phase so that the exception fixup mechanism can functional once the deprivileged is done. 