### PR TITLE
pviommu initialization patches

### DIFF
--- a/arch/x86/include/asm/kvm_host.h
+++ b/arch/x86/include/asm/kvm_host.h
@@ -2173,8 +2173,17 @@ void pkvm_create_vm_debugfs(struct kvm *kvm);
 int pkvm_vm_ioctl_enable_cap(struct kvm *kvm, struct kvm_enable_cap *cap);
 int kvm_topup_pkvm_memcache(struct pkvm_memcache *mc, unsigned long min_pages);
 void kvm_free_pkvm_memcache(struct pkvm_memcache *mc);
+
+DECLARE_STATIC_KEY_FALSE(pkvm_enabled_key);
+
+static inline bool pkvm_enabled(void)
+{
+	return static_branch_likely(&pkvm_enabled_key);
+}
 #else
 #define enable_pkvm		false
+static inline bool pkvm_enabled(void) { return false; }
+
 static inline void __init pkvm_reserve(void) {}
 static inline void pkvm_create_vm_debugfs(struct kvm *kvm) {}
 static inline int pkvm_vm_ioctl_enable_cap(struct kvm *kvm, struct kvm_enable_cap *cap)

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -140,17 +140,23 @@ static_assert(sizeof(union pkvm_hc_data) == PKVM_HC_DATA_MAX_NUM * sizeof(u64));
 
 #define PKVM_HC_DATA_NUM(f)		\
 	(ALIGN(sizeof(((union pkvm_hc_data *)0)->f), sizeof(u64)) / sizeof(u64))
+#define PKVM_HC_DATA_OUT_NUM(f)		\
+	(ALIGN(sizeof(((union pkvm_hc_data *)0)->f.out), sizeof(u64)) / sizeof(u64))
+#define PKVM_HC_DATA_IN_NUM(f)		\
+	(ALIGN(sizeof(((union pkvm_hc_data *)0)->f.in), sizeof(u64)) / sizeof(u64))
 
 #define PKVM_HC_OUTPUT_NUM(f)	f##_output_num
 #define PKVM_HC_INPUT_NUM(f)	f##_input_num
 
 enum {
-	#define PKVM_HC(f)	PKVM_HC_OUTPUT_NUM(f) = 0,
-	#define PKVM_HC_OUT(f)	PKVM_HC_OUTPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC(f)		PKVM_HC_OUTPUT_NUM(f) = 0,
+	#define PKVM_HC_OUT(f)		PKVM_HC_OUTPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC_INOUT(f)	PKVM_HC_OUTPUT_NUM(f) = PKVM_HC_DATA_OUT_NUM(f),
 	#include <asm/pkvm_hypercalls.h>
 
-	#define PKVM_HC(f)	PKVM_HC_INPUT_NUM(f) = 0,
-	#define PKVM_HC_IN(f)	PKVM_HC_INPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC(f)		PKVM_HC_INPUT_NUM(f) = 0,
+	#define PKVM_HC_IN(f)		PKVM_HC_INPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC_INOUT(f)	PKVM_HC_INPUT_NUM(f) = PKVM_HC_DATA_IN_NUM(f),
 	#include <asm/pkvm_hypercalls.h>
 };
 
@@ -209,7 +215,7 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 	__pkvm_hypercall(f, NULL, 0, ##__VA_ARGS__);					\
 })
 
-#define pkvm_hypercall_out(f, o, ...)							\
+#define __pkvm_hypercall_inout(f, o, ...)						\
 	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 0,				\
 			      __pkvm_hypercall(f, NULL, 0, ##__VA_ARGS__),		\
 	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 1,				\
@@ -222,22 +228,28 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 			      __pkvm_hypercall(f, o, 4, ##__VA_ARGS__),			\
 	PKVM_HC_UNREACHABLE(f))))))
 
-#define pkvm_hypercall_in(f, i)								\
+#define pkvm_hypercall_inout(f, i, o)							\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 1,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0]),		\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0]),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 2,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0],		\
-					       (i)->raw.data[1]),			\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
+						     (i)->raw.data[1]),			\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 3,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0],		\
-					       (i)->raw.data[1],			\
-					       (i)->raw.data[2]),			\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
+						     (i)->raw.data[1],			\
+						     (i)->raw.data[2]),			\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 4,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0],		\
-					       (i)->raw.data[1],			\
-					       (i)->raw.data[2],			\
-					       (i)->raw.data[3]),			\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
+						     (i)->raw.data[1],			\
+						     (i)->raw.data[2],			\
+						     (i)->raw.data[3]),			\
 	PKVM_HC_UNREACHABLE(f)))))
