### PR TITLE
SQUASHME: pKVM: x86: Fix compiling issue with CONFIG_PKVM_INTEL=n

### DIFF
--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -7328,10 +7328,14 @@ int vmx_sync_pir_to_irr(struct kvm_vcpu *vcpu)
 	 * a VM-Exit and the subsequent entry will call sync_pir_to_irr.
 	 */
 	if (!is_guest_mode(vcpu) && kvm_vcpu_apicv_active(vcpu)) {
+#ifdef CONFIG_PKVM_INTEL
 		if (!enable_pkvm)
 			vmx_set_rvi(max_irr);
 		else if (max_irr != -1)
 			KVM_BUG_ON(pkvm_hypercall(sync_pir_to_irr, max_irr), vcpu->kvm);
+#else
+		vmx_set_rvi(max_irr);
+#endif
 	} else if (got_posted_interrupt) {
 		kvm_make_request(KVM_REQ_EVENT, vcpu);
 	}


### PR DESCRIPTION
Fixes: e40778e1df0b ("KVM: pVMX: Implement sync_pir_to_irr operation")