### PR TITLE
SQUASHME: pKVM: x86: Inject #GP for the host lapic emulation failure

### DIFF
--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -184,9 +184,9 @@ static int handle_write_msr(struct kvm_vcpu *vcpu)
 	}
 	case MSR_IA32_APICBASE:
 	case APIC_BASE_MSR ... APIC_BASE_MSR + 0xff:
-		if (!pkvm_lapic_msr_write(msr, val))
-			break;
-		fallthrough;
+		if (pkvm_lapic_msr_write(msr, val))
+			ret = X86EMUL_UNHANDLEABLE;
+		break;
 	default:
 		/*
 		 * The MSRs intercepted by the writing bitmap should be


### PR DESCRIPTION
Inject #GP to the host if the LAPIC emulation is failed rather than BUG_ON in the pKVM hypervisor.

Fixes: bc395be4431f ("pKVM: VMX: Intercept writing to some X2APIC MSRs")