+
+#define pkvm_hypercall_out(f, o, ...)							\
+	__pkvm_hypercall_inout(f, o, ##__VA_ARGS__)
+
+#define pkvm_hypercall_in(f, i)								\
+	pkvm_hypercall_inout(f, i, (union pkvm_hc_data *)NULL)
 
 static inline unsigned long pkvm_hc(struct kvm_vcpu *vcpu)
 {

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -61,7 +61,7 @@ enum pkvm_hc {
 	MAX_PKVM_HYPERCALLS,
 };
 
-#define PKVM_HC_DATA_MAX_NUM		4
+#define PKVM_HC_DATA_MAX_NUM		10
 
 union pkvm_hc_data {
 	struct {
@@ -180,22 +180,103 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 	}
 }
 
-#define PKVM_HC_IN_0()
-#define PKVM_HC_IN_1(a1)		, "b"((unsigned long)a1)
-#define PKVM_HC_IN_2(a1, a2)		PKVM_HC_IN_1(a1), "c"((unsigned long)a2)
-#define PKVM_HC_IN_3(a1, a2, a3)	PKVM_HC_IN_2(a1, a2), "d"((unsigned long)a3)
-#define PKVM_HC_IN_4(a1, a2, a3, a4)	PKVM_HC_IN_3(a1, a2, a3), "S"((unsigned long)a4)
+#define IN_ARG_0()
+#define IN_ARG_1(a1, ...)						(unsigned long)a1
+#define IN_ARG_2(a1, a2, ...)						(unsigned long)a2
+#define IN_ARG_3(a1, a2, a3, ...)					(unsigned long)a3
+#define IN_ARG_4(a1, a2, a3, a4, ...)					(unsigned long)a4
+#define IN_ARG_5(a1, a2, a3, a4, a5, ...)				(unsigned long)a5
+#define IN_ARG_6(a1, a2, a3, a4, a5, a6, ...)				(unsigned long)a6
+#define IN_ARG_7(a1, a2, a3, a4, a5, a6, a7, ...)			(unsigned long)a7
+#define IN_ARG_8(a1, a2, a3, a4, a5, a6, a7, a8, ...)			(unsigned long)a8
+#define IN_ARG_9(a1, a2, a3, a4, a5, a6, a7, a8, a9, ...)		(unsigned long)a9
+#define IN_ARG_10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, ...)		(unsigned long)a10
+
+#define PKVM_HC_DECLARE_IN_0(...)
+#define PKVM_HC_DECLARE_IN_1(...)
+#define PKVM_HC_DECLARE_IN_2(...)
+#define PKVM_HC_DECLARE_IN_3(...)
+#define PKVM_HC_DECLARE_IN_4(...)
+#define PKVM_HC_DECLARE_IN_5(...)
+#define PKVM_HC_DECLARE_IN_6(...)	register unsigned long r8_in asm("r8") = 	\
+								IN_ARG_6(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_7(...)	PKVM_HC_DECLARE_IN_6(__VA_ARGS__);		\
+					register unsigned long r9_in asm("r9") = 	\
+								IN_ARG_7(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_8(...)	PKVM_HC_DECLARE_IN_7(__VA_ARGS__);		\
+					register unsigned long r10_in asm("r10") = 	\
+								IN_ARG_8(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_9(...)	PKVM_HC_DECLARE_IN_8(__VA_ARGS__);		\
+					register unsigned long r11_in asm("r11") = 	\
+								IN_ARG_9(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_10(...)	PKVM_HC_DECLARE_IN_9(__VA_ARGS__);		\
+					register unsigned long r12_in asm("r12") = 	\
+								IN_ARG_10(__VA_ARGS__)
+
+#define PKVM_HC_IN_0(...)
+#define PKVM_HC_IN_1(...)		, "b"(IN_ARG_1(__VA_ARGS__))
+#define PKVM_HC_IN_2(...)		PKVM_HC_IN_1(__VA_ARGS__), "c"(IN_ARG_2(__VA_ARGS__))
+#define PKVM_HC_IN_3(...)		PKVM_HC_IN_2(__VA_ARGS__), "d"(IN_ARG_3(__VA_ARGS__))
+#define PKVM_HC_IN_4(...)		PKVM_HC_IN_3(__VA_ARGS__), "S"(IN_ARG_4(__VA_ARGS__))
+#define PKVM_HC_IN_5(...)		PKVM_HC_IN_4(__VA_ARGS__), "D"(IN_ARG_5(__VA_ARGS__))
+#define PKVM_HC_IN_6(...)		PKVM_HC_IN_5(__VA_ARGS__), "r" (r8_in)
+#define PKVM_HC_IN_7(...)		PKVM_HC_IN_6(__VA_ARGS__), "r" (r9_in)
+#define PKVM_HC_IN_8(...)		PKVM_HC_IN_7(__VA_ARGS__), "r" (r10_in)
+#define PKVM_HC_IN_9(...)		PKVM_HC_IN_8(__VA_ARGS__), "r" (r11_in)
+#define PKVM_HC_IN_10(...)		PKVM_HC_IN_9(__VA_ARGS__), "r" (r12_in)
+
+#define PKVM_HC_DECLARE_OUT_0
+#define PKVM_HC_DECLARE_OUT_1
+#define PKVM_HC_DECLARE_OUT_2
+#define PKVM_HC_DECLARE_OUT_3
+#define PKVM_HC_DECLARE_OUT_4
+#define PKVM_HC_DECLARE_OUT_5
+#define PKVM_HC_DECLARE_OUT_6		register unsigned long r8_out asm("r8")
+#define PKVM_HC_DECLARE_OUT_7		PKVM_HC_DECLARE_OUT_6;				\
+					register unsigned long r9_out asm("r9")
+#define PKVM_HC_DECLARE_OUT_8		PKVM_HC_DECLARE_OUT_7;				\
+					register unsigned long r10_out asm("r10")
+#define PKVM_HC_DECLARE_OUT_9		PKVM_HC_DECLARE_OUT_8;				\
+					register unsigned long r11_out asm("r11")
+#define PKVM_HC_DECLARE_OUT_10		PKVM_HC_DECLARE_OUT_9;				\
+					register unsigned long r12_out asm("r12")
+
+#define PKVM_HC_OUT_INSN_0
+#define PKVM_HC_OUT_INSN_1
+#define PKVM_HC_OUT_INSN_2
+#define PKVM_HC_OUT_INSN_3
+#define PKVM_HC_OUT_INSN_4
+#define PKVM_HC_OUT_INSN_5
+#define PKVM_HC_OUT_INSN_6		"movq %%r8, %[out5]\n\t"
+#define PKVM_HC_OUT_INSN_7		PKVM_HC_OUT_INSN_6 "movq %%r9, %[out6]\n\t"
+#define PKVM_HC_OUT_INSN_8		PKVM_HC_OUT_INSN_7 "movq %%r10, %[out7]\n\t"
+#define PKVM_HC_OUT_INSN_9		PKVM_HC_OUT_INSN_8 "movq %%r11, %[out8]\n\t"
+#define PKVM_HC_OUT_INSN_10		PKVM_HC_OUT_INSN_9 "movq %%r12, %[out9]\n\t"
 
 #define PKVM_HC_OUT_0(o)
 #define PKVM_HC_OUT_1(o)		, "=b"((o)->raw.data[0])
 #define PKVM_HC_OUT_2(o)		PKVM_HC_OUT_1(o), "=c"((o)->raw.data[1])
 #define PKVM_HC_OUT_3(o)		PKVM_HC_OUT_2(o), "=d"((o)->raw.data[2])
 #define PKVM_HC_OUT_4(o)		PKVM_HC_OUT_3(o), "=S"((o)->raw.data[3])
+#define PKVM_HC_OUT_5(o)		PKVM_HC_OUT_4(o), "=D" ((o)->raw.data[4])
+#define PKVM_HC_OUT_6(o)		PKVM_HC_OUT_5(o), "=r"(r8_out),			\
+					[out5] "=m" ((o)->raw.data[5])
+#define PKVM_HC_OUT_7(o)		PKVM_HC_OUT_6(o), "=r"(r9_out),			\
+					[out6] "=m" ((o)->raw.data[6])
+#define PKVM_HC_OUT_8(o)		PKVM_HC_OUT_7(o), "=r"(r10_out),		\
+					[out7] "=m" ((o)->raw.data[7])
+#define PKVM_HC_OUT_9(o)		PKVM_HC_OUT_8(o), "=r"(r11_out),		\
+					[out8] "=m" ((o)->raw.data[8])
+#define PKVM_HC_OUT_10(o)		PKVM_HC_OUT_9(o), "=r"(r12_out),		\
+					[out9] "=m" ((o)->raw.data[9])
 
 #define __pkvm_hypercall(f, o, n, ...)							\
 ({											\
+	CONCATENATE(PKVM_HC_DECLARE_IN_, COUNT_ARGS(__VA_ARGS__))(__VA_ARGS__);		\
+	CONCATENATE(PKVM_HC_DECLARE_OUT_, n);						\
 	int ret;									\
 	asm volatile(KVM_HYPERCALL							\
+		     PKVM_HC_OUT_INSN_##n						\
 		     : "=a"(ret) CONCATENATE(PKVM_HC_OUT_, n)(o)			\
 		     : "a"(TO_PKVM_HC(f))						\
 		       CONCATENATE(PKVM_HC_IN_, COUNT_ARGS(__VA_ARGS__))(__VA_ARGS__)	\
@@ -226,24 +307,53 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 			      __pkvm_hypercall(f, o, 3, ##__VA_ARGS__),			\
 	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 4,				\
 			      __pkvm_hypercall(f, o, 4, ##__VA_ARGS__),			\
-	PKVM_HC_UNREACHABLE(f))))))
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 5,				\
+			      __pkvm_hypercall(f, o, 5, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 6,				\
+			      __pkvm_hypercall(f, o, 6, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 7,				\
+			      __pkvm_hypercall(f, o, 7, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 8,				\
+			      __pkvm_hypercall(f, o, 8, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 9,				\
+			      __pkvm_hypercall(f, o, 9, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 10,				\
+			      __pkvm_hypercall(f, o, 10, ##__VA_ARGS__),		\
+	PKVM_HC_UNREACHABLE(f))))))))))))
+
+#define INPUT_DATA_1(i)		(i)->raw.data[0]
+#define INPUT_DATA_2(i)		INPUT_DATA_1(i), (i)->raw.data[1]
+#define INPUT_DATA_3(i)		INPUT_DATA_2(i), (i)->raw.data[2]
+#define INPUT_DATA_4(i)		INPUT_DATA_3(i), (i)->raw.data[3]
+#define INPUT_DATA_5(i)		INPUT_DATA_4(i), (i)->raw.data[4]
+#define INPUT_DATA_6(i)		INPUT_DATA_5(i), (i)->raw.data[5]
+#define INPUT_DATA_7(i)		INPUT_DATA_6(i), (i)->raw.data[6]
+#define INPUT_DATA_8(i)		INPUT_DATA_7(i), (i)->raw.data[7]
+#define INPUT_DATA_9(i)		INPUT_DATA_8(i), (i)->raw.data[8]
+#define INPUT_DATA_10(i)	INPUT_DATA_9(i), (i)->raw.data[9]
 
 #define pkvm_hypercall_inout(f, i, o)							\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 1,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0]),		\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_1(i)),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 2,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
-						     (i)->raw.data[1]),			\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_2(i)),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 3,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
-						     (i)->raw.data[1],			\
-						     (i)->raw.data[2]),			\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_3(i)),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 4,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
-						     (i)->raw.data[1],			\
-						     (i)->raw.data[2],			\
-						     (i)->raw.data[3]),			\
-	PKVM_HC_UNREACHABLE(f)))))
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_4(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 5,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_5(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 6,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_6(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 7,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_7(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 8,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_8(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 9,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_9(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 10,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_10(i)),		\
+	PKVM_HC_UNREACHABLE(f)))))))))))
 
 #define pkvm_hypercall_out(f, o, ...)							\
 	__pkvm_hypercall_inout(f, o, ##__VA_ARGS__)
@@ -271,11 +381,35 @@ DEFINE_PKVM_HC_INPUT(1, RBX)
 DEFINE_PKVM_HC_INPUT(2, RCX)
 DEFINE_PKVM_HC_INPUT(3, RDX)
 DEFINE_PKVM_HC_INPUT(4, RSI)
+DEFINE_PKVM_HC_INPUT(5, RDI)
+DEFINE_PKVM_HC_INPUT(6, R8)
+DEFINE_PKVM_HC_INPUT(7, R9)
+DEFINE_PKVM_HC_INPUT(8, R10)
+DEFINE_PKVM_HC_INPUT(9, R11)
+DEFINE_PKVM_HC_INPUT(10, R12)
 
 static inline void pkvm_hc_get_input(struct kvm_vcpu *vcpu, enum pkvm_hc hc,
 				     union pkvm_hc_data *in)
 {
 	switch (pkvm_hc_input_num(hc)) {
+	case 10:
+		pkvm_hc_get_input10(vcpu, in);
+		fallthrough;
+	case 9:
+		pkvm_hc_get_input9(vcpu, in);
+		fallthrough;
+	case 8:
+		pkvm_hc_get_input8(vcpu, in);
+		fallthrough;
+	case 7:
+		pkvm_hc_get_input7(vcpu, in);
+		fallthrough;
+	case 6:
+		pkvm_hc_get_input6(vcpu, in);
+		fallthrough;
+	case 5:
+		pkvm_hc_get_input5(vcpu, in);
+		fallthrough;
 	case 4:
 		pkvm_hc_get_input4(vcpu, in);
 		fallthrough;
@@ -311,11 +445,35 @@ DEFINE_PKVM_HC_OUTPUT(1, RBX)
 DEFINE_PKVM_HC_OUTPUT(2, RCX)
 DEFINE_PKVM_HC_OUTPUT(3, RDX)
 DEFINE_PKVM_HC_OUTPUT(4, RSI)
+DEFINE_PKVM_HC_OUTPUT(5, RDI)
+DEFINE_PKVM_HC_OUTPUT(6, R8)
+DEFINE_PKVM_HC_OUTPUT(7, R9)
+DEFINE_PKVM_HC_OUTPUT(8, R10)
+DEFINE_PKVM_HC_OUTPUT(9, R11)
+DEFINE_PKVM_HC_OUTPUT(10, R12)
 
 static inline void pkvm_hc_set_output(struct kvm_vcpu *vcpu, enum pkvm_hc hc,
 				      union pkvm_hc_data *out)
 {
 	switch (pkvm_hc_output_num(hc)) {
+	case 10:
+		pkvm_hc_set_output10(vcpu, out);
+		fallthrough;
+	case 9:
+		pkvm_hc_set_output9(vcpu, out);
+		fallthrough;
+	case 8:
+		pkvm_hc_set_output8(vcpu, out);
+		fallthrough;
+	case 7:
+		pkvm_hc_set_output7(vcpu, out);
+		fallthrough;
+	case 6:
+		pkvm_hc_set_output6(vcpu, out);
+		fallthrough;
+	case 5:
+		pkvm_hc_set_output5(vcpu, out);
+		fallthrough;
 	case 4:
 		pkvm_hc_set_output4(vcpu, out);
 		fallthrough;

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -506,6 +506,7 @@ extern pteval_t pkvm_sym(__default_kernel_pte_mask);
 #ifdef CONFIG_AMD_MEM_ENCRYPT
 extern u64 pkvm_sym(sme_me_mask);
 #endif
+extern uint16_t	pkvm_sym(__cachemode2pte_tbl)[];
 extern struct pkvm_init_ops *pkvm_sym(init_ops);
 extern struct cpumask pkvm_sym(__cpu_possible_mask);
 extern unsigned int pkvm_sym(nr_cpu_ids);

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -52,6 +52,31 @@ struct pkvm_mem_info {
 	u64 prot;
 };
 
+struct pkvm_iommu_ops {
+	/*
+	 * Common callbacks for all vendors implementations.
+	 * These hypercalls are generic in the sense that
+	 * generic IOMMU driver calls into vendor implementation
+	 * with same arguments. Even though the implementation
+	 * is in vendor code, there is no specific vendor specific
+	 * details in the API. Having it as separate callbacks
+	 * saves us one extra redirection.
+	 */
+	int (*mmio_read)(u64 phys, int len, u64 *val);
+	int (*mmio_write)(u64 phys, int len, u64 val);
+	/* TODO: domain_map() */
+	/* TODO: domain_unmap() */
+
+	/*
+	 * Vendor specific hypercall handler, that abstracts the
+	 * hypercall name arguments which might be based on the
+	 * hardware specifics of vendor IOMMU.
+	 * There is one redirection where the vendor implementation
+	 * of this callback calls into the vendor specific hypercall.
+	 */
+	int (*hypercall)(void *in, void *out);
+};
+
 #define TO_PKVM_HC(f)		CONCATENATE(__pkvm__, f)
 
 enum pkvm_hc {
@@ -126,6 +151,23 @@ union pkvm_hc_data {
 #define HOST_RESET_MMU				3
 #define HOST_APF_READY				4
 	} vcpu_run;
+	struct {
+		u64 val;
+	} iommu_mmio_read;
+	/*
+	 * Use the maximum supported size for iommu hypercall
+	 * Vendor specific iommu hypercall arguments are not
+	 * exposed here and the vendor implementation casts it
+	 * to its own representation.
+	 */
+	union {
+		struct {
+			u64 data[PKVM_HC_DATA_MAX_NUM];
+		} in;
+		struct {
+			u64 data[PKVM_HC_DATA_MAX_NUM];
+		} out;
+	} iommu_hypercall;
 	struct {
 		u64 data[PKVM_HC_DATA_MAX_NUM];
 	} raw;
@@ -733,6 +775,8 @@ static inline size_t pkvm_guest_initial_fpstate_size(struct kvm *kvm)
 
 #undef KVM_BUG
 #define KVM_BUG(cond, kvm, fmt...)		KVM_BUG_ON(cond, kvm)
+
+void pkvm_register_iommu_ops(struct pkvm_iommu_ops *ops);
 
 #endif /* __PKVM_HYP__ */
 

--- a/arch/x86/include/asm/pkvm_hypercalls.h
+++ b/arch/x86/include/asm/pkvm_hypercalls.h
@@ -11,6 +11,10 @@ BUILD_BUG_ON(1)
 #define PKVM_HC_IN PKVM_HC
 #endif
 
+#ifndef PKVM_HC_INOUT
+#define PKVM_HC_INOUT PKVM_HC
+#endif
+
 /* Hypercalls used only during pKVM initialization */
 PKVM_HC(init)
 PKVM_HC(init_finalize)
@@ -88,3 +92,4 @@ PKVM_HC(vm_mmu_age)
 #undef PKVM_HC
 #undef PKVM_HC_OUT
 #undef PKVM_HC_IN
+#undef PKVM_HC_INOUT

--- a/arch/x86/include/asm/pkvm_hypercalls.h
+++ b/arch/x86/include/asm/pkvm_hypercalls.h
@@ -89,6 +89,11 @@ PKVM_HC(vm_mmu_map)
 PKVM_HC(vm_mmu_unmap)
 PKVM_HC(vm_mmu_age)
 
+/* IOMMU hypercalls */
+PKVM_HC_OUT(iommu_mmio_read)
+PKVM_HC(iommu_mmio_write)
+PKVM_HC_INOUT(iommu_hypercall)
+
 #undef PKVM_HC
 #undef PKVM_HC_OUT
 #undef PKVM_HC_IN

--- a/arch/x86/include/asm/pkvm_image.h
+++ b/arch/x86/include/asm/pkvm_image.h
@@ -43,12 +43,13 @@
 
 #ifndef __ASSEMBLER__
 
+#include <asm/extable.h>
+
 #ifdef CONFIG_PKVM_X86
 extern char pkvm_sym(text_start)[], pkvm_sym(text_end)[];
 extern char pkvm_sym(rodata_start)[], pkvm_sym(rodata_end)[];
 extern char pkvm_sym(data_start)[], pkvm_sym(data_end)[];
 extern char pkvm_sym(bss_start)[], pkvm_sym(bss_end)[];
-struct exception_table_entry;
 extern struct exception_table_entry pkvm_sym(__start___ex_table)[];
 extern struct exception_table_entry pkvm_sym(__stop___ex_table)[];
 static inline bool is_pkvm_text(void *addr)

--- a/arch/x86/kvm/Kconfig
+++ b/arch/x86/kvm/Kconfig
@@ -137,6 +137,7 @@ config PKVM_X86
 config PKVM_INTEL
 	bool "pKVM for Intel processors support"
 	depends on KVM_INTEL=y
+	depends on INTEL_IOMMU
 	select PKVM_X86
 	help
 	  Provides support for pKVM on Intel processors.

--- a/arch/x86/kvm/Kconfig
+++ b/arch/x86/kvm/Kconfig
@@ -121,6 +121,7 @@ config KVM_INTEL_PROVE_VE
 
 config PKVM_X86
 	bool
+	depends on X86_64
 	depends on X86_X2APIC
 
 	help
@@ -136,7 +137,6 @@ config PKVM_X86
 config PKVM_INTEL
 	bool "pKVM for Intel processors support"
 	depends on KVM_INTEL=y
-	depends on X86_64
 	select PKVM_X86
 	help
 	  Provides support for pKVM on Intel processors.

--- a/arch/x86/kvm/Makefile
+++ b/arch/x86/kvm/Makefile
@@ -47,6 +47,9 @@ $(obj)/kvm-asm-offsets.h: $(obj)/kvm-asm-offsets.s FORCE
 
 pkvm-intel-$(CONFIG_PKVM_INTEL)	+= vmx/pkvm_init.o vmx/pkvm_host.o
 
+ccflags-$(CONFIG_PKVM_INTEL) += -I $(srctree)/drivers/iommu/intel
+pkvm-intel-$(CONFIG_PKVM_INTEL)	+= ../../../drivers/iommu/intel/pkvm_iommu.o
+
 $(obj)/vmx/pkvm_init.o: $(obj)/pkvm_constants.h
 $(obj)/vmx/pkvm_host.o: $(obj)/pkvm_constants.h
 

--- a/arch/x86/kvm/pkvm.c
+++ b/arch/x86/kvm/pkvm.c
@@ -5,7 +5,11 @@
 #include <linux/sort.h>
 #include <asm/kvm_pkvm.h>
 
+/* Kernel command-line parameter */
 bool __read_mostly enable_pkvm;
+
+/* Flag denoting pKVM successfully initialized */
+DEFINE_STATIC_KEY_FALSE(pkvm_enabled_key);
 
 static struct memblock_region *pkvm_memory = pkvm_sym(pkvm_memory);
 static unsigned int pkvm_memblock_nr;

--- a/arch/x86/kvm/pkvm/Makefile
+++ b/arch/x86/kvm/pkvm/Makefile
@@ -51,6 +51,8 @@ $(obj)/$(kvm)/vmx/vmenter.pkvm.o: $(obj)/kvm-asm-offsets.h
 fpu				:= ../../kernel/fpu
 pkvm-hyp-y			+= $(fpu)/core.o $(fpu)/xstate.o
 
+include $(srctree)/drivers/iommu/intel/pkvm/Makefile.pkvm
+
 pkvm-obj 			:= $(patsubst %.o,%.pkvm.o,$(pkvm-hyp-y))
 obj-$(CONFIG_PKVM_X86)		+= pkvm.o
 

--- a/arch/x86/kvm/pkvm/debug.h
+++ b/arch/x86/kvm/pkvm/debug.h
@@ -7,5 +7,13 @@
 #define pkvm_err(f, x...)		pr_err("pkvm [CPU%d]: " f, raw_smp_processor_id(), ## x)
 #define pkvm_err_ratelimited(f, x...)	pr_err_ratelimited("pkvm [CPU%d]: " f, \
 							   raw_smp_processor_id(), ## x)
+#define pkvm_warn(f, x...)		pr_warn("pkvm [CPU%d]: " f, raw_smp_processor_id(), ## x)
+#define pkvm_info(f, x...)		pr_info("pkvm [CPU%d]: " f, raw_smp_processor_id(), ## x)
+
+#ifdef CONFIG_PKVM_X86_DEBUG
+#define pkvm_dbg(f, x...)		pr_debug("pkvm [CPU%d]: " f, raw_smp_processor_id(), ## x)
+#else
+#define pkvm_dbg(f, x...)		no_printk(KERN_DEBUG pr_fmt(f), ## x)
+#endif
 
 #endif /* __PKVM_X86_DEBUG_H */

--- a/arch/x86/kvm/pkvm/init.c
+++ b/arch/x86/kvm/pkvm/init.c
@@ -216,6 +216,7 @@ static int create_host_mmu(const struct pkvm_mem_info infos[], int nr_infos,
 static int initialize_global(struct pkvm_mem_info infos[], int nr_infos)
 {
 	host_mmu_init_fn_t host_mmu_init_fn = init_ops ? init_ops->host_mmu_init : NULL;
+	hyp_iommu_init_fn_t hyp_iommu_init = init_ops ? init_ops->hyp_iommu_init : NULL;
 	hyp_global_init_fn_t hyp_global_init = init_ops ? init_ops->hyp_global_init : NULL;
 	struct pkvm_mem_info tmp_infos[TMP_NR_INFOS];
 	phys_addr_t mem_base = INVALID_PAGE;
@@ -264,6 +265,12 @@ static int initialize_global(struct pkvm_mem_info infos[], int nr_infos)
 	 * guest VMs.
 	 */
 	kvm_init_xstate_sizes();
+
+	if (hyp_iommu_init) {
+		ret = hyp_iommu_init();
+		if (ret)
+			return ret;
+	}
 
 	return hyp_global_init ? hyp_global_init() : 0;
 }

--- a/arch/x86/kvm/pkvm/init.h
+++ b/arch/x86/kvm/pkvm/init.h
@@ -9,6 +9,7 @@ typedef int (*hyp_mmu_finalize_fn_t)(struct pkvm_pgtable *pgt);
 typedef int (*host_mmu_init_fn_t)(struct pkvm_pgtable *pgt, void *pool_base,
 				  unsigned long pool_pages);
 typedef int (*host_mmu_finalize_fn_t)(struct pkvm_pgtable *pgt);
+typedef int (*hyp_iommu_init_fn_t)(void);
 typedef int (*hyp_global_init_fn_t)(void);
 typedef void (*reprivilege_cpu_fn_t)(unsigned long *vcpu_regs);
 
@@ -28,6 +29,7 @@ struct pkvm_init_ops {
 	hyp_mmu_finalize_fn_t		hyp_mmu_finalize;
 	host_mmu_init_fn_t		host_mmu_init;
 	host_mmu_finalize_fn_t		host_mmu_finalize;
+	hyp_iommu_init_fn_t		hyp_iommu_init;
 	hyp_global_init_fn_t		hyp_global_init;
 	reprivilege_cpu_fn_t		reprivilege_cpu;
 };

--- a/arch/x86/kvm/pkvm/mem_protect.h
+++ b/arch/x86/kvm/pkvm/mem_protect.h
@@ -77,6 +77,8 @@ enum pkvm_owner_id {
 #define PKVM_OWNER_ID_BITS		bits_per(PKVM_MAX_ID - 1)
 
 int pkvm_host_donate_hyp(unsigned long phys, unsigned long size, bool clear);
+int pkvm_host_donate_hyp_share_ro(unsigned long phys, unsigned long size,
+				  bool clear);
 void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear);
 int pkvm_hyp_donate_host_mmio_locked(unsigned long phys, unsigned long size);
 int pkvm_host_share_hyp(unsigned long phys, unsigned long size);

--- a/arch/x86/kvm/pkvm/mem_protect.h
+++ b/arch/x86/kvm/pkvm/mem_protect.h
@@ -80,6 +80,7 @@ int pkvm_host_donate_hyp(unsigned long phys, unsigned long size, bool clear);
 int pkvm_host_donate_hyp_share_ro(unsigned long phys, unsigned long size,
 				  bool clear);
 void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear);
+int pkvm_host_donate_hyp_mmio(unsigned long phys, unsigned long size);
 int pkvm_hyp_donate_host_mmio_locked(unsigned long phys, unsigned long size);
 int pkvm_host_share_hyp(unsigned long phys, unsigned long size);
 void pkvm_host_unshare_hyp(unsigned long phys, unsigned long size);

--- a/arch/x86/kvm/pkvm/memory.c
+++ b/arch/x86/kvm/pkvm/memory.c
@@ -14,6 +14,25 @@ pteval_t __default_kernel_pte_mask;
 u64 sme_me_mask;
 #endif
 
+/*
+ * Copied from arch/x86/mm/init.c: __cachemode2pte_tbl
+ * Needed for PAGE_KERNEL_IO_NOCACHE which is used for
+ * mapping MMIO space.
+ *
+ * Static values are not filled here. Host updates its
+ * copy during early boot and the updated values are
+ * copied during pKVM initialization.
+ */
+uint16_t __cachemode2pte_tbl[_PAGE_CACHE_MODE_NUM];
+
+/* Copied from arch/x86/mm/init.c: cachemode2protval */
+unsigned long cachemode2protval(enum page_cache_mode pcm)
+{
+	if (likely(pcm == 0))
+		return 0;
+	return __cachemode2pte_tbl[pcm];
+}
+
 struct memblock_region pkvm_memory[PKVM_MEMBLOCK_REGIONS];
 unsigned int pkvm_memblock_nr;
 

--- a/arch/x86/kvm/pkvm/memory.c
+++ b/arch/x86/kvm/pkvm/memory.c
@@ -80,7 +80,8 @@ bool pkvm_find_addr_range(unsigned long phys, struct range *range)
 	return false;
 }
 
-static void pkvm_clflush_cache_range_opt(void *vaddr, unsigned int size)
+/* Copied from arch/x86/mm/pat/set_memory.c: clflush_cache_range_opt() */
+static void clflush_cache_range_opt(void *vaddr, unsigned int size)
 {
 	const unsigned long clflush_size = boot_cpu_data.x86_clflush_size;
 	void *p = (void *)((unsigned long)vaddr & ~(clflush_size - 1));
@@ -93,9 +94,9 @@ static void pkvm_clflush_cache_range_opt(void *vaddr, unsigned int size)
 		clflushopt(p);
 }
 
+/* Copied from arch/x86/mm/pat/set_memory.c: clflush_cache_range() */
 /**
- * pkvm_clflush_cache_range - flush a cache range with clflush
- * which is implemented refer to clflush_cache_range() in kernel.
+ * clflush_cache_range - flush a cache range with clflush
  *
  * @vaddr:	virtual start address
  * @size:	number of bytes to flush
@@ -103,10 +104,10 @@ static void pkvm_clflush_cache_range_opt(void *vaddr, unsigned int size)
  * CLFLUSHOPT is an unordered instruction which needs fencing with MFENCE or
  * SFENCE to avoid ordering issues.
  */
-void pkvm_clflush_cache_range(void *vaddr, unsigned int size)
+void clflush_cache_range(void *vaddr, unsigned int size)
 {
 	mb();
-	pkvm_clflush_cache_range_opt(vaddr, size);
+	clflush_cache_range_opt(vaddr, size);
 	mb();
 }
 

--- a/arch/x86/kvm/pkvm/memory.h
+++ b/arch/x86/kvm/pkvm/memory.h
@@ -19,7 +19,9 @@ struct pkvm_page {
 	u8 order;
 
 	/* Store host memory page state. */
-	enum pkvm_page_state host_state: 8;
+	enum pkvm_page_state host_state: 4;
+	/* Store page owner id. */
+	enum pkvm_owner_id owner: 4;
 
 	/* Tracks how many times the page is shared with pKVM. */
 	u16 host_share_hyp_count;

--- a/arch/x86/kvm/pkvm/memory.h
+++ b/arch/x86/kvm/pkvm/memory.h
@@ -150,7 +150,7 @@ static inline void *kern_pkvm_va(void *va)
 	return va;
 }
 
-void pkvm_clflush_cache_range(void *vaddr, unsigned int size);
+void clflush_cache_range(void *vaddr, unsigned int size);
 
 static inline void pkvm_clear_memory(void *va, size_t size)
 {
@@ -159,7 +159,7 @@ static inline void pkvm_clear_memory(void *va, size_t size)
 	 * Flush CPU cache to ensure clearing the memory range in RAM, so that
 	 * the previous contents cannot be read via non-coherent DMA.
 	 */
-	pkvm_clflush_cache_range(va, size);
+	clflush_cache_range(va, size);
 }
 
 static inline void *pkvm_phys_to_virt(phys_addr_t phys)

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -1134,6 +1134,49 @@ out:
 }
 
 /**
+ * pkvm_host_donate_hyp_mmio() - Donate MMIO pages from host to hypervisor
+ * @phys:	Physical address of the MMIO region to donate.
+ * @size:	Size of the MMIO region to donate.
+ *
+ * This operation transfers ownership of the MMIO pages in range
+ * [@phys, @phys + @size) from the host to the hypervisor thereby revoking host
+ * access.
+ * @phys and @size are required to be PAGE_SIZE aligned (@size is also required
+ * to be non-zeroed value) to make sure the caller is aware that only PAGE_SIZE
+ * aligned memory range can be donated.
+ *
+ * NOTE: Unlike the memory donation APIs, this API doesn't check the current
+ * ownership of the MMIO pages, i.e. doesn't check if they are already owned
+ * by the host with PKVM_PAGE_OWNED state before donating them to the hypervisor.
+ * This is ok for now, so long as pKVM does not support device assignment so
+ * there is no guest MMIO, i.e. MMIO pages may only be either exclusively owned
+ * by the host or exclusively owned by the hypervisor, not donated to guests or
+ * shared with guests
+ * NOTE: This API doesn't map the MMIO space in hyp mmu and expects the caller
+ * to do that before calling this API.
+ *
+ * Returns: 0 on success, or a negative error code on failure.
+ */
+int pkvm_host_donate_hyp_mmio(unsigned long phys, unsigned long size)
+{
+	int ret;
+
+	if (!PAGE_ALIGNED(phys) || !PAGE_ALIGNED(size) || size == 0)
+		return -EINVAL;
+
+	if (!is_mmio_range(phys, size))
+		return -EINVAL;
+
+	pkvm_host_mmu_lock();
+
+	/* The vaddr == phys for the host MMU. */
+	ret = pkvm_pgtable_set_owner(&host_mmu, phys, size, PKVM_ID_HYP);
+
+	pkvm_host_mmu_unlock();
+	return ret;
+}
+
+/**
  * pkvm_hyp_donate_host_mmio_locked() - Donate MMIO pages from hypervisor to
  *					host with the host mmu already locked
  *					by the caller.

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -195,20 +195,26 @@ static int fix_hyp_mmu_page_refcnt(void)
 }
 
 static void set_host_mem_pgstate(unsigned long phys, unsigned long size,
-				 enum pkvm_page_state pgstate)
+				 enum pkvm_page_state state,
+				 enum pkvm_owner_id owner)
 {
-	for_each_pkvm_page(page, phys, size)
-		page->host_state = pgstate;
+	for_each_pkvm_page(page, phys, size) {
+		page->host_state = state;
+		page->owner = owner;
+	}
 }
 
 static int check_host_mem_pgstate(unsigned long phys, unsigned long size,
-				  enum pkvm_page_state pgstate)
+				  enum pkvm_page_state state,
+				  enum pkvm_owner_id owner)
 {
 	if (!is_memory_range(phys, size))
 		return -EINVAL;
 
 	for_each_pkvm_page(page, phys, size) {
-		if (page->host_state != pgstate)
+		if (page->host_state != state)
+			return -EPERM;
+		if (page->owner != owner)
 			return -EPERM;
 	}
 
@@ -241,22 +247,6 @@ static int check_page_ownership_walker(struct pkvm_pgtable_visit_ctx *ctx,
 		return -EPERM;
 
 	return 0;
-}
-
-static int check_page_owner(struct pkvm_pgtable *pgt, unsigned long vaddr,
-			    unsigned long size, const enum pkvm_owner_id expected_owner)
-{
-	struct page_ownership expected_ownership = {
-		.owner = &expected_owner,
-		.state = NULL,
-	};
-	struct pkvm_pgtable_walker walker = {
-		.cb = check_page_ownership_walker,
-		.arg = &expected_ownership,
-		.walk_flags = PKVM_PGTABLE_WALK_LEAF,
-	};
-
-	return pkvm_pgtable_walk(pgt, vaddr, size, &walker);
 }
 
 static int check_page_state(struct pkvm_pgtable *pgt, unsigned long vaddr,
@@ -328,7 +318,7 @@ static int fix_host_mmu_pgstate_walker(struct pkvm_pgtable_visit_ctx *ctx,
 			 * it is a code bug.
 			 */
 			BUG_ON(!is_memory_range(phys, size));
-			set_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED);
+			set_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED, PKVM_ID_HOST);
 		}
 	} else {
 		/*
@@ -515,8 +505,8 @@ static int host_reclaim_guest_walker(struct pkvm_pgtable_visit_ctx *ctx,
 	switch (pkvm_pte_pgstate(ctx->pgt, ptep)) {
 	case PKVM_PAGE_OWNED:
 		BUG_ON(!pkvm_is_protected_vm(kvm));
-		BUG_ON(check_host_mem_pgstate(phys, size, PKVM_PAGE_NONE));
-		BUG_ON(check_page_owner(&host_mmu, phys, size, PKVM_ID_GUEST));
+		BUG_ON(check_host_mem_pgstate(phys, size, PKVM_PAGE_NONE,
+					      PKVM_ID_GUEST));
 		/*
 		 * This must be a protected VM's page. Clear its contents
 		 * before returning it to host.
@@ -525,7 +515,8 @@ static int host_reclaim_guest_walker(struct pkvm_pgtable_visit_ctx *ctx,
 		break;
 	case PKVM_PAGE_SHARED_OWNED:
 		BUG_ON(!pkvm_is_protected_vm(kvm));
-		BUG_ON(check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_BORROWED));
+		BUG_ON(check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_BORROWED,
+					      PKVM_ID_GUEST));
 		/*
 		 * Still must be a protected VM's page, but already shared
 		 * with the host => no need to clear.
@@ -533,7 +524,8 @@ static int host_reclaim_guest_walker(struct pkvm_pgtable_visit_ctx *ctx,
 		break;
 	case PKVM_PAGE_SHARED_BORROWED:
 		BUG_ON(pkvm_is_protected_vm(kvm));
-		BUG_ON(check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_OWNED));
+		BUG_ON(check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_OWNED,
+					      PKVM_ID_HOST));
 		break;
 	default:
 		BUG();
@@ -552,6 +544,7 @@ static int host_reclaim_guest_walker(struct pkvm_pgtable_visit_ctx *ctx,
 			BUG_ON(page->host_share_guest_count);
 
 			page->host_state = PKVM_PAGE_OWNED;
+			page->owner = PKVM_ID_HOST;
 		}
 	} else {
 		for_each_pkvm_page(page, phys, size) {
@@ -632,7 +625,12 @@ static int for_each_contig_range(struct pkvm_pgtable *pgt,
 static int __check_guest_host_state(unsigned long gpa, unsigned long hpa,
 				    unsigned long size, u64 prot, void *arg)
 {
-	return check_host_mem_pgstate(hpa, size, *(enum pkvm_page_state *)arg);
+	enum pkvm_page_state host_state = *(enum pkvm_page_state *)arg;
+	enum pkvm_owner_id owner = (host_state == PKVM_PAGE_OWNED ||
+				    host_state == PKVM_PAGE_SHARED_OWNED) ?
+				   PKVM_ID_HOST : PKVM_ID_GUEST;
+
+	return check_host_mem_pgstate(hpa, size, host_state, owner);
 }
 
 static int check_guest_host_state(struct pkvm_vm *pkvm_vm,
@@ -663,6 +661,7 @@ static int __host_unshare_guest(unsigned long gpa, unsigned long hpa,
 	for_each_pkvm_page(page, hpa, size) {
 		BUG_ON(!page->host_share_guest_count);
 		BUG_ON(page->host_share_hyp_count);
+		BUG_ON(page->owner != PKVM_ID_HOST);
 
 		if (!--page->host_share_guest_count)
 			page->host_state = PKVM_PAGE_OWNED;
@@ -686,7 +685,7 @@ static int __guest_share_host(unsigned long gpa, unsigned long hpa,
 
 	BUG_ON(pkvm_pgtable_map(&host_mmu, hpa, hpa, size,
 				host_mmu_pte_prot(false), NULL));
-	set_host_mem_pgstate(hpa, size, PKVM_PAGE_SHARED_BORROWED);
+	set_host_mem_pgstate(hpa, size, PKVM_PAGE_SHARED_BORROWED, PKVM_ID_GUEST);
 
 	return 0;
 }
@@ -697,8 +696,8 @@ static int __guest_unshare_host(unsigned long gpa, unsigned long hpa,
 	struct kvm_vcpu *vcpu = arg;
 	struct pkvm_vm *pkvm_vm = to_pkvm_vcpu(vcpu)->pkvm_vm;
 
-	BUG_ON(pkvm_pgtable_set_owner(&host_mmu, hpa, size, PKVM_ID_GUEST));
-	set_host_mem_pgstate(hpa, size, PKVM_PAGE_NONE);
+	BUG_ON(pkvm_pgtable_unmap(&host_mmu, hpa, hpa, size));
+	set_host_mem_pgstate(hpa, size, PKVM_PAGE_NONE, PKVM_ID_GUEST);
 
 	prot = pkvm_pte_set_pgstate(prot, &pkvm_vm->mmu, PKVM_PAGE_OWNED);
 	return pkvm_pgtable_map(&pkvm_vm->mmu, gpa, hpa, size, prot, NULL);
@@ -981,14 +980,14 @@ int pkvm_host_donate_hyp(unsigned long phys, unsigned long size, bool clear)
 
 	pkvm_host_mmu_lock();
 
-	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED);
+	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED, PKVM_ID_HOST);
 	if (ret)
 		goto unlock;
 
 	/* The vaddr == phys for the host MMU. */
-	ret = pkvm_pgtable_set_owner(&host_mmu, phys, size, PKVM_ID_HYP);
+	ret = pkvm_pgtable_unmap(&host_mmu, phys, phys, size);
 	/*
-	 * pkvm_pgtable_set_owner() shouldn't fail here unless there is a bug.
+	 * pkvm_pgtable_unmap() shouldn't fail here unless there is a bug.
 	 * Furthermore, if it fails, it means some (maybe not all) pages in the
 	 * range remain mapped in the host mmu, whereas their state will be
 	 * changed to PKVM_PAGE_NONE below, causing an inconsistency between the
@@ -997,7 +996,7 @@ int pkvm_host_donate_hyp(unsigned long phys, unsigned long size, bool clear)
 	 */
 	BUG_ON(ret);
 
-	set_host_mem_pgstate(phys, size, PKVM_PAGE_NONE);
+	set_host_mem_pgstate(phys, size, PKVM_PAGE_NONE, PKVM_ID_HYP);
 unlock:
 	pkvm_host_mmu_unlock();
 
@@ -1045,12 +1044,7 @@ void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
 
 	pkvm_host_mmu_lock();
 
-	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_NONE);
-	if (ret)
-		goto unlock;
-
-	/* The vaddr == phys for the host MMU */
-	ret = check_page_owner(&host_mmu, phys, size, PKVM_ID_HYP);
+	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_NONE, PKVM_ID_HYP);
 	if (ret)
 		goto unlock;
 
