### PR TITLE
pKVM: x86: Simplify extable support

### DIFF
--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -29,8 +29,7 @@ quiet_cmd_patch_retpoline = PATCH_RETPOLINE $@
       cmd_patch_retpoline = $(BASH) $(src)/compiling_cmds.sh patch_retpoline $< $@
 
 kernel-lib			:= ../../../../lib
-pkvm-hyp-y			+= $(kernel-lib)/sort.o $(kernel-lib)/bsearch.o \
-				   $(kernel-lib)/extable.o $(kernel-lib)/find_bit.o \
+pkvm-hyp-y			+= $(kernel-lib)/bsearch.o $(kernel-lib)/find_bit.o \
 				   $(kernel-lib)/hweight.o $(kernel-lib)/string.o \
 				   $(kernel-lib)/ctype.o
 pkvm-hyp-$(CONFIG_LIST_HARDENED) += $(kernel-lib)/list_debug.o

--- a/arch/x86/kvm/pkvm/idt.c
+++ b/arch/x86/kvm/pkvm/idt.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <linux/array_size.h>
 #include <linux/bitfield.h>
+#include <linux/bsearch.h>
 #include <linux/extable.h>
 #include <asm/processor.h>
 #include <asm/extable.h>
@@ -97,6 +98,40 @@ static bool ex_handler_msr(const struct exception_table_entry *fixup,
 		*pt_regs_nr(regs, reg) = -EIO;
 
 	return ex_handler_default(fixup, regs);
+}
+
+static inline unsigned long ex_to_insn(const struct exception_table_entry *x)
+{
+	return (unsigned long)&x->insn + x->insn;
+}
+
+static int cmp_ex_search(const void *key, const void *elt)
+{
+	const struct exception_table_entry *_elt = elt;
+	unsigned long _key = *(unsigned long *)key;
+
+	/* avoid overflow */
+	if (_key > ex_to_insn(_elt))
+		return 1;
+	if (_key < ex_to_insn(_elt))
+		return -1;
+	return 0;
+}
+
+/*
+ * Search one exception table for an entry corresponding to the
+ * given instruction address, and return the address of the entry,
+ * or NULL if none is found.
+ * We use a binary search, and thus we assume that the table is
+ * already sorted.
+ */
+const struct exception_table_entry *
+search_extable(const struct exception_table_entry *base,
+	       const size_t num,
+	       unsigned long value)
+{
+	return bsearch(&value, base, num,
+		       sizeof(struct exception_table_entry), cmp_ex_search);
 }
 
 static bool pkvm_fixup_exception(struct pt_regs *regs)

--- a/lib/sort.c
+++ b/lib/sort.c
@@ -264,10 +264,6 @@ static void __sort_r(void *base, size_t num, size_t size,
 			do_swap(base + b, base + c, size, swap_func, priv);
 		}
 
-#ifndef __PKVM_HYP__
-		if (may_schedule)
-			cond_resched();
-#else
 		/*
 		 * The pKVM hypervisor runs in the interrupt disabled context
 		 * and doesn't own scheduling. It doesn't have a capability to
@@ -275,7 +271,6 @@ static void __sort_r(void *base, size_t num, size_t size,
 		 * so just warn on for this case.
 		 */
 		WARN_ON_ONCE(may_schedule);
-#endif
 	}
 
 	n -= size;


### PR DESCRIPTION
We don't sort pKVM's extable on the hypervisor side anymore (we do that on the host side before deprivileging). So we don't need to compile `lib/sort.c` into the hypervisor code, and thus also can avoid making pKVM-specific changes to `lib/sort.c`.

Also this means that only a small part of `lib/extable.c` is used by the hypervisor, so it's easier to copy that small part, instead of pulling in the entire `lib/extable.c`.