### PR TITLE
SQUASHME: KVM: pVMX: fix pkvm_set_idt PV interface

### DIFF
--- a/arch/x86/kvm/vmx/pkvm_host.c
+++ b/arch/x86/kvm/vmx/pkvm_host.c
@@ -635,7 +635,7 @@ static void pkvm_get_idt(struct kvm_vcpu *vcpu, struct desc_ptr *dt)
 static void pkvm_set_idt(struct kvm_vcpu *vcpu, struct desc_ptr *dt)
 {
 	union pkvm_hc_data data = {
-		.set_gdt.desc = *dt,
+		.set_idt.desc = *dt,
 	};
 
 	if (vcpu->arch.guest_state_protected)


### PR DESCRIPTION
Fix pkvm_set_idt which accidentally used set_gdt instead of set_idt field.

Fixes: 62e9247018db ("KVM: pVMX: Implement idt/gdt related operations")