@@ -1065,7 +1059,7 @@ void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
 	BUG_ON(ret = pkvm_pgtable_map(&host_mmu, phys, phys, size,
 				      host_mmu_pte_prot(false), NULL));
 
-	set_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED);
+	set_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED, PKVM_ID_HOST);
 unlock:
 	pkvm_host_mmu_unlock();
 out:
@@ -1146,10 +1140,12 @@ int pkvm_host_share_hyp(unsigned long phys, unsigned long size)
 	for_each_pkvm_page(page, phys, size) {
 		switch (page->host_state) {
 		case PKVM_PAGE_OWNED:
+			BUG_ON(page->owner != PKVM_ID_HOST);
 			BUG_ON(page->host_share_hyp_count);
 			BUG_ON(page->host_share_guest_count);
 			continue;
 		case PKVM_PAGE_SHARED_OWNED:
+			BUG_ON(page->owner != PKVM_ID_HOST);
 			if (page->host_share_hyp_count == U16_MAX) {
 				ret = -ENOSPC;
 				goto unlock;
@@ -1207,7 +1203,7 @@ void pkvm_host_unshare_hyp(unsigned long phys, unsigned long size)
 
 	pkvm_host_mmu_lock();
 
-	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_OWNED);
+	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_OWNED, PKVM_ID_HOST);
 	if (ret)
 		goto unlock;
 
@@ -1274,7 +1270,7 @@ int pkvm_host_donate_guest(struct kvm_vcpu *vcpu, unsigned long gpa,
 	pkvm_host_mmu_lock();
 	pkvm_guest_mmu_lock(pkvm_vm);
 
-	ret = check_host_mem_pgstate(hpa, size, PKVM_PAGE_OWNED);
+	ret = check_host_mem_pgstate(hpa, size, PKVM_PAGE_OWNED, PKVM_ID_HOST);
 	if (ret)
 		goto unlock;
 
@@ -1283,14 +1279,14 @@ int pkvm_host_donate_guest(struct kvm_vcpu *vcpu, unsigned long gpa,
 		goto unlock;
 
 	/* The vaddr == phys for the host MMU. */
-	ret = pkvm_pgtable_set_owner(&host_mmu, hpa, size, PKVM_ID_GUEST);
+	ret = pkvm_pgtable_unmap(&host_mmu, hpa, hpa, size);
 	/*
-	 * pkvm_pgtable_set_owner() shouldn't fail here unless there is a bug.
+	 * pkvm_pgtable_unmap() shouldn't fail here unless there is a bug.
 	 * See also comment in pkvm_host_donate_hyp().
 	 */
 	BUG_ON(ret);
 
-	set_host_mem_pgstate(hpa, size, PKVM_PAGE_NONE);
+	set_host_mem_pgstate(hpa, size, PKVM_PAGE_NONE, PKVM_ID_GUEST);
 
 	if (gpa_range_overlaps_pvmfw(&pkvm_vm->kvm, gpa, size, &gpa_offset,
 				     &pvmfw_offset, &load_size)) {
@@ -1367,10 +1363,12 @@ int pkvm_host_share_guest(struct kvm_vcpu *vcpu, unsigned long gpa,
 	for_each_pkvm_page(page, hpa, size) {
 		switch (page->host_state) {
 		case PKVM_PAGE_OWNED:
+			BUG_ON(page->owner != PKVM_ID_HOST);
 			BUG_ON(page->host_share_guest_count);
 			BUG_ON(page->host_share_hyp_count);
 			continue;
 		case PKVM_PAGE_SHARED_OWNED:
+			BUG_ON(page->owner != PKVM_ID_HOST);
 			if (page->host_share_guest_count == U16_MAX) {
 				ret = -ENOSPC;
 				goto unlock;

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -204,21 +204,27 @@ static void set_host_mem_pgstate(unsigned long phys, unsigned long size,
 	}
 }
 
-static int check_host_mem_pgstate(unsigned long phys, unsigned long size,
-				  enum pkvm_page_state state,
-				  enum pkvm_owner_id owner)
+static int check_host_mem_pgstate_mask(unsigned long phys, unsigned long size,
+				       u64 states, enum pkvm_owner_id owner)
 {
 	if (!is_memory_range(phys, size))
 		return -EINVAL;
 
 	for_each_pkvm_page(page, phys, size) {
-		if (page->host_state != state)
+		if (!((1 << page->host_state) & states))
 			return -EPERM;
 		if (page->owner != owner)
 			return -EPERM;
 	}
 
 	return 0;
+}
+
+static int check_host_mem_pgstate(unsigned long phys, unsigned long size,
+				  enum pkvm_page_state state,
+				  enum pkvm_owner_id owner)
+{
+	return check_host_mem_pgstate_mask(phys, size, 1 << state, owner);
 }
 
 struct page_ownership {
@@ -282,9 +288,9 @@ static int check_page_owner_and_state(struct pkvm_pgtable *pgt, unsigned long va
 	return pkvm_pgtable_walk(pgt, vaddr, size, &walker);
 }
 
-static u64 host_mmu_pte_prot(bool mmio)
+static u64 host_mmu_pte_prot(bool write, bool mmio)
 {
-	return host_mmu.pgt_ops->calc_pte_perm(true, true, true) |
+	return host_mmu.pgt_ops->calc_pte_perm(true, write, true) |
 	       host_mmu.pgt_ops->calc_pte_memtype(mmio);
 }
 
@@ -353,7 +359,7 @@ static int host_mmu_map(unsigned long phys, unsigned long size, bool mmio)
 {
 	/* The vaddr == phys for the host MMU */
 	return pkvm_pgtable_map(&host_mmu, phys, phys, size,
-				host_mmu_pte_prot(mmio), NULL);
+				host_mmu_pte_prot(true, mmio), NULL);
 }
 
 static void *guest_mmu_zalloc_page(struct pkvm_memcache *mc)
@@ -537,7 +543,7 @@ static int host_reclaim_guest_walker(struct pkvm_pgtable_visit_ctx *ctx,
 		 * See also comment in pkvm_hyp_donate_host().
 		 */
 		BUG_ON(pkvm_pgtable_map(&host_mmu, phys, phys, size,
-					host_mmu_pte_prot(false), NULL));
+					host_mmu_pte_prot(true, false), NULL));
 
 		for_each_pkvm_page(page, phys, size) {
 			BUG_ON(page->host_share_hyp_count);
@@ -684,7 +690,7 @@ static int __guest_share_host(unsigned long gpa, unsigned long hpa,
 		return ret;
 
 	BUG_ON(pkvm_pgtable_map(&host_mmu, hpa, hpa, size,
-				host_mmu_pte_prot(false), NULL));
+				host_mmu_pte_prot(true, false), NULL));
 	set_host_mem_pgstate(hpa, size, PKVM_PAGE_SHARED_BORROWED, PKVM_ID_GUEST);
 
 	return 0;
@@ -1013,6 +1019,60 @@ unlock:
 	return ret;
 }
 
+/*
+ * pkvm_host_donate_hyp_share_ro() - Donate host memory to the hypervisor and
+ *				     re-map it back as read-only.
+ * @phys:	Physical base address of the memory region to donate.
+ * @size:	Size of the memory region in bytes.
+ * @clear:	If true, zero-initialize the memory region during donation.
+ *
+ * This function transfers ownership of the physical memory range [@phys, @phys + @size)
+ * from the host to the hypervisor. While the hypervisor becomes the primary owner,
+ * the memory is mapped back into the host's page tables with Read-Only (RO)
+ * permissions. This ensures the host can still read the data but is prevented
+ * from modifying it.
+ *
+ * Constraints:
+ * - @phys and @size must be PAGE_SIZE aligned.
+ * - @size must be non-zero.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int pkvm_host_donate_hyp_share_ro(unsigned long phys, unsigned long size, bool clear)
+{
+	int ret;
+
+	if (!PAGE_ALIGNED(phys) || !PAGE_ALIGNED(size) || size == 0)
+		return -EINVAL;
+
+	pkvm_host_mmu_lock();
+
+	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED, PKVM_ID_HOST);
+	if (ret)
+		goto unlock;
+
+	/* The vaddr == phys for the host MMU. */
+	ret = pkvm_pgtable_map(&host_mmu, phys, phys, size,
+			       host_mmu_pte_prot(false, false), NULL);
+	BUG_ON(ret);
+
+	set_host_mem_pgstate(phys, size, PKVM_PAGE_SHARED_BORROWED, PKVM_ID_HYP);
+unlock:
+	pkvm_host_mmu_unlock();
+
+	if (!ret && clear) {
+		/*
+		 * No need to flush CPU cache, like what pkvm_clear_memory()
+		 * does, as the pKVM hypervisor doesn't access memory via
+		 * non-coherent DMA (actually there is no DMA in the pKVM
+		 * hypervisor).
+		 */
+		memset(__pkvm_va(phys), 0, size);
+	}
+
+	return ret;
+}
+
 /**
  * pkvm_hyp_donate_host() - Donate memory pages from hypervisor to host.
  * @phys:	Physical address of the memory region to donate.
@@ -1031,6 +1091,7 @@ unlock:
  */
 void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
 {
+	u64 expected_pgstates = (1 << PKVM_PAGE_NONE) | (1 << PKVM_PAGE_SHARED_BORROWED);
 	void *va = __pkvm_va(phys);
 	int ret;
 
@@ -1044,7 +1105,7 @@ void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
 
 	pkvm_host_mmu_lock();
 
-	ret = check_host_mem_pgstate(phys, size, PKVM_PAGE_NONE, PKVM_ID_HYP);
+	ret = check_host_mem_pgstate_mask(phys, size, expected_pgstates, PKVM_ID_HYP);
 	if (ret)
 		goto unlock;
 
@@ -1057,7 +1118,7 @@ void pkvm_hyp_donate_host(unsigned long phys, unsigned long size, bool clear)
 	 * behavior. So panic if it fails.
 	 */
 	BUG_ON(ret = pkvm_pgtable_map(&host_mmu, phys, phys, size,
-				      host_mmu_pte_prot(false), NULL));
+				      host_mmu_pte_prot(true, false), NULL));
 
 	set_host_mem_pgstate(phys, size, PKVM_PAGE_OWNED, PKVM_ID_HOST);
 unlock:
@@ -1096,7 +1157,7 @@ out:
 int pkvm_hyp_donate_host_mmio_locked(unsigned long phys, unsigned long size)
 {
 	u64 prot = host_mmu.pgt_ops->pte_mk_pgstate(PKVM_PAGE_OWNED) |
-		   host_mmu_pte_prot(true);
+		   host_mmu_pte_prot(true, true);
 	int ret;
 
 	if (!PAGE_ALIGNED(phys) || !PAGE_ALIGNED(size) || size == 0)

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -65,6 +65,24 @@ static struct pkvm_x86_ops pkvm_x86_ops __read_mostly;
 /* TODO: If can be optimized with the static call mechanism. */
 #define pkvm_x86_call(func)		(pkvm_x86_ops.func)
 
+static struct pkvm_iommu_ops *iommu_ops;
+
+void pkvm_register_iommu_ops(struct pkvm_iommu_ops *ops)
+{
+	BUG_ON(READ_ONCE(iommu_ops));
+	WRITE_ONCE(iommu_ops, ops);
+}
+
+/*
+ * Until the static call mechanism is available, use indirect
+ * calls. All iommu_ops callbacks are mandatory for now.
+ */
+#define pkvm_iommu_call(func)				\
+({							\
+	BUG_ON(!iommu_ops || !iommu_ops->func);			\
+	(iommu_ops->func);				\
+})
+
 static int __pkvm_vcpu_free(struct pkvm_vm *pkvm_vm, int vcpu_handle,
 			    struct pkvm_memcache *mc);
 
@@ -1874,6 +1892,20 @@ void pkvm_handle_host_hypercall(struct kvm_vcpu *vcpu)
 	case __pkvm__vm_mmu_age:
 		ret = pkvm_vm_mmu_age(pkvm_hc_input1(vcpu), pkvm_hc_input2(vcpu),
 				      pkvm_hc_input3(vcpu), pkvm_hc_input4(vcpu));
+		break;
+	case __pkvm__iommu_mmio_read:
+		ret = pkvm_iommu_call(mmio_read)(pkvm_hc_input1(vcpu),
+						 pkvm_hc_input2(vcpu),
+						 &out.iommu_mmio_read.val);
+		break;
+	case __pkvm__iommu_mmio_write:
+		ret = pkvm_iommu_call(mmio_write)(pkvm_hc_input1(vcpu),
+						  pkvm_hc_input2(vcpu),
+						  pkvm_hc_input3(vcpu));
+		break;
+	case __pkvm__iommu_hypercall:
+		ret = pkvm_iommu_call(hypercall)(&in.iommu_hypercall.in,
+						 &out.iommu_hypercall.out);
 		break;
 	default:
 		ret = pkvm_vcpu_handle_host_hypercall(vcpu, hc, &in, &out);

--- a/arch/x86/kvm/pkvm/vmx/ept.c
+++ b/arch/x86/kvm/pkvm/vmx/ept.c
@@ -369,7 +369,8 @@ int pkvm_handle_host_ept_violation(void)
 	 * EPT when initialize, except for the MMIO in the high-end address.
 	 * Handle the MMIO only.
 	 */
-	if (pkvm_find_addr_range(gpa, &range) || is_pvmfw(gpa)) {
+	if (pkvm_find_addr_range(gpa, &range) || is_pvmfw(gpa) ||
+	    is_iommu_mmio(gpa)) {
 		pkvm_err("Host access to protected memory at 0x%lx\n", gpa);
 		return ret;
 	}
@@ -402,7 +403,8 @@ int pkvm_handle_host_ept_violation(void)
 		cur.start = ALIGN_DOWN(gpa, size);
 		cur.end = cur.start + size - 1;
 
-		if (range_contains(&range, &cur) && !overlaps_pvmfw(cur.start, size)) {
+		if (range_contains(&range, &cur) && !overlaps_pvmfw(cur.start, size) &&
+		    !overlaps_iommu_mmio(cur.start, size)) {
 			/*
 			 * TODO: In case the host mmu free pages are not
 			 * enough, -ENOMEM will be returned. This could be

--- a/arch/x86/kvm/pkvm/vmx/ept.c
+++ b/arch/x86/kvm/pkvm/vmx/ept.c
@@ -11,6 +11,7 @@
 #include "gfp.h"
 #include "pkvm/mmu.h"
 #include "pkvm.h"
+#include "pkvm_iommu.h"
 
 /* The ignored bit56 ~ bit52 in EPT present leaf are used to store page state */
 #define EPT_PAGE_STATE_SHIFT			52
@@ -277,7 +278,7 @@ int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
 {
 	unsigned long pfn = __pkvm_pa(pool_base) >> PAGE_SHIFT;
 	struct pkvm_pgtable_cap cap = {
-		.level = cpu_has_vmx_ept_5levels() ? 5 : 4,
+		.level = 4,
 		.allowed_pgsz = 1 << PG_LEVEL_4K,
 		.table_prot = VMX_EPT_RWX_MASK,
 		.flush_tlb_lazy = true,
@@ -293,10 +294,13 @@ int pkvm_host_ept_init(struct pkvm_pgtable *pgt, void *pool_base,
 	if (ret)
 		return ret;
 
-	if (cpu_has_vmx_ept_2m_page())
+	if (cpu_has_vmx_ept_2m_page() && iommu_supports_2m_page())
 		cap.allowed_pgsz |=  1 << PG_LEVEL_2M;
-	if (cpu_has_vmx_ept_1g_page())
+	if (cpu_has_vmx_ept_1g_page() && iommu_supports_1g_page())
 		cap.allowed_pgsz |=  1 << PG_LEVEL_1G;
+
+	if (cpu_has_vmx_ept_5levels() && iommu_supports_5levels())
+		cap.level = 5;
 
 	ret = pkvm_pgtable_init(pgt, cap, &host_ept_mm_ops, &host_ept_pgt_ops);
 	if (ret)

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -10,6 +10,7 @@
 #include "pkvm/lapic.h"
 #include "pkvm/trace.h"
 #include "pkvm.h"
+#include "pkvm_iommu.h"
 
 #define CR4			4
 #define MOV_TO_CR		0
@@ -32,6 +33,7 @@ static struct pkvm_init_ops vmx_init_ops = {
 	.host_mmu_finalize = pkvm_host_ept_finalize,
 	.hyp_global_init = pkvm_vmx_init,
 	.reprivilege_cpu = pkvm_vmx_reprivilege_cpu,
+	.hyp_iommu_init = pkvm_intel_iommu_init,
 };
 
 struct pkvm_init_ops *pkvm_vmx_init_ops = &vmx_init_ops;

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -1272,7 +1272,6 @@ static int __init pkvm_firmware_rmem_clear(void)
 	return 0;
 }
 
-
 int __init vmx_pkvm_init(void)
 {
 	struct pkvm_hyp *pkvm;
@@ -1352,6 +1351,7 @@ int __init vmx_pkvm_init(void)
 	ret = pkvm_hyp_init();
 	if (ret)
 		goto repriv_cpus;
+	static_branch_enable(&pkvm_enabled_key);
 
 	pkvm_hypercall(init_finalize);
 

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -84,6 +84,8 @@ u64 pkvm_total_reserve_pages(void)
 
 static __init void pkvm_setup_syms(void)
 {
+	int i;
+
 	/*
 	 * The pKVM hypervisor has defined the same symbol page_offset_base
 	 * and phys_base with the linux kernel. Initialize with the same value
@@ -105,6 +107,9 @@ static __init void pkvm_setup_syms(void)
 #endif
 	/* For the pKVM hypervisor to leverage pgprot_val macro */
 	pkvm_sym(__default_kernel_pte_mask) = __default_kernel_pte_mask;
+	for (i = 0; i < _PAGE_CACHE_MODE_NUM; i++)
+		pkvm_sym(__cachemode2pte_tbl)[i] = cachemode2protval(i);
+
 #ifdef CONFIG_AMD_MEM_ENCRYPT
 	pkvm_sym(sme_me_mask) = sme_me_mask;
 #endif

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -8,6 +8,7 @@
 #include <asm/pkvm_image.h>
 #include "pkvm_constants.h"
 #include "vmx.h"
+#include "pkvm_iommu.h"
 
 extern u64 x86_pred_cmd;
 
@@ -1342,6 +1343,10 @@ int __init vmx_pkvm_init(void)
 		pr_cont("reboot with kvm-intel.pkvm_relax_cpu_bugs=false\n");
 	}
 
+	ret = pkvm_host_prepare_iommu();
+	if (ret)
+		goto out;
+
 	pkvm_sym(init_ops) = pkvm_sym(pkvm_vmx_init_ops);
 
 	ret = pkvm_host_deprivilege_cpus(pkvm);
@@ -1352,6 +1357,12 @@ int __init vmx_pkvm_init(void)
 	if (ret)
 		goto repriv_cpus;
 	static_branch_enable(&pkvm_enabled_key);
+
+	ret = pkvm_host_init_iommu();
+	if (ret) {
+		static_branch_disable(&pkvm_enabled_key);
+		goto repriv_cpus;
+	}
 
 	pkvm_hypercall(init_finalize);
 
@@ -1371,6 +1382,17 @@ out:
 	 * can clear it while we are still in VMX non-root.
 	 */
 	pkvm_firmware_rmem_clear();
+
+	/*
+	 * Try enabling iommu on initialization failure to let the
+	 * system boot normally without pKVM. Try iommu init even if
+	 * we tried it while deprivileged and failed there. Host driver
+	 * uninitializes iommu on any failure, so retrying with cpus
+	 * reprivileged should be okay and may succeed if the previous
+	 * failure was due to pKVM.
+	 */
+	pkvm_host_init_iommu();
+
 	/*
 	 * As the reserved memory at the pkvm_mem_base will not be
 	 * released back to the host, no need to de-initialize or

--- a/drivers/iommu/intel/debugfs.c
+++ b/drivers/iommu/intel/debugfs.c
@@ -133,13 +133,13 @@ static int iommu_regset_show(struct seq_file *m, void *unused)
 		 */
 		raw_spin_lock_irqsave(&iommu->register_lock, flag);
 		for (i = 0 ; i < ARRAY_SIZE(iommu_regs_32); i++) {
-			value = dmar_readl(iommu->reg + iommu_regs_32[i].offset);
+			value = dmar_readl(iommu, iommu_regs_32[i].offset);
 			seq_printf(m, "%-16s\t0x%02x\t\t0x%016llx\n",
 				   iommu_regs_32[i].regs, iommu_regs_32[i].offset,
 				   value);
 		}
 		for (i = 0 ; i < ARRAY_SIZE(iommu_regs_64); i++) {
-			value = dmar_readq(iommu->reg + iommu_regs_64[i].offset);
+			value = dmar_readq(iommu, iommu_regs_64[i].offset);
 			seq_printf(m, "%-16s\t0x%02x\t\t0x%016llx\n",
 				   iommu_regs_64[i].regs, iommu_regs_64[i].offset,
 				   value);
@@ -247,7 +247,7 @@ static void ctx_tbl_walk(struct seq_file *m, struct intel_iommu *iommu, u16 bus)
 		tbl_wlk.ctx_entry = context;
 		m->private = &tbl_wlk;
 
-		if (dmar_readq(iommu->reg + DMAR_RTADDR_REG) & DMA_RTADDR_SMT) {
+		if (dmar_readq(iommu, DMAR_RTADDR_REG) & DMA_RTADDR_SMT) {
 			pasid_dir_ptr = context->lo & VTD_PAGE_MASK;
 			pasid_dir_size = get_pasid_dir_size(context);
 			pasid_dir_walk(m, pasid_dir_ptr, pasid_dir_size);
@@ -285,7 +285,7 @@ static int dmar_translation_struct_show(struct seq_file *m, void *unused)
 
 	rcu_read_lock();
 	for_each_active_iommu(iommu, drhd) {
-		sts = dmar_readl(iommu->reg + DMAR_GSTS_REG);
+		sts = dmar_readl(iommu, DMAR_GSTS_REG);
 		if (!(sts & DMA_GSTS_TES)) {
 			seq_printf(m, "DMA Remapping is not enabled on %s\n",
 				   iommu->name);
@@ -364,13 +364,13 @@ static int domain_translation_struct_show(struct seq_file *m,
 		if (seg != iommu->segment)
 			continue;
 
-		sts = dmar_readl(iommu->reg + DMAR_GSTS_REG);
+		sts = dmar_readl(iommu, DMAR_GSTS_REG);
 		if (!(sts & DMA_GSTS_TES)) {
 			seq_printf(m, "DMA Remapping is not enabled on %s\n",
 				   iommu->name);
 			continue;
 		}
-		if (dmar_readq(iommu->reg + DMAR_RTADDR_REG) & DMA_RTADDR_SMT)
+		if (dmar_readq(iommu, DMAR_RTADDR_REG) & DMA_RTADDR_SMT)
 			scalable = true;
 		else
 			scalable = false;
@@ -538,8 +538,8 @@ static int invalidation_queue_show(struct seq_file *m, void *unused)
 		raw_spin_lock_irqsave(&qi->q_lock, flags);
 		seq_printf(m, " Base: 0x%llx\tHead: %lld\tTail: %lld\n",
 			   (u64)virt_to_phys(qi->desc),
-			   dmar_readq(iommu->reg + DMAR_IQH_REG) >> shift,
-			   dmar_readq(iommu->reg + DMAR_IQT_REG) >> shift);
+			   dmar_readq(iommu, DMAR_IQH_REG) >> shift,
+			   dmar_readq(iommu, DMAR_IQT_REG) >> shift);
 		invalidation_queue_entry_show(m, iommu);
 		raw_spin_unlock_irqrestore(&qi->q_lock, flags);
 		seq_putc(m, '\n');
@@ -620,7 +620,7 @@ static int ir_translation_struct_show(struct seq_file *m, void *unused)
 		seq_printf(m, "Remapped Interrupt supported on IOMMU: %s\n",
 			   iommu->name);
 
-		sts = dmar_readl(iommu->reg + DMAR_GSTS_REG);
+		sts = dmar_readl(iommu, DMAR_GSTS_REG);
 		if (iommu->ir_table && (sts & DMA_GSTS_IRES)) {
 			irta = virt_to_phys(iommu->ir_table->base);
 			seq_printf(m, " IR table address:%llx\n", irta);

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -900,8 +900,8 @@ dmar_validate_one_drhd(struct acpi_dmar_header *entry, void *arg)
 		return -EINVAL;
 	}
 
-	cap = dmar_readq(addr + DMAR_CAP_REG);
-	ecap = dmar_readq(addr + DMAR_ECAP_REG);
+	cap = readq(addr + DMAR_CAP_REG);
+	ecap = readq(addr + DMAR_ECAP_REG);
 
 	if (arg)
 		iounmap(addr);
@@ -1003,8 +1003,8 @@ static int map_iommu(struct intel_iommu *iommu, struct dmar_drhd_unit *drhd)
 		goto release;
 	}
 
-	iommu->cap = dmar_readq(iommu->reg + DMAR_CAP_REG);
-	iommu->ecap = dmar_readq(iommu->reg + DMAR_ECAP_REG);
+	iommu->cap = dmar_readq(iommu, DMAR_CAP_REG);
+	iommu->ecap = dmar_readq(iommu, DMAR_ECAP_REG);
 
 	if (iommu->cap == (uint64_t)-1 && iommu->ecap == (uint64_t)-1) {
 		err = -EINVAL;
@@ -1038,7 +1038,7 @@ static int map_iommu(struct intel_iommu *iommu, struct dmar_drhd_unit *drhd)
 		int i;
 
 		for (i = 0; i < DMA_MAX_NUM_ECMDCAP; i++) {
-			iommu->ecmdcap[i] = dmar_readq(iommu->reg + DMAR_ECCAP_REG +
+			iommu->ecmdcap[i] = dmar_readq(iommu, DMAR_ECCAP_REG +
 						       i * DMA_ECMD_REG_STEP);
 		}
 	}
@@ -1121,7 +1121,7 @@ static int alloc_iommu(struct dmar_drhd_unit *drhd)
 	ida_init(&iommu->domain_ida);
 	mutex_init(&iommu->did_lock);
 
-	ver = readl(iommu->reg + DMAR_VER_REG);
+	ver = dmar_readl(iommu, DMAR_VER_REG);
 	pr_info("%s: reg_base_addr %llx ver %d:%d cap %llx ecap %llx\n",
 		iommu->name,
 		(unsigned long long)drhd->reg_base_addr,
@@ -1130,7 +1130,7 @@ static int alloc_iommu(struct dmar_drhd_unit *drhd)
 		(unsigned long long)iommu->ecap);
 
 	/* Reflect status in gcmd */
-	sts = readl(iommu->reg + DMAR_GSTS_REG);
+	sts = dmar_readl(iommu, DMAR_GSTS_REG);
 	if (sts & DMA_GSTS_IRES)
 		iommu->gcmd |= DMA_GCMD_IRE;
 	if (sts & DMA_GSTS_TES)
@@ -1260,8 +1260,8 @@ static const char *qi_type_string(u8 type)
 
 static void qi_dump_fault(struct intel_iommu *iommu, u32 fault)
 {
-	unsigned int head = dmar_readl(iommu->reg + DMAR_IQH_REG);
-	u64 iqe_err = dmar_readq(iommu->reg + DMAR_IQER_REG);
+	unsigned int head = dmar_readl(iommu, DMAR_IQH_REG);
+	u64 iqe_err = dmar_readq(iommu, DMAR_IQER_REG);
 	struct qi_desc *desc = iommu->qi->desc + head;
 
 	if (fault & DMA_FSTS_IQE)
@@ -1301,7 +1301,7 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 	if (qi->desc_status[wait_index] == QI_ABORT)
 		return -EAGAIN;
 
-	fault = readl(iommu->reg + DMAR_FSTS_REG);
+	fault = dmar_readl(iommu, DMAR_FSTS_REG);
 	if (fault & (DMA_FSTS_IQE | DMA_FSTS_ITE | DMA_FSTS_ICE))
 		qi_dump_fault(iommu, fault);
 
@@ -1311,7 +1311,7 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 	 * is cleared.
 	 */
 	if (fault & DMA_FSTS_IQE) {
-		head = readl(iommu->reg + DMAR_IQH_REG);
+		head = dmar_readl(iommu, DMAR_IQH_REG);
 		if ((head >> shift) == index) {
 			struct qi_desc *desc = qi->desc + head;
 
@@ -1322,7 +1322,7 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 			 */
 			memcpy(desc, qi->desc + (wait_index << shift),
 			       1 << shift);
-			writel(DMA_FSTS_IQE, iommu->reg + DMAR_FSTS_REG);
+			dmar_writel(iommu, DMAR_FSTS_REG, DMA_FSTS_IQE);
 			pr_info("Invalidation Queue Error (IQE) cleared\n");
 			return -EINVAL;
 		}
@@ -1333,20 +1333,20 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 	 * No new descriptors are fetched until the ITE is cleared.
 	 */
 	if (fault & DMA_FSTS_ITE) {
-		head = readl(iommu->reg + DMAR_IQH_REG);
+		head = dmar_readl(iommu, DMAR_IQH_REG);
 		head = ((head >> shift) - 1 + QI_LENGTH) % QI_LENGTH;
 		head |= 1;
-		tail = readl(iommu->reg + DMAR_IQT_REG);
+		tail = dmar_readl(iommu, DMAR_IQT_REG);
 		tail = ((tail >> shift) - 1 + QI_LENGTH) % QI_LENGTH;
 
 		/*
 		 * SID field is valid only when the ITE field is Set in FSTS_REG
 		 * see Intel VT-d spec r4.1, section 11.4.9.9
 		 */
-		iqe_err = dmar_readq(iommu->reg + DMAR_IQER_REG);
+		iqe_err = dmar_readq(iommu, DMAR_IQER_REG);
 		ite_sid = DMAR_IQER_REG_ITESID(iqe_err);
 
-		writel(DMA_FSTS_ITE, iommu->reg + DMAR_FSTS_REG);
+		dmar_writel(iommu, DMAR_FSTS_REG, DMA_FSTS_ITE);
 		pr_info("Invalidation Time-out Error (ITE) cleared\n");
 
 		do {
@@ -1373,7 +1373,7 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 	}
 
 	if (fault & DMA_FSTS_ICE) {
-		writel(DMA_FSTS_ICE, iommu->reg + DMAR_FSTS_REG);
+		dmar_writel(iommu, DMAR_FSTS_REG, DMA_FSTS_ICE);
 		pr_info("Invalidation Completion Error (ICE) cleared\n");
 	}
 
@@ -1464,7 +1464,7 @@ restart:
 	 * update the HW tail register indicating the presence of
 	 * new descriptors.
 	 */
-	writel(qi->free_head << shift, iommu->reg + DMAR_IQT_REG);
+	dmar_writel(iommu, DMAR_IQT_REG, qi->free_head << shift);
 
 	while (READ_ONCE(qi->desc_status[wait_index]) != QI_DONE) {
 		/*
@@ -1637,22 +1637,22 @@ void dmar_disable_qi(struct intel_iommu *iommu)
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flags);
 
-	sts =  readl(iommu->reg + DMAR_GSTS_REG);
+	sts =  dmar_readl(iommu, DMAR_GSTS_REG);
 	if (!(sts & DMA_GSTS_QIES))
 		goto end;
 
 	/*
 	 * Give a chance to HW to complete the pending invalidation requests.
 	 */
-	while ((readl(iommu->reg + DMAR_IQT_REG) !=
-		readl(iommu->reg + DMAR_IQH_REG)) &&
+	while ((dmar_readl(iommu, DMAR_IQT_REG) !=
+		dmar_readl(iommu, DMAR_IQH_REG)) &&
 		(DMAR_OPERATION_TIMEOUT > (get_cycles() - start_time)))
 		cpu_relax();
 
 	iommu->gcmd &= ~DMA_GCMD_QIE;
-	writel(iommu->gcmd, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd);
 
-	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG, readl,
+	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG, dmar_readl,
 		      !(sts & DMA_GSTS_QIES), sts);
 end:
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flags);
@@ -1681,15 +1681,15 @@ static void __dmar_enable_qi(struct intel_iommu *iommu)
 	raw_spin_lock_irqsave(&iommu->register_lock, flags);
 
 	/* write zero to the tail reg */
-	writel(0, iommu->reg + DMAR_IQT_REG);
+	dmar_writel(iommu, DMAR_IQT_REG, 0);
 
-	dmar_writeq(iommu->reg + DMAR_IQA_REG, val);
+	dmar_writeq(iommu, DMAR_IQA_REG, val);
 
 	iommu->gcmd |= DMA_GCMD_QIE;
-	writel(iommu->gcmd, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd);
 
 	/* Make sure hardware complete it */
-	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG, readl, (sts & DMA_GSTS_QIES), sts);
+	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG, dmar_readl, (sts & DMA_GSTS_QIES), sts);
 
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flags);
 }
@@ -1884,9 +1884,9 @@ void dmar_msi_unmask(struct irq_data *data)
 
 	/* unmask it */
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
-	writel(0, iommu->reg + reg);
+	dmar_writel(iommu, reg, 0);
 	/* Read a reg to force flush the post write */
-	readl(iommu->reg + reg);
+	dmar_readl(iommu, reg);
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 }
 
@@ -1898,9 +1898,9 @@ void dmar_msi_mask(struct irq_data *data)
 
 	/* mask it */
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
-	writel(DMA_FECTL_IM, iommu->reg + reg);
+	dmar_writel(iommu, reg, DMA_FECTL_IM);
 	/* Read a reg to force flush the post write */
-	readl(iommu->reg + reg);
+	dmar_readl(iommu, reg);
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 }
 
@@ -1911,9 +1911,9 @@ void dmar_msi_write(int irq, struct msi_msg *msg)
 	unsigned long flag;
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
-	writel(msg->data, iommu->reg + reg + 4);
-	writel(msg->address_lo, iommu->reg + reg + 8);
-	writel(msg->address_hi, iommu->reg + reg + 12);
+	dmar_writel(iommu, reg + 4, msg->data);
+	dmar_writel(iommu, reg + 8, msg->address_lo);
+	dmar_writel(iommu, reg + 12, msg->address_hi);
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 }
 
@@ -1965,7 +1965,7 @@ irqreturn_t dmar_fault(int irq, void *dev_id)
 				      DEFAULT_RATELIMIT_BURST);
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
-	fault_status = readl(iommu->reg + DMAR_FSTS_REG);
+	fault_status = dmar_readl(iommu, DMAR_FSTS_REG);
 	if (fault_status && __ratelimit(&rs))
 		pr_err("DRHD: handling fault status reg %x\n", fault_status);
 
@@ -1987,7 +1987,7 @@ irqreturn_t dmar_fault(int irq, void *dev_id)
 		bool pasid_present;
 
 		/* highest 32 bits */
-		data = readl(iommu->reg + reg +
+		data = dmar_readl(iommu, reg +
 				fault_index * PRIMARY_FAULT_REG_LEN + 12);
 		if (!(data & DMA_FRCD_F))
 			break;
@@ -1997,19 +1997,19 @@ irqreturn_t dmar_fault(int irq, void *dev_id)
 			type = dma_frcd_type(data);
 
 			pasid = dma_frcd_pasid_value(data);
-			data = readl(iommu->reg + reg +
+			data = dmar_readl(iommu, reg +
 				     fault_index * PRIMARY_FAULT_REG_LEN + 8);
 			source_id = dma_frcd_source_id(data);
 
 			pasid_present = dma_frcd_pasid_present(data);
-			guest_addr = dmar_readq(iommu->reg + reg +
+			guest_addr = dmar_readq(iommu, reg +
 					fault_index * PRIMARY_FAULT_REG_LEN);
 			guest_addr = dma_frcd_page_addr(guest_addr);
 		}
 
 		/* clear the fault */
-		writel(DMA_FRCD_F, iommu->reg + reg +
-			fault_index * PRIMARY_FAULT_REG_LEN + 12);
+		dmar_writel(iommu, reg +
+			fault_index * PRIMARY_FAULT_REG_LEN + 12, DMA_FRCD_F);
 
 		raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 
@@ -2025,8 +2025,8 @@ irqreturn_t dmar_fault(int irq, void *dev_id)
 		raw_spin_lock_irqsave(&iommu->register_lock, flag);
 	}
 
-	writel(DMA_FSTS_PFO | DMA_FSTS_PPF | DMA_FSTS_PRO,
-	       iommu->reg + DMAR_FSTS_REG);
+	dmar_writel(iommu, DMAR_FSTS_REG,
+		DMA_FSTS_PFO | DMA_FSTS_PPF | DMA_FSTS_PRO);
 
 unlock_exit:
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
@@ -2085,8 +2085,8 @@ int enable_drhd_fault_handling(unsigned int cpu)
 		 * Clear any previous faults.
 		 */
 		dmar_fault(iommu->irq, iommu);
-		fault_status = readl(iommu->reg + DMAR_FSTS_REG);
-		writel(fault_status, iommu->reg + DMAR_FSTS_REG);
+		fault_status = dmar_readl(iommu, DMAR_FSTS_REG);
+		dmar_writel(iommu, DMAR_FSTS_REG, fault_status);
 	}
 
 	return 0;

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -1209,7 +1209,6 @@ static void free_iommu(struct intel_iommu *iommu)
 
 	if (iommu->qi) {
 		iommu_free_pages(iommu->qi->desc);
-		kfree(iommu->qi->desc_status);
 		kfree(iommu->qi);
 	}
 
@@ -1733,14 +1732,6 @@ int dmar_enable_qi(struct intel_iommu *iommu)
 	}
 
 	qi->desc = desc;
-
-	qi->desc_status = kcalloc(QI_LENGTH, sizeof(int), GFP_ATOMIC);
-	if (!qi->desc_status) {
-		iommu_free_pages(qi->desc);
-		kfree(qi);
-		iommu->qi = NULL;
-		return -ENOMEM;
-	}
 
 	raw_spin_lock_init(&qi->q_lock);
 

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -29,6 +29,7 @@
 #include <linux/numa.h>
 #include <linux/limits.h>
 #include <asm/irq_remapping.h>
+#include <asm/kvm_host.h>
 
 #include "iommu.h"
 #include "../irq_remapping.h"
@@ -915,6 +916,28 @@ dmar_validate_one_drhd(struct acpi_dmar_header *entry, void *arg)
 	return 0;
 }
 
+static int __init intel_iommu_init_nop(void) { return 0; }
+
+static inline void setup_iommu_init_hooks(void)
+{
+	if (enable_pkvm) {
+		/*
+		 * iommu_init happens during pkvm initialization
+		 * and hence a nop here.
+		 */
+		x86_init.iommu.iommu_init = intel_iommu_init_nop;
+	} else {
+		x86_init.iommu.iommu_init = intel_iommu_init;
+	}
+	/*
+	 * Set iommu_shutdown hook regardless of pkvm.
+	 * pkvm won't get a chance to shutdown iommu cleanly
+	 * on reboot as we don't reprivilege at reboot. So,
+	 * let the host do it in its normal shutdown flow.
+	 */
+	x86_platform.iommu_shutdown = intel_iommu_shutdown;
+}
+
 void __init detect_intel_iommu(void)
 {
 	int ret;
@@ -935,10 +958,8 @@ void __init detect_intel_iommu(void)
 		pci_request_acs();
 	}
 
-	if (!ret) {
-		x86_init.iommu.iommu_init = intel_iommu_init;
-		x86_platform.iommu_shutdown = intel_iommu_shutdown;
-	}
+	if (!ret)
+		setup_iommu_init_hooks();
 
 	if (dmar_tbl) {
 		acpi_put_table(dmar_tbl);

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -2363,6 +2363,11 @@ static int dmar_device_hotplug(acpi_handle handle, bool insert)
 	if (!dmar_in_use())
 		return 0;
 
+	if (pkvm_enabled()) {
+		pr_warn("DMAR hotplug not supported with pKVM!\n");
+		return -EOPNOTSUPP;
+	}
+
 	if (dmar_detect_dsm(handle, DMAR_DSM_FUNC_DRHD)) {
 		tmp = handle;
 	} else {

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -1438,6 +1438,9 @@ int qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
 		return 0;
 
 #ifndef __PKVM_HYP__
+	if (pkvm_enabled())
+		return pv_qi_submit_sync(iommu, desc, count, options);
+
 	type = desc->qw0 & GENMASK_ULL(3, 0);
 
 	if ((type == QI_IOTLB_TYPE || type == QI_EIOTLB_TYPE) &&

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -31,7 +31,14 @@
 #include <asm/irq_remapping.h>
 #include <asm/kvm_host.h>
 
+#ifdef __PKVM_HYP__
+#include <asm/pkvm_spinlock.h>
+#include "memory.h"
+#include "debug.h"
+#endif
+
 #include "iommu.h"
+#ifndef __PKVM_HYP__
 #include "../irq_remapping.h"
 #include "../iommu-pages.h"
 #include "perf.h"
@@ -1219,6 +1226,7 @@ static void free_iommu(struct intel_iommu *iommu)
 	ida_free(&dmar_seq_ids, iommu->seq_id);
 	kfree(iommu);
 }
+#endif /* !__PKVM_HYP__ */
 
 /*
  * Reclaim all the submitted descriptors which have completed its work.
@@ -1292,7 +1300,9 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 {
 	u32 fault;
 	int head, tail;
+#ifndef __PKVM_HYP__
 	struct device *dev;
+#endif
 	u64 iqe_err, ite_sid;
 	struct q_inval *qi = iommu->qi;
 	int shift = qi_shift(iommu);
@@ -1354,6 +1364,7 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 			head = (head - 2 + QI_LENGTH) % QI_LENGTH;
 		} while (head != tail);
 
+#ifndef __PKVM_HYP__
 		/*
 		 * If device was released or isn't present, no need to retry
 		 * the ATS invalidate request anymore.
@@ -1367,6 +1378,7 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 			    !pci_device_is_present(to_pci_dev(dev)))
 				return -ETIMEDOUT;
 		}
+#endif
 		if (qi->desc_status[wait_index] == QI_ABORT)
 			return -EAGAIN;
 	}
@@ -1379,6 +1391,22 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 	return 0;
 }
 
+#ifndef __PKVM_HYP__
+#define qi_lock(qi) raw_spin_lock(&(qi)->q_lock)
+#define qi_unlock(qi) raw_spin_unlock(&(qi)->q_lock)
+#define qi_lock_irqsave(qi, flags) raw_spin_lock_irqsave(&(qi)->q_lock, flags)
+#define qi_unlock_irqrestore(qi, flags) raw_spin_unlock_irqrestore(&(qi)->q_lock, flags)
+#else
+#define qi_lock(qi) pkvm_spin_lock(&(qi)->q_lock)
+#define qi_unlock(qi) pkvm_spin_unlock(&(qi)->q_lock)
+#define qi_lock_irqsave(qi, flags) qi_lock(qi)
+#define qi_unlock_irqrestore(qi, flags) qi_unlock(qi)
+
+#define trace_qi_submit(a1, a2, a3, a4, a5)
+#undef virt_to_phys
+#define virt_to_phys(ptr) __pkvm_pa(ptr)
+#endif
+
 /*
  * Function to submit invalidation descriptors of all types to the queued
  * invalidation interface(QI). Multiple descriptors can be submitted at a
@@ -1390,19 +1418,26 @@ int qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
 		   unsigned int count, unsigned long options)
 {
 	struct q_inval *qi = iommu->qi;
+#ifndef __PKVM_HYP__
 	s64 devtlb_start_ktime = 0;
 	s64 iotlb_start_ktime = 0;
 	s64 iec_start_ktime = 0;
+#endif
 	struct qi_desc wait_desc;
 	int wait_index, index;
+#ifndef __PKVM_HYP__
 	unsigned long flags;
+#endif
 	int offset, shift;
 	int rc, i;
+#ifndef __PKVM_HYP__
 	u64 type;
+#endif
 
 	if (!qi)
 		return 0;
 
+#ifndef __PKVM_HYP__
 	type = desc->qw0 & GENMASK_ULL(3, 0);
 
 	if ((type == QI_IOTLB_TYPE || type == QI_EIOTLB_TYPE) &&
@@ -1416,20 +1451,21 @@ int qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
 	if (type == QI_IEC_TYPE &&
 	    dmar_latency_enabled(iommu, DMAR_LATENCY_INV_IEC))
 		iec_start_ktime = ktime_to_ns(ktime_get());
+#endif /* !__PKVM_HYP__ */
 
 restart:
 	rc = 0;
 
-	raw_spin_lock_irqsave(&qi->q_lock, flags);
+	qi_lock_irqsave(qi, flags);
 	/*
 	 * Check if we have enough empty slots in the queue to submit,
 	 * the calculation is based on:
 	 * # of desc + 1 wait desc + 1 space between head and tail
 	 */
 	while (qi->free_cnt < count + 2) {
-		raw_spin_unlock_irqrestore(&qi->q_lock, flags);
+		qi_unlock_irqrestore(qi, flags);
 		cpu_relax();
-		raw_spin_lock_irqsave(&qi->q_lock, flags);
+		qi_lock_irqsave(qi, flags);
 	}
 
 	index = qi->free_head;
@@ -1477,9 +1513,9 @@ restart:
 		if (rc)
 			break;
 
-		raw_spin_unlock(&qi->q_lock);
+		qi_unlock(qi);
 		cpu_relax();
-		raw_spin_lock(&qi->q_lock);
+		qi_lock(qi);
 	}
 
 	/*
@@ -1494,11 +1530,12 @@ restart:
 		qi->desc_status[(index + i) % QI_LENGTH] = QI_FREE;
 
 	reclaim_free_desc(qi);
-	raw_spin_unlock_irqrestore(&qi->q_lock, flags);
+	qi_unlock_irqrestore(qi, flags);
 
 	if (rc == -EAGAIN)
 		goto restart;
 
+#ifndef __PKVM_HYP__
 	if (iotlb_start_ktime)
 		dmar_latency_update(iommu, DMAR_LATENCY_INV_IOTLB,
 				ktime_to_ns(ktime_get()) - iotlb_start_ktime);
@@ -1510,6 +1547,7 @@ restart:
 	if (iec_start_ktime)
 		dmar_latency_update(iommu, DMAR_LATENCY_INV_IEC,
 				ktime_to_ns(ktime_get()) - iec_start_ktime);
+#endif
 
 	return rc;
 }
@@ -1564,8 +1602,13 @@ void qi_flush_dev_iotlb(struct intel_iommu *iommu, u16 sid, u16 pfsid,
 	 * Software is recommended to not submit any Device-TLB invalidation
 	 * requests while address remapping hardware is disabled.
 	 */
+#ifndef __PKVM_HYP__
 	if (!(iommu->gcmd & DMA_GCMD_TE))
 		return;
+#else
+	if (!(iommu->vgsts & DMA_GSTS_TES))
+		return;
+#endif
 
 	qi_desc_dev_iotlb(sid, pfsid, qdep, addr, mask, &desc);
 	qi_submit_sync(iommu, &desc, 1, 0);
@@ -1603,8 +1646,13 @@ void qi_flush_dev_iotlb_pasid(struct intel_iommu *iommu, u16 sid, u16 pfsid,
 	 * Software is recommended to not submit any Device-TLB invalidation
 	 * requests while address remapping hardware is disabled.
 	 */
+#ifndef __PKVM_HYP__
 	if (!(iommu->gcmd & DMA_GCMD_TE))
 		return;
+#else
+	if (!(iommu->vgsts & DMA_GSTS_TES))
+		return;
+#endif
 
 	qi_desc_dev_iotlb_pasid(sid, pfsid, pasid,
 				qdep, addr, size_order,
@@ -1622,6 +1670,7 @@ void qi_flush_pasid_cache(struct intel_iommu *iommu, u16 did,
 	qi_submit_sync(iommu, &desc, 1, 0);
 }
 
+#ifndef __PKVM_HYP__
 /*
  * Disable Queued Invalidation interface.
  */
@@ -2418,3 +2467,4 @@ bool dmar_platform_optin(void)
 	return ret;
 }
 EXPORT_SYMBOL_GPL(dmar_platform_optin);
+#endif /* !__PKVM_HYP__ */

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -1887,8 +1887,10 @@ static int device_def_domain_type(struct device *dev)
 	return 0;
 }
 
-static void intel_iommu_init_qi(struct intel_iommu *iommu)
+static int intel_iommu_init_qi(struct intel_iommu *iommu)
 {
+	int ret = 0;
+
 	/*
 	 * Start from the sane iommu hardware state.
 	 * If the queued invalidation is already initialized by us
@@ -1905,9 +1907,17 @@ static void intel_iommu_init_qi(struct intel_iommu *iommu)
 		 * before OS handover.
 		 */
 		dmar_disable_qi(iommu);
+	} else if (pkvm_enabled()) {
+		/* Re-initialize QI to start from a clean state. */
+		dmar_reenable_qi(iommu);
 	}
 
-	if (dmar_enable_qi(iommu)) {
+	ret = dmar_enable_qi(iommu);
+	if (ret) {
+		/* pKVM requires QI enabled */
+		if (pkvm_enabled())
+			return ret;
+
 		/*
 		 * Queued Invalidate not enabled, use Register Based Invalidate
 		 */
@@ -1920,6 +1930,8 @@ static void intel_iommu_init_qi(struct intel_iommu *iommu)
 		iommu->flush.flush_iotlb = qi_flush_iotlb;
 		pr_info("%s: Using Queued invalidation\n", iommu->name);
 	}
+
+	return ret;
 }
 
 static int copy_context_table(struct intel_iommu *iommu,
@@ -2125,7 +2137,10 @@ static int __init init_dmars(void)
 						   intel_pasid_max_id);
 		}
 
-		intel_iommu_init_qi(iommu);
+		ret = intel_iommu_init_qi(iommu);
+		if (ret)
+			goto free_iommu;
+
 		init_translation_status(iommu);
 
 		if (translation_pre_enabled(iommu) && !is_kdump_kernel()) {

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -1317,7 +1317,7 @@ static void free_dmar_iommu(struct intel_iommu *iommu)
 	/* free context mapping */
 	free_context_table(iommu);
 
-	if (ecap_prs(iommu->ecap))
+	if (prs_supported(iommu))
 		intel_iommu_finish_prq(iommu);
 }
 
@@ -2104,6 +2104,15 @@ static int __init init_dmars(void)
 			continue;
 		}
 
+		if (pkvm_enabled()) {
+			if (ecap_prs(iommu->ecap))
+				pr_debug("iommu%d: PRS disabled as pKVM is enabled!\n",
+					 iommu->seq_id);
+			if (ecap_nest(iommu->ecap))
+				pr_debug("iommu%d: NEST disabled as pKVM is enabled!\n",
+					 iommu->seq_id);
+		}
+
 		/*
 		 * Find the max pasid size of all IOMMU's in the system.
 		 * We need to ensure the system pasid table is no bigger
@@ -2194,7 +2203,7 @@ static int __init init_dmars(void)
 
 		iommu_flush_write_buffer(iommu);
 
-		if (ecap_prs(iommu->ecap)) {
+		if (prs_supported(iommu)) {
 			/*
 			 * Call dmar_alloc_hwirq() with dmar_global_lock held,
 			 * could cause possible lock race condition.
@@ -2612,7 +2621,7 @@ static int intel_iommu_add(struct dmar_drhd_unit *dmaru)
 	intel_iommu_init_qi(iommu);
 	iommu_flush_write_buffer(iommu);
 
-	if (ecap_prs(iommu->ecap)) {
+	if (prs_supported(iommu)) {
 		ret = intel_iommu_enable_prq(iommu);
 		if (ret)
 			goto disable_iommu;
@@ -3819,7 +3828,7 @@ static struct iommu_device *intel_iommu_probe_device(struct device *dev)
 					info->pasid_supported = features | 1;
 			}
 
-			if (info->ats_supported && ecap_prs(iommu->ecap) &&
+			if (info->ats_supported && prs_supported(iommu) &&
 			    ecap_pds(iommu->ecap) && pci_pri_supported(pdev))
 				info->pri_supported = 1;
 		}

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -236,7 +236,7 @@ static void init_translation_status(struct intel_iommu *iommu)
 {
 	u32 gsts;
 
-	gsts = readl(iommu->reg + DMAR_GSTS_REG);
+	gsts = dmar_readl(iommu, DMAR_GSTS_REG);
 	if (gsts & DMA_GSTS_TES)
 		iommu->flags |= VTD_FLAG_TRANS_PRE_ENABLED;
 }
@@ -1013,13 +1013,13 @@ static void iommu_set_root_entry(struct intel_iommu *iommu)
 		addr |= DMA_RTADDR_SMT;
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
-	dmar_writeq(iommu->reg + DMAR_RTADDR_REG, addr);
+	dmar_writeq(iommu, DMAR_RTADDR_REG, addr);
 
-	writel(iommu->gcmd | DMA_GCMD_SRTP, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd | DMA_GCMD_SRTP);
 
 	/* Make sure hardware complete it */
 	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-		      readl, (sts & DMA_GSTS_RTPS), sts);
+		      dmar_readl, (sts & DMA_GSTS_RTPS), sts);
 
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 
@@ -1045,11 +1045,11 @@ void iommu_flush_write_buffer(struct intel_iommu *iommu)
 		return;
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
-	writel(iommu->gcmd | DMA_GCMD_WBF, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd | DMA_GCMD_WBF);
 
 	/* Make sure hardware complete it */
 	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-		      readl, (!(val & DMA_GSTS_WBFS)), val);
+		      dmar_readl, (!(val & DMA_GSTS_WBFS)), val);
 
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 }
@@ -1081,7 +1081,7 @@ static void __iommu_flush_context(struct intel_iommu *iommu,
 	val |= DMA_CCMD_ICC;
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
-	dmar_writeq(iommu->reg + DMAR_CCMD_REG, val);
+	dmar_writeq(iommu, DMAR_CCMD_REG, val);
 
 	/* Make sure hardware complete it */
 	IOMMU_WAIT_OP(iommu, DMAR_CCMD_REG,
@@ -1122,8 +1122,8 @@ void __iommu_flush_iotlb(struct intel_iommu *iommu, u16 did, u64 addr,
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
 	/* Note: Only uses first TLB reg currently */
 	if (val_iva)
-		dmar_writeq(iommu->reg + tlb_offset, val_iva);
-	dmar_writeq(iommu->reg + tlb_offset + 8, val);
+		dmar_writeq(iommu, tlb_offset, val_iva);
+	dmar_writeq(iommu, tlb_offset + 8, val);
 
 	/* Make sure hardware complete it */
 	IOMMU_WAIT_OP(iommu, tlb_offset + 8,
@@ -1247,13 +1247,13 @@ static void iommu_disable_protect_mem_regions(struct intel_iommu *iommu)
 		return;
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flags);
-	pmen = readl(iommu->reg + DMAR_PMEN_REG);
+	pmen = dmar_readl(iommu, DMAR_PMEN_REG);
 	pmen &= ~DMA_PMEN_EPM;
-	writel(pmen, iommu->reg + DMAR_PMEN_REG);
+	dmar_writel(iommu, DMAR_PMEN_REG, pmen);
 
 	/* wait for the protected region status bit to clear */
 	IOMMU_WAIT_OP(iommu, DMAR_PMEN_REG,
-		readl, !(pmen & DMA_PMEN_PRS), pmen);
+		dmar_readl, !(pmen & DMA_PMEN_PRS), pmen);
 
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flags);
 }
@@ -1265,11 +1265,11 @@ static void iommu_enable_translation(struct intel_iommu *iommu)
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flags);
 	iommu->gcmd |= DMA_GCMD_TE;
-	writel(iommu->gcmd, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd);
 
 	/* Make sure hardware complete it */
 	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-		      readl, (sts & DMA_GSTS_TES), sts);
+		      dmar_readl, (sts & DMA_GSTS_TES), sts);
 
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flags);
 }
@@ -1285,11 +1285,11 @@ static void iommu_disable_translation(struct intel_iommu *iommu)
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flag);
 	iommu->gcmd &= ~DMA_GCMD_TE;
-	writel(iommu->gcmd, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd);
 
 	/* Make sure hardware complete it */
 	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-		      readl, (!(sts & DMA_GSTS_TES)), sts);
+		      dmar_readl, (!(sts & DMA_GSTS_TES)), sts);
 
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 }
@@ -2017,7 +2017,7 @@ static int copy_translation_tables(struct intel_iommu *iommu)
 	int bus, ret;
 	bool new_ext, ext;
 
-	rtaddr_reg = dmar_readq(iommu->reg + DMAR_RTADDR_REG);
+	rtaddr_reg = dmar_readq(iommu, DMAR_RTADDR_REG);
 	ext        = !!(rtaddr_reg & DMA_RTADDR_SMT);
 	new_ext    = !!sm_supported(iommu);
 
@@ -2329,13 +2329,13 @@ static int iommu_suspend(void)
 		raw_spin_lock_irqsave(&iommu->register_lock, flag);
 
 		iommu->iommu_state[SR_DMAR_FECTL_REG] =
-			readl(iommu->reg + DMAR_FECTL_REG);
+			dmar_readl(iommu, DMAR_FECTL_REG);
 		iommu->iommu_state[SR_DMAR_FEDATA_REG] =
-			readl(iommu->reg + DMAR_FEDATA_REG);
+			dmar_readl(iommu, DMAR_FEDATA_REG);
 		iommu->iommu_state[SR_DMAR_FEADDR_REG] =
-			readl(iommu->reg + DMAR_FEADDR_REG);
+			dmar_readl(iommu, DMAR_FEADDR_REG);
 		iommu->iommu_state[SR_DMAR_FEUADDR_REG] =
-			readl(iommu->reg + DMAR_FEUADDR_REG);
+			dmar_readl(iommu, DMAR_FEUADDR_REG);
 
 		raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 	}
@@ -2360,14 +2360,10 @@ static void iommu_resume(void)
 
 		raw_spin_lock_irqsave(&iommu->register_lock, flag);
 
-		writel(iommu->iommu_state[SR_DMAR_FECTL_REG],
-			iommu->reg + DMAR_FECTL_REG);
-		writel(iommu->iommu_state[SR_DMAR_FEDATA_REG],
-			iommu->reg + DMAR_FEDATA_REG);
-		writel(iommu->iommu_state[SR_DMAR_FEADDR_REG],
-			iommu->reg + DMAR_FEADDR_REG);
-		writel(iommu->iommu_state[SR_DMAR_FEUADDR_REG],
-			iommu->reg + DMAR_FEUADDR_REG);
+		dmar_writel(iommu, DMAR_FECTL_REG, iommu->iommu_state[SR_DMAR_FECTL_REG]);
+		dmar_writel(iommu, DMAR_FEDATA_REG, iommu->iommu_state[SR_DMAR_FEDATA_REG]);
+		dmar_writel(iommu, DMAR_FEADDR_REG, iommu->iommu_state[SR_DMAR_FEADDR_REG]);
+		dmar_writel(iommu, DMAR_FEUADDR_REG, iommu->iommu_state[SR_DMAR_FEUADDR_REG]);
 
 		raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 	}
@@ -2880,7 +2876,7 @@ static ssize_t version_show(struct device *dev,
 			    struct device_attribute *attr, char *buf)
 {
 	struct intel_iommu *iommu = dev_to_intel_iommu(dev);
-	u32 ver = readl(iommu->reg + DMAR_VER_REG);
+	u32 ver = dmar_readl(iommu, DMAR_VER_REG);
 	return sysfs_emit(buf, "%d:%d\n",
 			  DMAR_VER_MAJOR(ver), DMAR_VER_MINOR(ver));
 }
@@ -4779,7 +4775,7 @@ int ecmd_submit_sync(struct intel_iommu *iommu, u8 ecmd, u64 oa, u64 ob)
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flags);
 
-	res = dmar_readq(iommu->reg + DMAR_ECRSP_REG);
+	res = dmar_readq(iommu, DMAR_ECRSP_REG);
 	if (res & DMA_ECMD_ECRSP_IP) {
 		ret = -EBUSY;
 		goto err;
@@ -4792,8 +4788,8 @@ int ecmd_submit_sync(struct intel_iommu *iommu, u8 ecmd, u64 oa, u64 ob)
 	 * - It's not invoked in any critical path. The extra MMIO
 	 *   write doesn't bring any performance concerns.
 	 */
-	dmar_writeq(iommu->reg + DMAR_ECEO_REG, ob);
-	dmar_writeq(iommu->reg + DMAR_ECMD_REG, ecmd | (oa << DMA_ECMD_OA_SHIFT));
+	dmar_writeq(iommu, DMAR_ECEO_REG, ob);
+	dmar_writeq(iommu, DMAR_ECMD_REG, ecmd | (oa << DMA_ECMD_OA_SHIFT));
 
 	IOMMU_WAIT_OP(iommu, DMAR_ECRSP_REG, dmar_readq,
 		      !(res & DMA_ECMD_ECRSP_IP), res);

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -1023,6 +1023,10 @@ static void iommu_set_root_entry(struct intel_iommu *iommu)
 
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flag);
 
+	/* pKVM hypervisor takes care of the invalidation logic */
+	if (pkvm_enabled())
+		return;
+
 	/*
 	 * Hardware invalidates all DMA remapping hardware translation
 	 * caches as part of SRTP flow.

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -13,6 +13,7 @@
 #define pr_fmt(fmt)     "DMAR: " fmt
 #define dev_fmt(fmt)    pr_fmt(fmt)
 
+#ifndef __PKVM_HYP__
 #include <linux/crash_dump.h>
 #include <linux/dma-direct.h>
 #include <linux/dmi.h>
@@ -204,8 +205,10 @@ static LIST_HEAD(dmar_satc_units);
 static void intel_iommu_domain_free(struct iommu_domain *domain);
 
 int dmar_disabled = !IS_ENABLED(CONFIG_INTEL_IOMMU_DEFAULT_ON);
+#endif /* !__PKVM_HYP__ */
 int intel_iommu_sm = IS_ENABLED(CONFIG_INTEL_IOMMU_SCALABLE_MODE_DEFAULT_ON);
 
+#ifndef __PKVM_HYP__
 int intel_iommu_enabled = 0;
 EXPORT_SYMBOL_GPL(intel_iommu_enabled);
 
@@ -4797,3 +4800,4 @@ err:
 
 	return ret;
 }
+#endif /* !__PKVM_HYP__ */

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -546,11 +546,21 @@ enum {
 #define sm_supported(iommu)	(intel_iommu_sm && ecap_smts((iommu)->ecap))
 #define pasid_supported(iommu)	(sm_supported(iommu) &&			\
 				 ecap_pasid((iommu)->ecap))
-#define ssads_supported(iommu) (sm_supported(iommu) &&                 \
+/* pKVM doesn't yet support dirty tracking, nested and PRS */
+#ifndef __PKVM_HYP__
+#define ssads_supported(iommu) (!pkvm_enabled() &&                    \
+				sm_supported(iommu) &&                 \
 				ecap_slads((iommu)->ecap) &&           \
 				ecap_smpwc(iommu->ecap))
-#define nested_supported(iommu)	(sm_supported(iommu) &&			\
+
+#define nested_supported(iommu)	(!pkvm_enabled() && sm_supported(iommu) &&\
 				 ecap_nest((iommu)->ecap))
+#define prs_supported(iommu)	(!pkvm_enabled() && ecap_prs((iommu)->ecap))
+#else
+#define ssads_supported(iommu)	false
+#define nested_supported(iommu)	false
+#define prs_supported(iommu)	false
+#endif
 
 struct pasid_entry;
 struct pasid_state_entry;

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -827,12 +827,14 @@ struct intel_iommu {
 	u64		ecap;
 	u32		vgsts;	/* Virtual GSTS register */
 	u64		viqa;  /* Virtual IQA register */
+	u64		vrta; /* Virtual RTA register */
 	int		seq_id;	/* sequence id of the iommu */
 	int		agaw; /* agaw of this iommu */
 	int		msagaw; /* max sagaw of this iommu */
 	struct q_inval  _qi;    /* Queued invalidation info */
 	struct q_inval  *qi;    /* Pointer to _qi. Enables host code re-use */
 	struct iommu_flush flush;
+	struct root_entry *root_entry;
 	pkvm_spinlock_t lock;
 };
 #endif /* !__PKVM_HYP__ */

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -28,6 +28,8 @@
 #include <asm/iommu.h>
 #include <uapi/linux/iommufd.h>
 
+#include "pkvm_iommu.h"
+
 /*
  * VT-d hardware uses 4KiB page size regardless of host page size.
  */

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -150,10 +150,10 @@
 
 #define OFFSET_STRIDE		(9)
 
-#define dmar_readq(a) readq(a)
-#define dmar_writeq(a,v) writeq(v,a)
-#define dmar_readl(a) readl(a)
-#define dmar_writel(a, v) writel(v, a)
+#define dmar_readq(iommu, o) readq((iommu)->reg + o)
+#define dmar_writeq(iommu, o, v) writeq(v, (iommu)->reg + o)
+#define dmar_readl(iommu, o) readl((iommu)->reg + o)
+#define dmar_writel(iommu, o, v) writel(v, (iommu)->reg + o)
 
 #define DMAR_VER_MAJOR(v)		(((v) & 0xf0) >> 4)
 #define DMAR_VER_MINOR(v)		((v) & 0x0f)
@@ -367,7 +367,7 @@
 do {									\
 	cycles_t start_time = get_cycles();				\
 	while (1) {							\
-		sts = op(iommu->reg + offset);				\
+		sts = op(iommu, offset);				\
 		if (cond)						\
 			break;						\
 		if (DMAR_OPERATION_TIMEOUT < (get_cycles() - start_time))\

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -826,9 +826,12 @@ struct intel_iommu {
 	u64		cap;
 	u64		ecap;
 	u32		vgsts;	/* Virtual GSTS register */
+	u64		viqa;  /* Virtual IQA register */
 	int		seq_id;	/* sequence id of the iommu */
 	int		agaw; /* agaw of this iommu */
 	int		msagaw; /* max sagaw of this iommu */
+	struct q_inval  _qi;    /* Queued invalidation info */
+	struct q_inval  *qi;    /* Pointer to _qi. Enables host code re-use */
 	pkvm_spinlock_t lock;
 };
 #endif /* !__PKVM_HYP__ */

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -506,7 +506,7 @@ struct q_inval {
 	pkvm_spinlock_t	q_lock;
 #endif
 	void		*desc;          /* invalidation queue */
-	int             *desc_status;   /* desc status */
+	int             desc_status[QI_LENGTH]; /* desc status */
 	int             free_head;      /* first free entry */
 	int             free_tail;      /* last free entry */
 	int             free_cnt;

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -832,6 +832,7 @@ struct intel_iommu {
 	int		msagaw; /* max sagaw of this iommu */
 	struct q_inval  _qi;    /* Queued invalidation info */
 	struct q_inval  *qi;    /* Pointer to _qi. Enables host code re-use */
+	struct iommu_flush flush;
 	pkvm_spinlock_t lock;
 };
 #endif /* !__PKVM_HYP__ */

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -382,6 +382,16 @@ do {									\
 		cpu_relax();						\
 	}								\
 } while (0)
+#else
+#define IOMMU_WAIT_OP(iommu, offset, op, cond, sts)			\
+do {									\
+	while (1) {							\
+		sts = op(iommu->reg + offset);				\
+		if (cond)						\
+			break;						\
+		cpu_relax();						\
+	}								\
+} while (0)
 #endif /* !__PKVM_HYP__ */
 
 #define QI_LENGTH	256	/* queue length */

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -150,10 +150,17 @@
 
 #define OFFSET_STRIDE		(9)
 
+#if defined(CONFIG_PKVM_INTEL) && !defined(__PKVM_HYP__)
+#define dmar_readq(iommu, o)		pkvm_readq((iommu)->reg, (iommu)->reg_phys, o)
+#define dmar_writeq(iommu, o, v)	pkvm_writeq((iommu)->reg, (iommu)->reg_phys, o, v)
+#define dmar_readl(iommu, o)		pkvm_readl((iommu)->reg, (iommu)->reg_phys, o)
+#define dmar_writel(iommu, o, v)	pkvm_writel((iommu)->reg, (iommu)->reg_phys, o, v)
+#else
 #define dmar_readq(iommu, o) readq((iommu)->reg + o)
 #define dmar_writeq(iommu, o, v) writeq(v, (iommu)->reg + o)
 #define dmar_readl(iommu, o) readl((iommu)->reg + o)
 #define dmar_writel(iommu, o, v) writel(v, (iommu)->reg + o)
+#endif /* CONFIG_PKVM_INTEL */
 
 #define DMAR_VER_MAJOR(v)		(((v) & 0xf0) >> 4)
 #define DMAR_VER_MINOR(v)		((v) & 0x0f)

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -362,6 +362,7 @@
 /* PERFINTRSTS_REG */
 #define DMA_PERFINTRSTS_PIS	((u32)1)
 
+#ifndef __PKVM_HYP__
 #define IOMMU_WAIT_OP(iommu, offset, op, cond, sts)			\
 do {									\
 	cycles_t start_time = get_cycles();				\
@@ -374,6 +375,7 @@ do {									\
 		cpu_relax();						\
 	}								\
 } while (0)
+#endif /* !__PKVM_HYP__ */
 
 #define QI_LENGTH	256	/* queue length */
 
@@ -481,7 +483,11 @@ struct qi_desc {
 };
 
 struct q_inval {
+#ifndef __PKVM_HYP__
 	raw_spinlock_t  q_lock;
+#else
+	pkvm_spinlock_t	q_lock;
+#endif
 	void		*desc;          /* invalidation queue */
 	int             *desc_status;   /* desc status */
 	int             free_head;      /* first free entry */
@@ -495,6 +501,7 @@ struct q_inval {
 #define PRQ_RING_MASK	(PRQ_SIZE - 0x20)
 #define PRQ_DEPTH	(PRQ_SIZE >> 5)
 
+#ifndef __PKVM_HYP__
 struct dmar_pci_notify_info;
 
 #ifdef CONFIG_IRQ_REMAP
@@ -515,6 +522,7 @@ void intel_irq_remap_add_device(struct dmar_pci_notify_info *info);
 static inline void
 intel_irq_remap_add_device(struct dmar_pci_notify_info *info) { }
 #endif
+#endif /* !__PKVM_HYP__ */
 
 struct iommu_flush {
 	void (*flush_context)(struct intel_iommu *iommu, u16 did, u16 sid,
@@ -597,8 +605,10 @@ struct qi_batch {
 };
 
 struct dmar_domain {
+#ifndef __PKVM_HYP__
 	int	nid;			/* node id */
 	struct xarray iommu_array;	/* Attached IOMMU array */
+#endif
 
 	u8 iommu_coherency: 1;		/* indicate coherency of iommu access */
 	u8 force_snooping : 1;		/* Create IOPTEs with snoop control */
@@ -617,6 +627,7 @@ struct dmar_domain {
 					 * buffer when creating mappings.
 					 */
 
+#ifndef __PKVM_HYP__
 	spinlock_t lock;		/* Protect device tracking lists */
 	struct list_head devices;	/* all devices' list */
 	struct list_head dev_pasids;	/* all attached pasids */
@@ -624,10 +635,12 @@ struct dmar_domain {
 	spinlock_t cache_lock;		/* Protect the cache tag list */
 	struct list_head cache_tags;	/* Cache tag list */
 	struct qi_batch *qi_batch;	/* Batched QI descriptors */
+#endif
 
 	int		iommu_superpage;/* Level of superpages supported:
 					   0 == 4KiB (no superpages), 1 == 2MiB,
 					   2 == 1GiB, 3 == 512GiB, 4 == 1TiB */
+#ifndef __PKVM_HYP__
 	union {
 		/* DMA remapping domain */
 		struct {
@@ -669,8 +682,25 @@ struct dmar_domain {
 
 	struct iommu_domain domain;	/* generic domain data structure for
 					   iommu core */
+#else
+	/* virtual address */
+	struct dma_pte	*pgd;
+	/* max guest address width */
+	int		gaw;
+	/*
+	 * adjusted guest address width:
+	 *   0: level 2 30-bit
+	 *   1: level 3 39-bit
+	 *   2: level 4 48-bit
+	 *   3: level 5 57-bit
+	 */
+	int		agaw;
+	/* maximum mapped address */
+	u64		max_addr;
+#endif /* !__PKVM_HYP__ */
 };
 
+#ifndef __PKVM_HYP__
 /*
  * In theory, the VT-d 4.0 spec can support up to 2 ^ 16 counters.
  * But in practice, there are only 14 counters for the existing
@@ -761,7 +791,22 @@ struct intel_iommu {
 
 	struct iommu_pmu *pmu;
 };
+#else
+struct intel_iommu {
+	void __iomem	*reg; /* Pointer to hardware regs, virtual addr */
+	u64		reg_phys; /* physical address of hw register set */
+	u64		reg_size; /* size of hw register set */
+	u64		cap;
+	u64		ecap;
+	u32		vgsts;	/* Virtual GSTS register */
+	int		seq_id;	/* sequence id of the iommu */
+	int		agaw; /* agaw of this iommu */
+	int		msagaw; /* max sagaw of this iommu */
+	pkvm_spinlock_t lock;
+};
+#endif /* !__PKVM_HYP__ */
 
+#ifndef __PKVM_HYP__
 /* PCI domain-device relationship */
 struct device_domain_info {
 	struct list_head link;	/* link to domain siblings */
@@ -798,6 +843,13 @@ struct dev_pasid_info {
 	struct dentry *debugfs_dentry; /* pointer to pasid directory dentry */
 #endif
 };
+#else
+struct device_domain_info {
+	u8 bus;			/* PCI bus number */
+	u8 devfn;		/* PCI devfn number */
+	struct intel_iommu *iommu; /* IOMMU used by this device */
+};
+#endif /* !__PKVM_HYP__ */
 
 static inline void __iommu_flush_cache(
 	struct intel_iommu *iommu, void *addr, int size)
@@ -806,11 +858,13 @@ static inline void __iommu_flush_cache(
 		clflush_cache_range(addr, size);
 }
 
+#ifndef __PKVM_HYP__
 /* Convert generic struct iommu_domain to private struct dmar_domain */
 static inline struct dmar_domain *to_dmar_domain(struct iommu_domain *dom)
 {
 	return container_of(dom, struct dmar_domain, domain);
 }
+#endif
 
 /*
  * Domain ID 0 and 1 are reserved:
@@ -830,6 +884,7 @@ static inline struct dmar_domain *to_dmar_domain(struct iommu_domain *dom)
 #define FLPT_DEFAULT_DID		1
 #define IDA_START_DID			2
 
+#ifndef __PKVM_HYP__
 /* Retrieve the domain ID which has allocated to the domain */
 static inline u16
 domain_id_iommu(struct dmar_domain *domain, struct intel_iommu *iommu)
@@ -854,6 +909,7 @@ static inline bool dev_is_real_dma_subdevice(struct device *dev)
 	return dev && dev_is_pci(dev) &&
 	       pci_real_dma_dev(to_pci_dev(dev)) != to_pci_dev(dev);
 }
+#endif /* !__PKVM_HYP__ */
 
 /*
  * 0: readable
@@ -1021,6 +1077,7 @@ static inline void context_clear_entry(struct context_entry *context)
 	context->hi = 0;
 }
 
+#ifndef __PKVM_HYP__
 #ifdef CONFIG_INTEL_IOMMU
 static inline bool context_copied(struct intel_iommu *iommu, u8 bus, u8 devfn)
 {
@@ -1042,6 +1099,9 @@ clear_context_copied(struct intel_iommu *iommu, u8 bus, u8 devfn)
 	clear_bit(((long)bus << 8) | devfn, iommu->copied_tables);
 }
 #endif /* CONFIG_INTEL_IOMMU */
+#else
+#define context_copied(iommu, bus, devfn) false
+#endif /* ! __PKVM_HYP__ */
 
 /*
  * Set the RID_PASID field of a scalable mode context entry. The
@@ -1305,6 +1365,7 @@ void cache_tag_flush_range_np(struct dmar_domain *domain, unsigned long start,
 void intel_context_flush_no_pasid(struct device_domain_info *info,
 				  struct context_entry *context, u16 did);
 
+#ifndef __PKVM_HYP__
 int intel_iommu_enable_prq(struct intel_iommu *iommu);
 int intel_iommu_finish_prq(struct intel_iommu *iommu);
 void intel_iommu_page_response(struct device *dev, struct iopf_fault *evt,
@@ -1375,9 +1436,11 @@ static inline void intel_iommu_debugfs_remove_dev_pasid(struct dev_pasid_info *d
 #endif /* CONFIG_INTEL_IOMMU_DEBUGFS */
 
 extern const struct attribute_group *intel_iommu_groups[];
+#endif /* !__PKVM_HYP__ */
 struct context_entry *iommu_context_addr(struct intel_iommu *iommu, u8 bus,
 					 u8 devfn, int alloc);
 
+#ifndef __PKVM_HYP__
 extern const struct iommu_ops intel_iommu_ops;
 extern const struct iommu_domain_ops intel_fs_paging_domain_ops;
 extern const struct iommu_domain_ops intel_ss_paging_domain_ops;
@@ -1391,11 +1454,13 @@ static inline bool intel_domain_is_ss_paging(struct dmar_domain *domain)
 {
 	return domain->domain.ops == &intel_ss_paging_domain_ops;
 }
+#endif /* !__PKVM_HYP__ */
 
 #ifdef CONFIG_INTEL_IOMMU
 extern int intel_iommu_sm;
 int iommu_calculate_agaw(struct intel_iommu *iommu);
 int iommu_calculate_max_sagaw(struct intel_iommu *iommu);
+#ifndef __PKVM_HYP__
 int ecmd_submit_sync(struct intel_iommu *iommu, u8 ecmd, u64 oa, u64 ob);
 
 static inline bool ecmd_has_pmu_essential(struct intel_iommu *iommu)
@@ -1403,6 +1468,7 @@ static inline bool ecmd_has_pmu_essential(struct intel_iommu *iommu)
 	return (iommu->ecmdcap[DMA_ECMD_ECCAP3] & DMA_ECMD_ECCAP3_ESSENTIAL) ==
 		DMA_ECMD_ECCAP3_ESSENTIAL;
 }
+#endif /* !__PKVM_HYP__ */
 
 extern int dmar_disabled;
 extern int intel_iommu_enabled;
@@ -1420,6 +1486,7 @@ static inline int iommu_calculate_max_sagaw(struct intel_iommu *iommu)
 #define intel_iommu_sm (0)
 #endif
 
+#ifndef __PKVM_HYP__
 static inline const char *decode_prq_descriptor(char *str, size_t size,
 		u64 dw0, u64 dw1, u64 dw2, u64 dw3)
 {
@@ -1447,5 +1514,6 @@ static inline const char *decode_prq_descriptor(char *str, size_t size,
 
 	return str;
 }
+#endif /* !__PKVM_HYP__ */
 
 #endif

--- a/drivers/iommu/intel/irq_remapping.c
+++ b/drivers/iommu/intel/irq_remapping.c
@@ -96,7 +96,7 @@ static void init_ir_status(struct intel_iommu *iommu)
 {
 	u32 gsts;
 
-	gsts = readl(iommu->reg + DMAR_GSTS_REG);
+	gsts = dmar_readl(iommu, DMAR_GSTS_REG);
 	if (gsts & DMA_GSTS_IRES)
 		iommu->flags |= VTD_FLAG_IRQ_REMAP_PRE_ENABLED;
 }
@@ -422,7 +422,7 @@ static int iommu_load_old_irte(struct intel_iommu *iommu)
 	u64 irta;
 
 	/* Check whether the old ir-table has the same size as ours */
-	irta = dmar_readq(iommu->reg + DMAR_IRTA_REG);
+	irta = dmar_readq(iommu, DMAR_IRTA_REG);
 	if ((irta & INTR_REMAP_TABLE_REG_SIZE_MASK)
 	     != INTR_REMAP_TABLE_REG_SIZE)
 		return -EINVAL;
@@ -465,14 +465,14 @@ static void iommu_set_irq_remapping(struct intel_iommu *iommu, int mode)
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flags);
 
-	dmar_writeq(iommu->reg + DMAR_IRTA_REG,
+	dmar_writeq(iommu, DMAR_IRTA_REG,
 		    (addr) | IR_X2APIC_MODE(mode) | INTR_REMAP_TABLE_REG_SIZE);
 
 	/* Set interrupt-remapping table pointer */
-	writel(iommu->gcmd | DMA_GCMD_SIRTP, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd | DMA_GCMD_SIRTP);
 
 	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-		      readl, (sts & DMA_GSTS_IRTPS), sts);
+		      dmar_readl, (sts & DMA_GSTS_IRTPS), sts);
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flags);
 
 	/*
@@ -492,16 +492,16 @@ static void iommu_enable_irq_remapping(struct intel_iommu *iommu)
 
 	/* Enable interrupt-remapping */
 	iommu->gcmd |= DMA_GCMD_IRE;
-	writel(iommu->gcmd, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd);
 	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-		      readl, (sts & DMA_GSTS_IRES), sts);
+		      dmar_readl, (sts & DMA_GSTS_IRES), sts);
 
 	/* Block compatibility-format MSIs */
 	if (sts & DMA_GSTS_CFIS) {
 		iommu->gcmd &= ~DMA_GCMD_CFI;
-		writel(iommu->gcmd, iommu->reg + DMAR_GCMD_REG);
+		dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd);
 		IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-			      readl, !(sts & DMA_GSTS_CFIS), sts);
+			      dmar_readl, !(sts & DMA_GSTS_CFIS), sts);
 	}
 
 	/*
@@ -658,15 +658,15 @@ static void iommu_disable_irq_remapping(struct intel_iommu *iommu)
 
 	raw_spin_lock_irqsave(&iommu->register_lock, flags);
 
-	sts = readl(iommu->reg + DMAR_GSTS_REG);
+	sts = dmar_readl(iommu, DMAR_GSTS_REG);
 	if (!(sts & DMA_GSTS_IRES))
 		goto end;
 
 	iommu->gcmd &= ~DMA_GCMD_IRE;
-	writel(iommu->gcmd, iommu->reg + DMAR_GCMD_REG);
+	dmar_writel(iommu, DMAR_GCMD_REG, iommu->gcmd);
 
 	IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG,
-		      readl, !(sts & DMA_GSTS_IRES), sts);
+		      dmar_readl, !(sts & DMA_GSTS_IRES), sts);
 
 end:
 	raw_spin_unlock_irqrestore(&iommu->register_lock, flags);

--- a/drivers/iommu/intel/perfmon.c
+++ b/drivers/iommu/intel/perfmon.c
@@ -96,10 +96,20 @@ IOMMU_PMU_ATTR(filter_page_table,	"config2:32-36",	IOMMU_PMU_FILTER_PAGE_TABLE);
 #define iommu_pmu_get_ats(filter)		(((filter) >> 24) & 0x1f)
 #define iommu_pmu_get_page_table(filter)	(((filter) >> 32) & 0x1f)
 
+#define dmar_pmu_readq(pmu, o)		dmar_readq((pmu)->iommu, (unsigned long)(o) - \
+						   (unsigned long)(pmu)->iommu->reg)
+#define dmar_pmu_writeq(pmu, o, v)	dmar_writeq((pmu)->iommu, (unsigned long)(o) - \
+						    (unsigned long)(pmu)->iommu->reg, (v))
+#define dmar_pmu_readl(pmu, o)		dmar_readl((pmu)->iommu, (unsigned long)(o) - \
+						   (unsigned long)(pmu)->iommu->reg)
+#define dmar_pmu_writel(pmu, o, v)	dmar_writel((pmu)->iommu, (unsigned long)(o) - \
+						    (unsigned long)(pmu)->iommu->reg, (v))
+
 #define iommu_pmu_set_filter(_name, _config, _filter, _idx, _econfig)		\
 {										\
 	if ((iommu_pmu->filter & _filter) && iommu_pmu_en_##_name(_econfig)) {	\
-		dmar_writel(iommu_pmu->cfg_reg + _idx * IOMMU_PMU_CFG_OFFSET +	\
+		dmar_pmu_writel(iommu_pmu,					\
+			    iommu_pmu->cfg_reg + _idx * IOMMU_PMU_CFG_OFFSET +	\
 			    IOMMU_PMU_CFG_SIZE +				\
 			    (ffs(_filter) - 1) * IOMMU_PMU_CFG_FILTERS_OFFSET,	\
 			    iommu_pmu_get_##_name(_config) | IOMMU_PMU_FILTER_EN);\
@@ -109,7 +119,8 @@ IOMMU_PMU_ATTR(filter_page_table,	"config2:32-36",	IOMMU_PMU_FILTER_PAGE_TABLE);
 #define iommu_pmu_clear_filter(_filter, _idx)					\
 {										\
 	if (iommu_pmu->filter & _filter) {					\
-		dmar_writel(iommu_pmu->cfg_reg + _idx * IOMMU_PMU_CFG_OFFSET +	\
+		dmar_pmu_writel(iommu_pmu,					\
+			    iommu_pmu->cfg_reg + _idx * IOMMU_PMU_CFG_OFFSET +	\
 			    IOMMU_PMU_CFG_SIZE +				\
 			    (ffs(_filter) - 1) * IOMMU_PMU_CFG_FILTERS_OFFSET,	\
 			    0);							\
@@ -307,7 +318,7 @@ static void iommu_pmu_event_update(struct perf_event *event)
 
 again:
 	prev_count = local64_read(&hwc->prev_count);
-	new_count = dmar_readq(iommu_event_base(iommu_pmu, hwc->idx));
+	new_count = dmar_pmu_readq(iommu_pmu, iommu_event_base(iommu_pmu, hwc->idx));
 	if (local64_xchg(&hwc->prev_count, new_count) != prev_count)
 		goto again;
 
@@ -340,7 +351,7 @@ static void iommu_pmu_start(struct perf_event *event, int flags)
 	hwc->state = 0;
 
 	/* Always reprogram the period */
-	count = dmar_readq(iommu_event_base(iommu_pmu, hwc->idx));
+	count = dmar_pmu_readq(iommu_pmu, iommu_event_base(iommu_pmu, hwc->idx));
 	local64_set((&hwc->prev_count), count);
 
 	/*
@@ -411,7 +422,7 @@ static int iommu_pmu_assign_event(struct iommu_pmu *iommu_pmu,
 	hwc->idx = idx;
 
 	/* config events */
-	dmar_writeq(iommu_config_base(iommu_pmu, idx), hwc->config);
+	dmar_pmu_writeq(iommu_pmu, iommu_config_base(iommu_pmu, idx), hwc->config);
 
 	iommu_pmu_set_filter(requester_id, event->attr.config1,
 			     IOMMU_PMU_FILTER_REQUESTER_ID, idx,
@@ -496,7 +507,7 @@ static void iommu_pmu_counter_overflow(struct iommu_pmu *iommu_pmu)
 	 * Two counters may be overflowed very close. Always check
 	 * whether there are more to handle.
 	 */
-	while ((status = dmar_readq(iommu_pmu->overflow))) {
+	while ((status = dmar_pmu_readq(iommu_pmu, iommu_pmu->overflow))) {
 		for_each_set_bit(i, (unsigned long *)&status, iommu_pmu->num_cntr) {
 			/*
 			 * Find the assigned event of the counter.
@@ -510,7 +521,7 @@ static void iommu_pmu_counter_overflow(struct iommu_pmu *iommu_pmu)
 			iommu_pmu_event_update(event);
 		}
 
-		dmar_writeq(iommu_pmu->overflow, status);
+		dmar_pmu_writeq(iommu_pmu, iommu_pmu->overflow, status);
 	}
 }
 
@@ -518,13 +529,13 @@ static irqreturn_t iommu_pmu_irq_handler(int irq, void *dev_id)
 {
 	struct intel_iommu *iommu = dev_id;
 
-	if (!dmar_readl(iommu->reg + DMAR_PERFINTRSTS_REG))
+	if (!dmar_readl(iommu, DMAR_PERFINTRSTS_REG))
 		return IRQ_NONE;
 
 	iommu_pmu_counter_overflow(iommu->pmu);
 
 	/* Clear the status bit */
-	dmar_writel(iommu->reg + DMAR_PERFINTRSTS_REG, DMA_PERFINTRSTS_PIS);
+	dmar_writel(iommu, DMAR_PERFINTRSTS_REG, DMA_PERFINTRSTS_PIS);
 
 	return IRQ_HANDLED;
 }
@@ -555,7 +566,7 @@ static int __iommu_pmu_register(struct intel_iommu *iommu)
 static inline void __iomem *
 get_perf_reg_address(struct intel_iommu *iommu, u32 offset)
 {
-	u32 off = dmar_readl(iommu->reg + offset);
+	u32 off = dmar_readl(iommu, offset);
 
 	return iommu->reg + off;
 }
@@ -574,7 +585,7 @@ int alloc_iommu_pmu(struct intel_iommu *iommu)
 	if (!cap_ecmds(iommu->cap))
 		return -ENODEV;
 
-	perfcap = dmar_readq(iommu->reg + DMAR_PERFCAP_REG);
+	perfcap = dmar_readq(iommu, DMAR_PERFCAP_REG);
 	/* The performance monitoring is not supported. */
 	if (!perfcap)
 		return -ENODEV;
@@ -617,8 +628,7 @@ int alloc_iommu_pmu(struct intel_iommu *iommu)
 	for (i = 0; i < iommu_pmu->num_eg; i++) {
 		u64 pcap;
 
-		pcap = dmar_readq(iommu->reg + DMAR_PERFEVNTCAP_REG +
-				  i * IOMMU_PMU_CAP_REGS_STEP);
+		pcap = dmar_readq(iommu, DMAR_PERFEVNTCAP_REG + i * IOMMU_PMU_CAP_REGS_STEP);
 		iommu_pmu->evcap[i] = pecap_es(pcap);
 	}
 
@@ -645,13 +655,15 @@ int alloc_iommu_pmu(struct intel_iommu *iommu)
 	iommu_pmu->cntr_reg = get_perf_reg_address(iommu, DMAR_PERFCNTROFF_REG);
 	iommu_pmu->overflow = get_perf_reg_address(iommu, DMAR_PERFOVFOFF_REG);
 
+	iommu_pmu->iommu = iommu;
+
 	/*
 	 * Check per-counter capabilities. All counters should have the
 	 * same capabilities on Interrupt on Overflow Support and Counter
 	 * Width.
 	 */
 	for (i = 0; i < iommu_pmu->num_cntr; i++) {
-		cap = dmar_readl(iommu_pmu->cfg_reg +
+		cap = dmar_pmu_readl(iommu_pmu, iommu_pmu->cfg_reg +
 				 i * IOMMU_PMU_CFG_OFFSET +
 				 IOMMU_PMU_CFG_CNTRCAP_OFFSET);
 		if (!iommu_cntrcap_pcc(cap))
@@ -675,7 +687,8 @@ int alloc_iommu_pmu(struct intel_iommu *iommu)
 
 		/* Override with per-counter event capabilities */
 		for (j = 0; j < iommu_cntrcap_egcnt(cap); j++) {
-			cap = dmar_readl(iommu_pmu->cfg_reg + i * IOMMU_PMU_CFG_OFFSET +
+			cap = dmar_pmu_readl(iommu_pmu,
+					 iommu_pmu->cfg_reg + i * IOMMU_PMU_CFG_OFFSET +
 					 IOMMU_PMU_CFG_CNTREVCAP_OFFSET +
 					 (j * IOMMU_PMU_OFF_REGS_STEP));
 			iommu_pmu->cntr_evcap[i][iommu_event_group(cap)] = iommu_event_select(cap);
@@ -687,7 +700,6 @@ int alloc_iommu_pmu(struct intel_iommu *iommu)
 		}
 	}
 
-	iommu_pmu->iommu = iommu;
 	iommu->pmu = iommu_pmu;
 
 	return 0;

--- a/drivers/iommu/intel/pkvm/Makefile.pkvm
+++ b/drivers/iommu/intel/pkvm/Makefile.pkvm
@@ -7,5 +7,5 @@ ccflags-$(CONFIG_PKVM_INTEL) += -I $(srctree)/drivers/iommu/intel
 pkvm-iommu = ../../../../drivers/iommu/intel/pkvm
 intel-iommu = ../../../../drivers/iommu/intel
 
-pkvm-hyp-$(CONFIG_PKVM_INTEL) += $(pkvm-iommu)/iommu.o $(intel-iommu)/iommu.o \
+pkvm-hyp-$(CONFIG_PKVM_INTEL) += $(pkvm-iommu)/iommu.o $(intel-iommu)/iommu.o $(pkvm-iommu)/iommu_hc.o \
 				 $(intel-iommu)/dmar.o

--- a/drivers/iommu/intel/pkvm/Makefile.pkvm
+++ b/drivers/iommu/intel/pkvm/Makefile.pkvm
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Makefile for IOMMU driver in pKVM
+
+ccflags-$(CONFIG_PKVM_INTEL) += -I $(srctree)/drivers/iommu/intel
+
+pkvm-iommu = ../../../../drivers/iommu/intel/pkvm
+
+pkvm-hyp-$(CONFIG_PKVM_INTEL) += $(pkvm-iommu)/iommu.o

--- a/drivers/iommu/intel/pkvm/Makefile.pkvm
+++ b/drivers/iommu/intel/pkvm/Makefile.pkvm
@@ -5,5 +5,6 @@
 ccflags-$(CONFIG_PKVM_INTEL) += -I $(srctree)/drivers/iommu/intel
 
 pkvm-iommu = ../../../../drivers/iommu/intel/pkvm
+intel-iommu = ../../../../drivers/iommu/intel
 
-pkvm-hyp-$(CONFIG_PKVM_INTEL) += $(pkvm-iommu)/iommu.o
+pkvm-hyp-$(CONFIG_PKVM_INTEL) += $(pkvm-iommu)/iommu.o $(intel-iommu)/iommu.o

--- a/drivers/iommu/intel/pkvm/Makefile.pkvm
+++ b/drivers/iommu/intel/pkvm/Makefile.pkvm
@@ -7,4 +7,5 @@ ccflags-$(CONFIG_PKVM_INTEL) += -I $(srctree)/drivers/iommu/intel
 pkvm-iommu = ../../../../drivers/iommu/intel/pkvm
 intel-iommu = ../../../../drivers/iommu/intel
 
-pkvm-hyp-$(CONFIG_PKVM_INTEL) += $(pkvm-iommu)/iommu.o $(intel-iommu)/iommu.o
+pkvm-hyp-$(CONFIG_PKVM_INTEL) += $(pkvm-iommu)/iommu.o $(intel-iommu)/iommu.o \
+				 $(intel-iommu)/dmar.o

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -45,6 +45,20 @@ struct intel_iommu *iommu_from_phys(unsigned long phys)
 	return NULL;
 }
 
+bool overlaps_iommu_mmio(unsigned long phys, unsigned long size)
+{
+	int i;
+
+	for (i = 0; i < nr_iommus; i++) {
+		struct intel_iommu *iommu = &iommus[i];
+
+		if (phys < (iommu->reg_phys + iommu->reg_size) &&
+		    (phys + size) > iommu->reg_phys)
+			return true;
+	}
+	return false;
+}
+
 static int iommu_direct_mmio_read(struct intel_iommu *iommu, u64 phys,
 				  int len, u64 *val)
 {

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -2,10 +2,73 @@
 /*
  * Copyright © 2026 Google.
  */
-#include "pkvm_iommu.h"
+#include <asm/kvm_pkvm.h>
+#include "pkvm/mmu.h"
+#include "pkvm/memory.h"
+#include "pkvm/pkvm.h"
+#include "pkvm/debug.h"
+#include "iommu.h"
+
+#define PKVM_MAX_IOMMU_NUM	16
+static struct intel_iommu iommus[PKVM_MAX_IOMMU_NUM];
+static int nr_iommus;
+
+int __init prepare_iommu(struct intel_iommu_info *info)
+{
+	struct intel_iommu *iommu;
+
+	if (nr_iommus >= PKVM_MAX_IOMMU_NUM)
+		return -ENOMEM;
+
+	iommu = &iommus[nr_iommus++];
+	iommu->reg_phys = info->reg_phys;
+	iommu->reg_size = info->reg_size;
+	iommu->cap = info->cap;
+	iommu->ecap = info->ecap;
+	iommu->agaw = info->agaw;
+	iommu->msagaw = info->msagaw;
+	iommu->seq_id = info->seq_id;
+
+	return 0;
+}
+
+static int iommu_init(struct intel_iommu *iommu)
+{
+	int ret;
+
+	if (!iommu->reg_phys)
+		return -EFAULT;
+
+	iommu->reg = __pkvm_va(iommu->reg_phys);
+	ret = pkvm_hyp_mmu_map((unsigned long)iommu->reg, iommu->reg_phys,
+			       iommu->reg_size, (u64)pgprot_val(PAGE_KERNEL_IO_NOCACHE));
+	if (ret) {
+		pkvm_err("iommu%d: failed to map MMIO space in hyp(err=%d)\n",
+			 iommu->seq_id, ret);
+		return ret;
+	}
+
+	pkvm_spin_lock_init(&iommu->lock);
+
+	/*
+	 * Take a snapshot of GSTS. GCMD updates will be handled by pKVM and
+	 * hence this snapshot will be kept up-to-date by pKVM and used as
+	 * virtual GSTS for the host.
+	 */
+	iommu->vgsts = readl(iommu->reg + DMAR_GSTS_REG);
+
+	return 0;
+}
 
 int pkvm_intel_iommu_init(void)
 {
-	/* TODO: Implement pKVM IOMMU initialization logic */
+	int i;
+
+	for (i = 0; i < nr_iommus; i++) {
+		int ret = iommu_init(&iommus[i]);
+
+		if (ret)
+			return ret;
+	}
 	return 0;
 }

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -9,6 +9,15 @@
 #include "pkvm/debug.h"
 #include "iommu.h"
 
+/*
+ * IOMMU supported page size and page levels for second stage page table.
+ *
+ * Here we set it to the maximum supported values and during IOMMU initialization,
+ * we determine the least common values supported by all the IOMMUs in the system.
+ */
+unsigned int iommu_pgsz_mask = 1 << PG_LEVEL_4K | 1 << PG_LEVEL_2M | 1 << PG_LEVEL_1G;
+unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
+
 #define PKVM_MAX_IOMMU_NUM	16
 static struct intel_iommu iommus[PKVM_MAX_IOMMU_NUM];
 static int nr_iommus;

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright © 2026 Google.
+ */
+#include "pkvm_iommu.h"
+
+int pkvm_intel_iommu_init(void)
+{
+	/* TODO: Implement pKVM IOMMU initialization logic */
+	return 0;
+}

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -23,7 +23,7 @@ unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
 /* GCMD oneshot bits where unsetting the bit doesn't have an effect */
 #define DMAR_GCMD_ONESHOT	(DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
 /* Mask of bits the host is allowed to access directly (passed through to hardware) */
-#define DMAR_GCMD_DIRECT	(DMA_GCMD_TE | DMA_GCMD_IRE | DMA_GCMD_CFI | DMA_GCMD_SIRTP)
+#define DMAR_GCMD_DIRECT	(DMA_GCMD_IRE | DMA_GCMD_CFI | DMA_GCMD_SIRTP)
 /* Mask of bits supported by pKVM */
 #define DMAR_GCMD_SUPPORTED_BITS	(DMAR_GSTS_EN_BITS | DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
 
@@ -219,6 +219,31 @@ static int handle_gcmd_srtp(struct intel_iommu *iommu)
 	return 0;
 }
 
+static int handle_gcmd_te(struct intel_iommu *iommu, bool enable)
+{
+	if (enable) {
+		if (iommu->vgsts & DMA_GSTS_TES) {
+			pkvm_err("iommu%d: TE allowed only once\n", iommu->seq_id);
+			return -EBUSY;
+		} else if (!(iommu->vgsts & DMA_GSTS_RTPS)) {
+			pkvm_err("iommu%d: TE not allowed before SRTP\n", iommu->seq_id);
+			return -EINVAL;
+		}
+
+		handle_gcmd_direct(iommu, DMA_GCMD_TE, true);
+		pkvm_dbg("iommu%d: Translation enabled!\n", iommu->seq_id);
+	} else {
+		/*
+		 * Translation is not really disabled as it would
+		 * compromise pKVM security guarantees.
+		 */
+		iommu->vgsts &= ~DMA_GSTS_TES;
+		pkvm_dbg("iommu%d: Translation marked as disabled!", iommu->seq_id);
+	}
+
+	return 0;
+}
+
 static int handle_global_cmd(struct intel_iommu *iommu, u32 val)
 {
 	u32 changed = (iommu->vgsts & DMAR_GSTS_EN_BITS) ^ val;
@@ -246,6 +271,9 @@ static int handle_global_cmd(struct intel_iommu *iommu, u32 val)
 
 	if (changed & DMA_GCMD_SRTP)
 		return handle_gcmd_srtp(iommu);
+
+	if (changed & DMA_GCMD_TE)
+		return handle_gcmd_te(iommu, !!(val & changed));
 
 	/*
 	 * Check if the bits are allowed to be directly accessible by the host

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -120,6 +120,9 @@ static int initialize_qi(struct intel_iommu *iommu)
 	 *       hypervisor take care of all QI logic.
 	 */
 
+	iommu->flush.flush_context = qi_flush_context;
+	iommu->flush.flush_iotlb = qi_flush_iotlb;
+
 	pkvm_spin_lock_init(&qi->q_lock);
 	qi->free_head = qi->free_tail = 0;
 	qi->free_cnt = QI_LENGTH;

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -182,6 +182,13 @@ static int iommu_init(struct intel_iommu *iommu)
 		return ret;
 	}
 
+	ret = pkvm_host_donate_hyp_mmio(iommu->reg_phys, PAGE_ALIGN(iommu->reg_size));
+	if (ret) {
+		pkvm_err("iommu%d: failed to donate MMIO space to hyp(err=%d)\n",
+			 iommu->seq_id, ret);
+		return ret;
+	}
+
 	pkvm_spin_lock_init(&iommu->lock);
 
 	/*

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -22,14 +22,118 @@ unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
 static struct intel_iommu iommus[PKVM_MAX_IOMMU_NUM];
 static int nr_iommus;
 
+static struct intel_iommu *iommu_from_phys(unsigned long phys)
+{
+	int i;
+
+	for (i = 0; i < nr_iommus; i++) {
+		struct intel_iommu *iommu = &iommus[i];
+
+		if (phys >= iommu->reg_phys && phys < (iommu->reg_phys + iommu->reg_size))
+			return iommu;
+	}
+
+	return NULL;
+}
+
+static int iommu_direct_mmio_read(struct intel_iommu *iommu, u64 phys,
+				  int len, u64 *val)
+{
+	unsigned long offset = phys - iommu->reg_phys;
+	void *reg = iommu->reg + offset;
+
+	switch (len) {
+	case 4:
+		*val = readl(reg);
+		break;
+	case 8:
+		*val = readq(reg);
+		break;
+	default:
+		pkvm_err("%s: unsupported len %d\n", __func__, len);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+static int iommu_direct_mmio_write(struct intel_iommu *iommu, u64 phys,
+				   int len, u64 val)
+{
+	unsigned long offset = phys - iommu->reg_phys;
+	void *reg = iommu->reg + offset;
+
+	switch (len) {
+	case 4:
+		writel((u32)val, reg);
+		break;
+	case 8:
+		writeq(val, reg);
+		break;
+	default:
+		pkvm_err("%s: unsupported len %d\n", __func__, len);
+		return -EINVAL;
+	}
+	return 0;
+}
+
 static int pkvm_iommu_mmio_read(u64 phys, int len, u64 *val)
 {
-	return 0;
+	struct intel_iommu *iommu = iommu_from_phys(phys);
+	unsigned long offset;
+	int ret = 0;
+
+	if (!iommu)
+		return -EINVAL;
+
+	pkvm_spin_lock(&iommu->lock);
+	offset = phys - iommu->reg_phys;
+
+	switch (offset) {
+	case DMAR_GCMD_REG:
+		ret = -EINVAL;
+		break;
+	case DMAR_CAP_REG:
+		*val = iommu->cap;
+		break;
+	case DMAR_ECAP_REG:
+		*val = iommu->ecap;
+		break;
+	default:
+		/* Not emulated MMIO can directly go to hardware */
+		ret = iommu_direct_mmio_read(iommu, phys, len, val);
+	}
+
+	pkvm_spin_unlock(&iommu->lock);
+	return ret;
 }
 
 static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
 {
-	return 0;
+	struct intel_iommu *iommu = iommu_from_phys(phys);
+	unsigned long offset;
+	int ret = 0;
+
+	if (!iommu)
+		return -EINVAL;
+
+	pkvm_spin_lock(&iommu->lock);
+	offset = phys - iommu->reg_phys;
+
+	switch (offset) {
+	case DMAR_CAP_REG:
+		fallthrough;
+	case DMAR_ECAP_REG:
+		fallthrough;
+	case DMAR_GSTS_REG:
+		ret = -EINVAL;
+		break;
+	default:
+		/* Not emulated MMIO can directly go to hardware */
+		ret = iommu_direct_mmio_write(iommu, phys, len, val);
+	}
+
+	pkvm_spin_unlock(&iommu->lock);
+	return ret;
 }
 
 static int pkvm_handle_iommu_hypercall(void *in, void *out)

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -23,7 +23,8 @@ unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
 /* GCMD oneshot bits where unsetting the bit doesn't have an effect */
 #define DMAR_GCMD_ONESHOT	(DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
 /* Mask of bits the host is allowed to access directly (passed through to hardware) */
-#define DMAR_GCMD_DIRECT	(DMAR_GSTS_EN_BITS | DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
+#define DMAR_GCMD_DIRECT	(DMA_GCMD_TE | DMA_GCMD_IRE | DMA_GCMD_CFI | DMA_GCMD_SRTP | \
+				 DMA_GCMD_SIRTP)
 /* Mask of bits supported by pKVM */
 #define DMAR_GCMD_SUPPORTED_BITS	(DMAR_GSTS_EN_BITS | DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
 
@@ -109,6 +110,70 @@ static int handle_gcmd_direct(struct intel_iommu *iommu, u32 gcmd_bit, bool set)
 	return 0;
 }
 
+static int initialize_qi(struct intel_iommu *iommu)
+{
+	struct q_inval *qi = iommu->qi;
+	u64 val = __pkvm_pa(qi->desc);
+
+	/*
+	 * TODO: Write protect QI descriptor page once we have
+	 *       hypervisor take care of all QI logic.
+	 */
+
+	pkvm_spin_lock_init(&qi->q_lock);
+	qi->free_head = qi->free_tail = 0;
+	qi->free_cnt = QI_LENGTH;
+
+	/*
+	 * Set DW=1 and QS=1 in IQA_REG when Scalable Mode capability
+	 * is present.
+	 */
+	if (sm_supported(iommu))
+		val |= BIT_ULL(11) | BIT_ULL(0);
+
+	/* write zero to the tail reg */
+	writel(0, iommu->reg + DMAR_IQT_REG);
+	/* Set IQA */
+	writeq(val, iommu->reg + DMAR_IQA_REG);
+
+	return handle_gcmd_direct(iommu, DMA_GCMD_QIE, true);
+}
+
+static int handle_gcmd_qie(struct intel_iommu *iommu, bool enable)
+{
+	int ret = 0;
+
+	if (enable) {
+		if (iommu->qi || iommu->vgsts & DMA_GSTS_QIES) {
+			pkvm_err("iommu%d: QI already enabled\n", iommu->seq_id);
+			return -EBUSY;
+		} else if (!iommu->viqa) {
+			pkvm_err("iommu%d: QIE before setting IQA\n", iommu->seq_id);
+			return -EINVAL;
+		}
+
+		/*
+		 * Host IOMMU driver dynamically allocates iommu->qi, but pKVM has it
+		 * embedded. For easy re-use of host code, the embedded field is named
+		 * as iommu->_qi, and the pointer iommu->qi points to iommu->_qi.
+		 * Also, it serves as a flag to denote whether qi is
+		 * enabled(similar to how host driver does)
+		 */
+		iommu->qi = &iommu->_qi;
+		iommu->qi->desc = pkvm_host_gpa_to_virt(iommu->viqa & VTD_PAGE_MASK);
+		ret = initialize_qi(iommu);
+	} else {
+		if (!iommu->qi)
+			ret = handle_gcmd_direct(iommu, DMA_GCMD_QIE, false);
+		else
+			iommu->vgsts &= ~DMA_GSTS_QIES;
+	}
+
+	pkvm_dbg("iommu%d: Quueued Invalidation %s!\n", iommu->seq_id,
+		 enable ? "enabled" : "disabled");
+	return ret;
+}
+
 static int handle_global_cmd(struct intel_iommu *iommu, u32 val)
 {
 	u32 changed = (iommu->vgsts & DMAR_GSTS_EN_BITS) ^ val;
@@ -130,6 +195,9 @@ static int handle_global_cmd(struct intel_iommu *iommu, u32 val)
 
 	pkvm_dbg("iommu%d: handle gcmd val 0x%x gsts 0x%x changed 0x%x\n",
 		 iommu->seq_id, val, iommu->vgsts, changed);
+
+	if (changed & DMA_GCMD_QIE)
+		return handle_gcmd_qie(iommu, !!(val & changed));
 
 	/*
 	 * Check if the bits are allowed to be directly accessible by the host
@@ -166,6 +234,9 @@ static int pkvm_iommu_mmio_read(u64 phys, int len, u64 *val)
 	case DMAR_ECAP_REG:
 		*val = iommu->ecap;
 		break;
+	case DMAR_IQA_REG:
+		*val = iommu->viqa;
+		break;
 	default:
 		/* Not emulated MMIO can directly go to hardware */
 		ret = iommu_direct_mmio_read(iommu, phys, len, val);
@@ -197,6 +268,15 @@ static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
 		break;
 	case DMAR_GCMD_REG:
 		ret = handle_global_cmd(iommu, val);
+		break;
+	case DMAR_IQA_REG:
+		if (iommu->viqa) {
+			pkvm_err("iommu%d: IQA set more than once!\n",
+				 iommu->seq_id);
+			ret = -EINVAL;
+		} else {
+			iommu->viqa = val;
+		}
 		break;
 	default:
 		/* Not emulated MMIO can directly go to hardware */

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -23,8 +23,7 @@ unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
 /* GCMD oneshot bits where unsetting the bit doesn't have an effect */
 #define DMAR_GCMD_ONESHOT	(DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
 /* Mask of bits the host is allowed to access directly (passed through to hardware) */
-#define DMAR_GCMD_DIRECT	(DMA_GCMD_TE | DMA_GCMD_IRE | DMA_GCMD_CFI | DMA_GCMD_SRTP | \
-				 DMA_GCMD_SIRTP)
+#define DMAR_GCMD_DIRECT	(DMA_GCMD_TE | DMA_GCMD_IRE | DMA_GCMD_CFI | DMA_GCMD_SIRTP)
 /* Mask of bits supported by pKVM */
 #define DMAR_GCMD_SUPPORTED_BITS	(DMAR_GSTS_EN_BITS | DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
 
@@ -180,6 +179,46 @@ static int handle_gcmd_qie(struct intel_iommu *iommu, bool enable)
 	return ret;
 }
 
+static void set_root_table(struct intel_iommu *iommu)
+{
+	writeq(iommu->vrta, iommu->reg + DMAR_RTADDR_REG);
+	handle_gcmd_direct(iommu, DMA_GCMD_SRTP, true);
+
+	if (cap_esrtps(iommu->cap))
+		return;
+
+	iommu->flush.flush_context(iommu, 0, 0, 0, DMA_CCMD_GLOBAL_INVL);
+	if (sm_supported(iommu))
+		qi_flush_pasid_cache(iommu, 0, QI_PC_GLOBAL, 0);
+	iommu->flush.flush_iotlb(iommu, 0, 0, 0, DMA_TLB_GLOBAL_FLUSH);
+}
+
+static int handle_gcmd_srtp(struct intel_iommu *iommu)
+{
+	u32 gsts = readl(iommu->reg + DMAR_GSTS_REG);
+
+	if (WARN_ON(gsts != iommu->vgsts))
+		iommu->vgsts = gsts;
+
+	if (!iommu->vrta) {
+		pkvm_warn("iommu%d: host RTADDR_REG not set", iommu->seq_id);
+		return -EINVAL;
+	} else if (iommu->vgsts & DMA_GSTS_TES) {
+		pkvm_warn("iommu%d: SRTP not allowed after TE", iommu->seq_id);
+		return -EBUSY;
+	} else if (iommu->root_entry) {
+		pkvm_warn("iommu%d: SRTP allowed only once", iommu->seq_id);
+		return -EBUSY;
+	}
+
+	/* TODO: Write protect Root Table page */
+	set_root_table(iommu);
+	iommu->root_entry = pkvm_host_gpa_to_virt(iommu->vrta & VTD_PAGE_MASK);
+
+	pkvm_dbg("iommu%d Set Root Table(%llx)!\n", iommu->seq_id, iommu->vrta);
+	return 0;
+}
+
 static int handle_global_cmd(struct intel_iommu *iommu, u32 val)
 {
 	u32 changed = (iommu->vgsts & DMAR_GSTS_EN_BITS) ^ val;
@@ -204,6 +243,9 @@ static int handle_global_cmd(struct intel_iommu *iommu, u32 val)
 
 	if (changed & DMA_GCMD_QIE)
 		return handle_gcmd_qie(iommu, !!(val & changed));
+
+	if (changed & DMA_GCMD_SRTP)
+		return handle_gcmd_srtp(iommu);
 
 	/*
 	 * Check if the bits are allowed to be directly accessible by the host
@@ -242,6 +284,12 @@ static int pkvm_iommu_mmio_read(u64 phys, int len, u64 *val)
 		break;
 	case DMAR_IQA_REG:
 		*val = iommu->viqa;
+		break;
+	case DMAR_RTADDR_REG:
+		*val = iommu->vrta;
+		break;
+	case DMAR_GSTS_REG:
+		*val = iommu->vgsts;
 		break;
 	default:
 		/* Not emulated MMIO can directly go to hardware */
@@ -291,6 +339,19 @@ static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
 			pkvm_err("iommu%d: write to IQT not allowed!\n",
 				 iommu->seq_id);
 			return -EPERM;
+		}
+		break;
+	case DMAR_RTADDR_REG:
+		if (sm_supported(iommu) && !(val & DMA_RTADDR_SMT)) {
+			pkvm_err("iommu%d: SM enabled but not set in RTA!\n",
+				 iommu->seq_id);
+			ret = -EINVAL;
+		} else if (iommu->vgsts & DMA_GSTS_TES) {
+			pkvm_err("iommu%d: Setting RTA after Translation enabled!\n",
+				 iommu->seq_id);
+			ret = -EBUSY;
+		} else {
+			iommu->vrta = val;
 		}
 		break;
 	default:

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -32,7 +32,7 @@ unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
 static struct intel_iommu iommus[PKVM_MAX_IOMMU_NUM];
 static int nr_iommus;
 
-static struct intel_iommu *iommu_from_phys(unsigned long phys)
+struct intel_iommu *iommu_from_phys(unsigned long phys)
 {
 	int i;
 
@@ -112,13 +112,16 @@ static int handle_gcmd_direct(struct intel_iommu *iommu, u32 gcmd_bit, bool set)
 
 static int initialize_qi(struct intel_iommu *iommu)
 {
+	u64 desc_sz = ecap_smts(iommu->ecap) ? SZ_8K : SZ_4K;
 	struct q_inval *qi = iommu->qi;
 	u64 val = __pkvm_pa(qi->desc);
+	int ret;
 
-	/*
-	 * TODO: Write protect QI descriptor page once we have
-	 *       hypervisor take care of all QI logic.
-	 */
+	ret = pkvm_host_donate_hyp_share_ro(val, desc_sz, true);
+	if (ret) {
+		pkvm_err("iommu%d: failed to write protect QI desc!\n", iommu->seq_id);
+		return ret;
+	}
 
 	iommu->flush.flush_context = qi_flush_context;
 	iommu->flush.flush_iotlb = qi_flush_iotlb;
@@ -267,6 +270,8 @@ static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
 	case DMAR_ECAP_REG:
 		fallthrough;
 	case DMAR_GSTS_REG:
+		fallthrough;
+	case DMAR_IQH_REG:
 		ret = -EINVAL;
 		break;
 	case DMAR_GCMD_REG:
@@ -281,6 +286,13 @@ static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
 			iommu->viqa = val;
 		}
 		break;
+	case DMAR_IQT_REG:
+		if (iommu->qi) {
+			pkvm_err("iommu%d: write to IQT not allowed!\n",
+				 iommu->seq_id);
+			return -EPERM;
+		}
+		break;
 	default:
 		/* Not emulated MMIO can directly go to hardware */
 		ret = iommu_direct_mmio_write(iommu, phys, len, val);
@@ -292,7 +304,20 @@ static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
 
 static int pkvm_handle_iommu_hypercall(void *in, void *out)
 {
-	return 0;
+	struct iommu_hc_data *data_in = (struct iommu_hc_data *)in;
+	int ret;
+
+	switch (data_in->hc_num) {
+	case qi_submit:
+		ret = pkvm_iommu_qi_submit(&data_in->qi_submit);
+		break;
+	default:
+		pkvm_err("Invalid hypercall: %d\n", data_in->hc_num);
+		ret = -EINVAL;
+	}
+
+	*(struct iommu_hc_data *)out = *data_in;
+	return ret;
 }
 
 struct pkvm_iommu_ops iommu_ops = {

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -22,6 +22,27 @@ unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
 static struct intel_iommu iommus[PKVM_MAX_IOMMU_NUM];
 static int nr_iommus;
 
+static int pkvm_iommu_mmio_read(u64 phys, int len, u64 *val)
+{
+	return 0;
+}
+
+static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
+{
+	return 0;
+}
+
+static int pkvm_handle_iommu_hypercall(void *in, void *out)
+{
+	return 0;
+}
+
+struct pkvm_iommu_ops iommu_ops = {
+	.mmio_read = pkvm_iommu_mmio_read,
+	.mmio_write = pkvm_iommu_mmio_write,
+	.hypercall = pkvm_handle_iommu_hypercall,
+};
+
 int __init prepare_iommu(struct intel_iommu_info *info)
 {
 	struct intel_iommu *iommu;
@@ -79,5 +100,6 @@ int pkvm_intel_iommu_init(void)
 		if (ret)
 			return ret;
 	}
+	pkvm_register_iommu_ops(&iommu_ops);
 	return 0;
 }

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -18,6 +18,15 @@
 unsigned int iommu_pgsz_mask = 1 << PG_LEVEL_4K | 1 << PG_LEVEL_2M | 1 << PG_LEVEL_1G;
 unsigned int iommu_pglvl_mask = IOMMU_PGT_4LEVEL | IOMMU_PGT_5LEVEL;
 
+/* GCMD bits that handle enabling/disabling of IOMMU features */
+#define DMAR_GSTS_EN_BITS	(DMA_GCMD_TE | DMA_GCMD_QIE | DMA_GCMD_IRE | DMA_GCMD_CFI)
+/* GCMD oneshot bits where unsetting the bit doesn't have an effect */
+#define DMAR_GCMD_ONESHOT	(DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
+/* Mask of bits the host is allowed to access directly (passed through to hardware) */
+#define DMAR_GCMD_DIRECT	(DMAR_GSTS_EN_BITS | DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
+/* Mask of bits supported by pKVM */
+#define DMAR_GCMD_SUPPORTED_BITS	(DMAR_GSTS_EN_BITS | DMA_GCMD_SRTP | DMA_GCMD_SIRTP)
+
 #define PKVM_MAX_IOMMU_NUM	16
 static struct intel_iommu iommus[PKVM_MAX_IOMMU_NUM];
 static int nr_iommus;
@@ -76,6 +85,65 @@ static int iommu_direct_mmio_write(struct intel_iommu *iommu, u64 phys,
 	return 0;
 }
 
+static int handle_gcmd_direct(struct intel_iommu *iommu, u32 gcmd_bit, bool set)
+{
+	u32 gcmd = iommu->vgsts & DMAR_GSTS_EN_BITS;
+	u32 sts;
+
+	if ((gcmd_bit & DMAR_GCMD_ONESHOT) && !set)
+		return -EINVAL;
+
+	if (set)
+		gcmd |= gcmd_bit;
+	else
+		gcmd &= ~gcmd_bit;
+
+	writel(gcmd, iommu->reg + DMAR_GCMD_REG);
+	if (set)
+		IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG, readl, (sts & gcmd_bit), sts);
+	else
+		IOMMU_WAIT_OP(iommu, DMAR_GSTS_REG, readl, !(sts & gcmd_bit), sts);
+
+	iommu->vgsts = (iommu->vgsts & DMAR_GCMD_ONESHOT) | gcmd;
+
+	return 0;
+}
+
+static int handle_global_cmd(struct intel_iommu *iommu, u32 val)
+{
+	u32 changed = (iommu->vgsts & DMAR_GSTS_EN_BITS) ^ val;
+
+	if (!changed)
+		return 0;
+
+	if (hweight32(changed) > 1) {
+		pkvm_warn("iommu%d: more than one changed bit in a gcmd write(%x)\n",
+			  iommu->seq_id, val);
+		return -EINVAL;
+	}
+
+	if (changed & ~DMAR_GCMD_SUPPORTED_BITS) {
+		pkvm_warn("iommu%d: received GCMD for unsupported bit: %x\n",
+			  iommu->seq_id, changed);
+		return -EOPNOTSUPP;
+	}
+
+	pkvm_dbg("iommu%d: handle gcmd val 0x%x gsts 0x%x changed 0x%x\n",
+		 iommu->seq_id, val, iommu->vgsts, changed);
+
+	/*
+	 * Check if the bits are allowed to be directly accessible by the host
+	 * and passthrough if so.
+	 */
+	if (changed & ~DMAR_GCMD_DIRECT) {
+		pkvm_warn("iommu%d: direct access of GCMD bit: %x(set=%d) not allowed\n",
+			  iommu->seq_id, changed, !!(val & changed));
+		return -EPERM;
+	}
+
+	return handle_gcmd_direct(iommu, changed, !!(val & changed));
+}
+
 static int pkvm_iommu_mmio_read(u64 phys, int len, u64 *val)
 {
 	struct intel_iommu *iommu = iommu_from_phys(phys);
@@ -126,6 +194,9 @@ static int pkvm_iommu_mmio_write(u64 phys, int len, u64 val)
 		fallthrough;
 	case DMAR_GSTS_REG:
 		ret = -EINVAL;
+		break;
+	case DMAR_GCMD_REG:
+		ret = handle_global_cmd(iommu, val);
 		break;
 	default:
 		/* Not emulated MMIO can directly go to hardware */

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright © 2026 Google.
+ *
+ */
+#include <asm/kvm_pkvm.h>
+#include "pkvm/mmu.h"
+#include "pkvm/memory.h"
+#include "pkvm/pkvm.h"
+#include "pkvm/debug.h"
+#include "iommu_hc.h"
+#include "../iommu.h"
+
+int pkvm_iommu_qi_submit(struct qi_submit_data *data)
+{
+	struct intel_iommu *iommu = iommu_from_phys(data->phys);
+
+	if (!iommu)
+		return -EINVAL;
+
+	BUG_ON(!iommu->qi);
+
+	return qi_submit_sync(iommu, pkvm_host_gpa_to_virt(data->desc_gpa),
+			      data->count, data->options);
+}

--- a/drivers/iommu/intel/pkvm/iommu_hc.h
+++ b/drivers/iommu/intel/pkvm/iommu_hc.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright © 2026 Google
+ */
+
+#ifndef _PKVM_INTEL_IOMMU_HC_H_
+#define _PKVM_INTEL_IOMMU_HC_H_
+
+#include <asm/kvm_pkvm.h>
+
+enum iommu_hc_num {
+	qi_submit,
+};
+
+struct qi_submit_data {
+	u64 phys;
+	u64 desc_gpa;
+	u32 options;
+	u32 count;
+};
+
+struct iommu_hc_data {
+	union {
+		struct qi_submit_data qi_submit;
+	};
+	u8 hc_num;
+};
+static_assert(sizeof(struct iommu_hc_data) <= PKVM_HC_DATA_MAX_NUM * sizeof(u64));
+
+int pkvm_iommu_qi_submit(struct qi_submit_data *data);
+#endif /* _PKVM_INTEL_IOMMU_HC_H_ */

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -12,7 +12,67 @@
 
 int __init pkvm_host_prepare_iommu(void)
 {
-	return 0;
+	struct dmar_drhd_unit *drhd;
+	struct intel_iommu *iommu;
+	int ret;
+
+	down_write(&dmar_global_lock);
+	ret = dmar_table_init();
+	if (ret) {
+		pr_err("Failed to initialize DMAR table!\n");
+		goto out;
+	}
+
+	ret = -ENODEV;
+	for_each_iommu(iommu, drhd) {
+		if (drhd->ignored) {
+			pr_warn("iommu%d ignored, but pKVM needs iommu to be enabled!\n",
+				iommu->seq_id);
+			goto out;
+		}
+
+		if (readl(iommu->reg + DMAR_GSTS_REG) & DMA_GSTS_TES) {
+			pr_warn("iommu%d: Translation enabled before initialization!\n",
+					iommu->seq_id);
+			goto out;
+		}
+
+		/*
+		 * Since pKVM is not expected to be supported on ancient hardware which
+		 * requires write buffer flushing, require cap_rwbf=0 for simplicity.
+		 */
+		if (cap_rwbf(iommu->cap)) {
+			pr_warn("iommu%d: CAP.RWBF=1 is not supported!\n", iommu->seq_id);
+			goto out;
+		}
+
+		/* pKVM expects Queued Invalidation support for simplicity and efficiency */
+		if (!ecap_qis(iommu->ecap)) {
+			pr_warn("iommu%d: queued Invalidation not supported!\n", iommu->seq_id);
+			goto out;
+		}
+	}
+
+	pkvm_sym(intel_iommu_sm) = intel_iommu_sm;
+
+	for_each_iommu(iommu, drhd) {
+		struct intel_iommu_info info = {
+			.reg_phys = iommu->reg_phys,
+			.reg_size = iommu->reg_size,
+			.cap = iommu->cap,
+			.ecap = iommu->ecap,
+			.seq_id = iommu->seq_id,
+			.agaw = iommu->agaw,
+			.msagaw = iommu->msagaw,
+		};
+
+		ret = pkvm_sym(prepare_iommu)(&info);
+		if (ret)
+			goto out;
+	}
+out:
+	up_write(&dmar_global_lock);
+	return ret;
 }
 
 int __init pkvm_host_init_iommu(void)

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -100,3 +100,27 @@ int __init pkvm_host_init_iommu(void)
 {
 	return intel_iommu_init();
 }
+
+int pv_qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
+		      unsigned int count, unsigned long options)
+{
+	union pkvm_hc_data d = { 0 };
+	struct iommu_hc_data *data = (struct iommu_hc_data *)&d;
+	struct qi_desc *desc_ptr;
+	int ret;
+
+	desc_ptr = kcalloc(count, sizeof(struct qi_desc), GFP_ATOMIC);
+	if (!desc_ptr)
+		return -ENOMEM;
+
+	memcpy(desc_ptr, desc, count * sizeof(struct qi_desc));
+	data->qi_submit.desc_gpa = virt_to_phys(desc_ptr);
+	data->qi_submit.phys = iommu->reg_phys;
+	data->qi_submit.count = count;
+	data->qi_submit.options = options;
+	data->hc_num = qi_submit;
+
+	ret = pkvm_hypercall_inout(iommu_hypercall, &d, &d);
+	kfree(desc_ptr);
+	return ret;
+}

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright © 2026 Google.
+ *
+ */
+
+#define pr_fmt(fmt)     "DMAR: pkvm: " fmt
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include "iommu.h"
+
+int __init pkvm_host_prepare_iommu(void)
+{
+	return 0;
+}
+
+int __init pkvm_host_init_iommu(void)
+{
+	return intel_iommu_init();
+}

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -25,6 +25,9 @@ int __init pkvm_host_prepare_iommu(void)
 
 	ret = -ENODEV;
 	for_each_iommu(iommu, drhd) {
+		unsigned int pgsz_mask = 1 << PG_LEVEL_4K;
+		unsigned int pglvl_mask = 0;
+
 		if (drhd->ignored) {
 			pr_warn("iommu%d ignored, but pKVM needs iommu to be enabled!\n",
 				iommu->seq_id);
@@ -51,6 +54,24 @@ int __init pkvm_host_prepare_iommu(void)
 			pr_warn("iommu%d: queued Invalidation not supported!\n", iommu->seq_id);
 			goto out;
 		}
+
+		if (cap_sagaw(iommu->cap) & IOMMU_PGT_4LEVEL)
+			pglvl_mask |= IOMMU_PGT_4LEVEL;
+		if (cap_sagaw(iommu->cap) & IOMMU_PGT_5LEVEL)
+			pglvl_mask |= IOMMU_PGT_5LEVEL;
+
+		if (cap_super_page_val(iommu->cap) & BIT(0))
+			pgsz_mask |= 1 << PG_LEVEL_2M;
+		if (cap_super_page_val(iommu->cap) & BIT(1))
+			pgsz_mask |= 1 << PG_LEVEL_1G;
+
+		if (!pglvl_mask) {
+			pr_warn("iommu%d: No supported page levels\n", iommu->seq_id);
+			goto out;
+		}
+
+		pkvm_sym(iommu_pglvl_mask) &= pglvl_mask;
+		pkvm_sym(iommu_pgsz_mask) &= pgsz_mask;
 	}
 
 	pkvm_sym(intel_iommu_sm) = intel_iommu_sm;

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -6,10 +6,30 @@
 #ifndef _PKVM_INTEL_IOMMU_H_
 #define _PKVM_INTEL_IOMMU_H_
 
+/* expose pkvm_enabled() when !CONFIG_PKVM_X86 */
+#include <asm/kvm_host.h>
+#include <asm/kvm_pkvm.h>
+
+struct intel_iommu_info {
+	u64 reg_phys;
+	u64 reg_size;
+	u64 cap;
+	u64 ecap;
+	int seq_id;
+	int agaw;
+	int msagaw;
+};
+
+#ifdef CONFIG_PKVM_INTEL
+extern int pkvm_sym(intel_iommu_sm);
+
+PKVM_DECLARE(int, prepare_iommu, (struct intel_iommu_info *info));
+
 #ifndef __PKVM_HYP__
 int __init pkvm_host_prepare_iommu(void);
 int __init pkvm_host_init_iommu(void);
-#else
+#else /* __PKVM_HYP__ */
 int pkvm_intel_iommu_init(void);
-#endif
-#endif
+#endif /* !__PKVM_HYP__ */
+#endif /* CONFIG_PKVM_INTEL */
+#endif /* _PKVM_INTEL_IOMMU_H_ */

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -6,7 +6,10 @@
 #ifndef _PKVM_INTEL_IOMMU_H_
 #define _PKVM_INTEL_IOMMU_H_
 
-#ifdef __PKVM_HYP__
+#ifndef __PKVM_HYP__
+int __init pkvm_host_prepare_iommu(void);
+int __init pkvm_host_init_iommu(void);
+#else
 int pkvm_intel_iommu_init(void);
 #endif
 #endif

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -10,6 +10,10 @@
 #include <asm/kvm_host.h>
 #include <asm/kvm_pkvm.h>
 
+/* Page table level represented by IOMMU cap SAGAW bits */
+#define IOMMU_PGT_4LEVEL	BIT(2)
+#define IOMMU_PGT_5LEVEL	BIT(3)
+
 struct intel_iommu_info {
 	u64 reg_phys;
 	u64 reg_size;
@@ -21,6 +25,9 @@ struct intel_iommu_info {
 };
 
 #ifdef CONFIG_PKVM_INTEL
+extern unsigned int pkvm_sym(iommu_pglvl_mask);
+extern unsigned int pkvm_sym(iommu_pgsz_mask);
+
 extern int pkvm_sym(intel_iommu_sm);
 
 PKVM_DECLARE(int, prepare_iommu, (struct intel_iommu_info *info));
@@ -29,6 +36,21 @@ PKVM_DECLARE(int, prepare_iommu, (struct intel_iommu_info *info));
 int __init pkvm_host_prepare_iommu(void);
 int __init pkvm_host_init_iommu(void);
 #else /* __PKVM_HYP__ */
+static inline bool iommu_supports_2m_page(void)
+{
+	return iommu_pgsz_mask & (1 << PG_LEVEL_2M);
+}
+
+static inline bool iommu_supports_1g_page(void)
+{
+	return iommu_pgsz_mask & (1 << PG_LEVEL_1G);
+}
+
+static inline bool iommu_supports_5levels(void)
+{
+	return iommu_pglvl_mask & IOMMU_PGT_5LEVEL;
+}
+
 int pkvm_intel_iommu_init(void);
 #endif /* !__PKVM_HYP__ */
 #endif /* CONFIG_PKVM_INTEL */

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright © 2026 Google
+ */
+
+#ifndef _PKVM_INTEL_IOMMU_H_
+#define _PKVM_INTEL_IOMMU_H_
+
+#ifdef __PKVM_HYP__
+int pkvm_intel_iommu_init(void);
+#endif
+#endif

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -100,6 +100,13 @@ static inline bool iommu_supports_5levels(void)
 }
 
 struct intel_iommu *iommu_from_phys(unsigned long phys);
+static inline bool is_iommu_mmio(unsigned long phys)
+{
+	return !!iommu_from_phys(phys);
+}
+
+bool overlaps_iommu_mmio(unsigned long phys, unsigned long size);
+
 int pkvm_intel_iommu_init(void);
 #endif /* !__PKVM_HYP__ */
 #else /* !CONFIG_PKVM_INTEL */

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -24,7 +24,12 @@ struct intel_iommu_info {
 	int msagaw;
 };
 
+struct qi_desc;
+struct intel_iommu;
+
 #ifdef CONFIG_PKVM_INTEL
+#include "pkvm/iommu_hc.h"
+
 extern unsigned int pkvm_sym(iommu_pglvl_mask);
 extern unsigned int pkvm_sym(iommu_pgsz_mask);
 
@@ -75,6 +80,9 @@ static inline void pkvm_writel(void __iomem *reg, unsigned long reg_phys,
 
 int __init pkvm_host_prepare_iommu(void);
 int __init pkvm_host_init_iommu(void);
+
+int pv_qi_submit_sync(struct intel_iommu *iommu, struct qi_desc *desc,
+		      unsigned int count, unsigned long options);
 #else /* __PKVM_HYP__ */
 static inline bool iommu_supports_2m_page(void)
 {
@@ -91,7 +99,15 @@ static inline bool iommu_supports_5levels(void)
 	return iommu_pglvl_mask & IOMMU_PGT_5LEVEL;
 }
 
+struct intel_iommu *iommu_from_phys(unsigned long phys);
 int pkvm_intel_iommu_init(void);
 #endif /* !__PKVM_HYP__ */
+#else /* !CONFIG_PKVM_INTEL */
+static inline int pv_qi_submit_sync(struct intel_iommu *iommu,
+				    struct qi_desc *desc, unsigned int count,
+				    unsigned long options)
+{
+	return -EOPNOTSUPP;
+}
 #endif /* CONFIG_PKVM_INTEL */
 #endif /* _PKVM_INTEL_IOMMU_H_ */

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -33,6 +33,46 @@ extern int pkvm_sym(intel_iommu_sm);
 PKVM_DECLARE(int, prepare_iommu, (struct intel_iommu_info *info));
 
 #ifndef __PKVM_HYP__
+static inline u64 pkvm_readq(void __iomem *reg, unsigned long reg_phys, unsigned long offset)
+{
+	union pkvm_hc_data d;
+
+	if (!pkvm_enabled())
+		return readq(reg + offset);
+
+	pkvm_hypercall_out(iommu_mmio_read, &d, reg_phys + offset, sizeof(u64));
+	return d.iommu_mmio_read.val;
+}
+
+static inline u32 pkvm_readl(void __iomem *reg, unsigned long reg_phys, unsigned long offset)
+{
+	union pkvm_hc_data d;
+
+	if (!pkvm_enabled())
+		return readl(reg + offset);
+
+	pkvm_hypercall_out(iommu_mmio_read, &d, reg_phys + offset, sizeof(u32));
+	return (u32)d.iommu_mmio_read.val;
+}
+
+static inline void pkvm_writeq(void __iomem *reg, unsigned long reg_phys,
+			       unsigned long offset, u64 val)
+{
+	if (pkvm_enabled())
+		pkvm_hypercall(iommu_mmio_write, reg_phys + offset, sizeof(u64), val);
+	else
+		writeq(val, reg + offset);
+}
+
+static inline void pkvm_writel(void __iomem *reg, unsigned long reg_phys,
+			       unsigned long offset, u32 val)
+{
+	if (pkvm_enabled())
+		pkvm_hypercall(iommu_mmio_write, reg_phys + offset, sizeof(u32), val);
+	else
+		writel(val, reg + offset);
+}
+
 int __init pkvm_host_prepare_iommu(void);
 int __init pkvm_host_init_iommu(void);
 #else /* __PKVM_HYP__ */

--- a/drivers/iommu/intel/prq.c
+++ b/drivers/iommu/intel/prq.c
@@ -81,8 +81,8 @@ void intel_iommu_drain_pasid_prq(struct device *dev, u32 pasid)
 	 */
 prq_retry:
 	reinit_completion(&iommu->prq_complete);
-	tail = dmar_readq(iommu->reg + DMAR_PQT_REG) & PRQ_RING_MASK;
-	head = dmar_readq(iommu->reg + DMAR_PQH_REG) & PRQ_RING_MASK;
+	tail = dmar_readq(iommu, DMAR_PQT_REG) & PRQ_RING_MASK;
+	head = dmar_readq(iommu, DMAR_PQH_REG) & PRQ_RING_MASK;
 	while (head != tail) {
 		struct page_req_dsc *req;
 
@@ -120,7 +120,7 @@ prq_retry:
 qi_retry:
 	reinit_completion(&iommu->prq_complete);
 	qi_submit_sync(iommu, desc, 3, QI_OPT_WAIT_DRAIN);
-	if (readl(iommu->reg + DMAR_PRS_REG) & DMA_PRS_PRO) {
+	if (dmar_readl(iommu, DMAR_PRS_REG) & DMA_PRS_PRO) {
 		wait_for_completion(&iommu->prq_complete);
 		goto qi_retry;
 	}
@@ -206,10 +206,10 @@ static irqreturn_t prq_event_thread(int irq, void *d)
 	 * Clear PPR bit before reading head/tail registers, to ensure that
 	 * we get a new interrupt if needed.
 	 */
-	writel(DMA_PRS_PPR, iommu->reg + DMAR_PRS_REG);
+	dmar_writel(iommu, DMAR_PRS_REG, DMA_PRS_PPR);
 
-	tail = dmar_readq(iommu->reg + DMAR_PQT_REG) & PRQ_RING_MASK;
-	head = dmar_readq(iommu->reg + DMAR_PQH_REG) & PRQ_RING_MASK;
+	tail = dmar_readq(iommu, DMAR_PQT_REG) & PRQ_RING_MASK;
+	head = dmar_readq(iommu, DMAR_PQH_REG) & PRQ_RING_MASK;
 	handled = (head != tail);
 	while (head != tail) {
 		req = &iommu->prq[head / sizeof(*req)];
@@ -259,20 +259,20 @@ prq_advance:
 		head = (head + sizeof(*req)) & PRQ_RING_MASK;
 	}
 
-	dmar_writeq(iommu->reg + DMAR_PQH_REG, tail);
+	dmar_writeq(iommu, DMAR_PQH_REG, tail);
 
 	/*
 	 * Clear the page request overflow bit and wake up all threads that
 	 * are waiting for the completion of this handling.
 	 */
-	if (readl(iommu->reg + DMAR_PRS_REG) & DMA_PRS_PRO) {
+	if (dmar_readl(iommu, DMAR_PRS_REG) & DMA_PRS_PRO) {
 		pr_info_ratelimited("IOMMU: %s: PRQ overflow detected\n",
 				    iommu->name);
-		head = dmar_readq(iommu->reg + DMAR_PQH_REG) & PRQ_RING_MASK;
-		tail = dmar_readq(iommu->reg + DMAR_PQT_REG) & PRQ_RING_MASK;
+		head = dmar_readq(iommu, DMAR_PQH_REG) & PRQ_RING_MASK;
+		tail = dmar_readq(iommu, DMAR_PQT_REG) & PRQ_RING_MASK;
 		if (head == tail) {
 			iopf_queue_discard_partial(iommu->iopf_queue);
-			writel(DMA_PRS_PRO, iommu->reg + DMAR_PRS_REG);
+			dmar_writel(iommu, DMAR_PRS_REG, DMA_PRS_PRO);
 			pr_info_ratelimited("IOMMU: %s: PRQ overflow cleared",
 					    iommu->name);
 		}
@@ -325,9 +325,9 @@ int intel_iommu_enable_prq(struct intel_iommu *iommu)
 		       iommu->name);
 		goto free_iopfq;
 	}
-	dmar_writeq(iommu->reg + DMAR_PQH_REG, 0ULL);
-	dmar_writeq(iommu->reg + DMAR_PQT_REG, 0ULL);
-	dmar_writeq(iommu->reg + DMAR_PQA_REG, virt_to_phys(iommu->prq) | PRQ_ORDER);
+	dmar_writeq(iommu, DMAR_PQH_REG, 0ULL);
+	dmar_writeq(iommu, DMAR_PQT_REG, 0ULL);
+	dmar_writeq(iommu, DMAR_PQA_REG, virt_to_phys(iommu->prq) | PRQ_ORDER);
 
 	init_completion(&iommu->prq_complete);
 
@@ -348,9 +348,9 @@ free_prq:
 
 int intel_iommu_finish_prq(struct intel_iommu *iommu)
 {
-	dmar_writeq(iommu->reg + DMAR_PQH_REG, 0ULL);
-	dmar_writeq(iommu->reg + DMAR_PQT_REG, 0ULL);
-	dmar_writeq(iommu->reg + DMAR_PQA_REG, 0ULL);
+	dmar_writeq(iommu, DMAR_PQH_REG, 0ULL);
+	dmar_writeq(iommu, DMAR_PQT_REG, 0ULL);
+	dmar_writeq(iommu, DMAR_PQA_REG, 0ULL);
 
 	if (iommu->pr_irq) {
 		free_irq(iommu->pr_irq, iommu);

--- a/drivers/iommu/intel/svm.c
+++ b/drivers/iommu/intel/svm.c
@@ -44,6 +44,12 @@ void intel_svm_check(struct intel_iommu *iommu)
 		return;
 	}
 
+	if (pkvm_enabled()) {
+		pr_info("%s SVM disabled, running virtualized in pKVM hypervisor\n",
+			iommu->name);
+		return;
+	}
+
 	iommu->flags |= VTD_FLAG_SVM_CAPABLE;
 }
 


### PR DESCRIPTION
These set of patches implements basic support for IOMMU in pKVM. The basic IOMMU initialization is implemented in this series, but protection is not yet implemented.