### PR TITLE
pKVM: x86: Support pKVM hypercalls with pkvm_hc_data as input and output

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -132,17 +132,23 @@ static_assert(sizeof(union pkvm_hc_data) == PKVM_HC_DATA_MAX_NUM * sizeof(u64));
 
 #define PKVM_HC_DATA_NUM(f)		\
 	(ALIGN(sizeof(((union pkvm_hc_data *)0)->f), sizeof(u64)) / sizeof(u64))
+#define PKVM_HC_DATA_OUT_NUM(f)		\
+	(ALIGN(sizeof(((union pkvm_hc_data *)0)->f.out), sizeof(u64)) / sizeof(u64))
+#define PKVM_HC_DATA_IN_NUM(f)		\
+	(ALIGN(sizeof(((union pkvm_hc_data *)0)->f.in), sizeof(u64)) / sizeof(u64))
 
 #define PKVM_HC_OUTPUT_NUM(f)	f##_output_num
 #define PKVM_HC_INPUT_NUM(f)	f##_input_num
 
 enum {
-	#define PKVM_HC(f)	PKVM_HC_OUTPUT_NUM(f) = 0,
-	#define PKVM_HC_OUT(f)	PKVM_HC_OUTPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC(f)		PKVM_HC_OUTPUT_NUM(f) = 0,
+	#define PKVM_HC_OUT(f)		PKVM_HC_OUTPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC_INOUT(f)	PKVM_HC_OUTPUT_NUM(f) = PKVM_HC_DATA_OUT_NUM(f),
 	#include <asm/pkvm_hypercalls.h>
 
-	#define PKVM_HC(f)	PKVM_HC_INPUT_NUM(f) = 0,
-	#define PKVM_HC_IN(f)	PKVM_HC_INPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC(f)		PKVM_HC_INPUT_NUM(f) = 0,
+	#define PKVM_HC_IN(f)		PKVM_HC_INPUT_NUM(f) = PKVM_HC_DATA_NUM(f),
+	#define PKVM_HC_INOUT(f)	PKVM_HC_INPUT_NUM(f) = PKVM_HC_DATA_IN_NUM(f),
 	#include <asm/pkvm_hypercalls.h>
 };
 
@@ -201,7 +207,7 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 	__pkvm_hypercall(f, NULL, 0, ##__VA_ARGS__);					\
 })
 
-#define pkvm_hypercall_out(f, o, ...)							\
+#define __pkvm_hypercall_inout(f, o, ...)						\
 	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 0,				\
 			      __pkvm_hypercall(f, NULL, 0, ##__VA_ARGS__),		\
 	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 1,				\
@@ -214,22 +220,28 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 			      __pkvm_hypercall(f, o, 4, ##__VA_ARGS__),			\
 	PKVM_HC_UNREACHABLE(f))))))
 
-#define pkvm_hypercall_in(f, i)								\
+#define pkvm_hypercall_inout(f, i, o)							\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 1,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0]),		\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0]),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 2,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0],		\
-					       (i)->raw.data[1]),			\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
+						     (i)->raw.data[1]),			\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 3,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0],		\
-					       (i)->raw.data[1],			\
-					       (i)->raw.data[2]),			\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
+						     (i)->raw.data[1],			\
+						     (i)->raw.data[2]),			\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 4,				\
-			      __pkvm_hypercall(f, NULL, 0, (i)->raw.data[0],		\
-					       (i)->raw.data[1],			\
-					       (i)->raw.data[2],			\
-					       (i)->raw.data[3]),			\
+			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
+						     (i)->raw.data[1],			\
+						     (i)->raw.data[2],			\
+						     (i)->raw.data[3]),			\
 	PKVM_HC_UNREACHABLE(f)))))
+
+#define pkvm_hypercall_out(f, o, ...)							\
+	__pkvm_hypercall_inout(f, o, ##__VA_ARGS__)
+
+#define pkvm_hypercall_in(f, i)								\
+	pkvm_hypercall_inout(f, i, (union pkvm_hc_data *)NULL)
 
 static inline unsigned long pkvm_hc(struct kvm_vcpu *vcpu)
 {

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -61,7 +61,7 @@ enum pkvm_hc {
 	MAX_PKVM_HYPERCALLS,
 };
 
-#define PKVM_HC_DATA_MAX_NUM		4
+#define PKVM_HC_DATA_MAX_NUM		10
 
 union pkvm_hc_data {
 	struct {
@@ -172,22 +172,103 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 	}
 }
 
-#define PKVM_HC_IN_0()
-#define PKVM_HC_IN_1(a1)		, "b"((unsigned long)a1)
-#define PKVM_HC_IN_2(a1, a2)		PKVM_HC_IN_1(a1), "c"((unsigned long)a2)
-#define PKVM_HC_IN_3(a1, a2, a3)	PKVM_HC_IN_2(a1, a2), "d"((unsigned long)a3)
-#define PKVM_HC_IN_4(a1, a2, a3, a4)	PKVM_HC_IN_3(a1, a2, a3), "S"((unsigned long)a4)
+#define IN_ARG_0()
+#define IN_ARG_1(a1, ...)						(unsigned long)a1
+#define IN_ARG_2(a1, a2, ...)						(unsigned long)a2
+#define IN_ARG_3(a1, a2, a3, ...)					(unsigned long)a3
+#define IN_ARG_4(a1, a2, a3, a4, ...)					(unsigned long)a4
+#define IN_ARG_5(a1, a2, a3, a4, a5, ...)				(unsigned long)a5
+#define IN_ARG_6(a1, a2, a3, a4, a5, a6, ...)				(unsigned long)a6
+#define IN_ARG_7(a1, a2, a3, a4, a5, a6, a7, ...)			(unsigned long)a7
+#define IN_ARG_8(a1, a2, a3, a4, a5, a6, a7, a8, ...)			(unsigned long)a8
+#define IN_ARG_9(a1, a2, a3, a4, a5, a6, a7, a8, a9, ...)		(unsigned long)a9
+#define IN_ARG_10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, ...)		(unsigned long)a10
+
+#define PKVM_HC_DECLARE_IN_0(...)
+#define PKVM_HC_DECLARE_IN_1(...)
+#define PKVM_HC_DECLARE_IN_2(...)
+#define PKVM_HC_DECLARE_IN_3(...)
+#define PKVM_HC_DECLARE_IN_4(...)
+#define PKVM_HC_DECLARE_IN_5(...)
+#define PKVM_HC_DECLARE_IN_6(...)	register unsigned long r8_in asm("r8") = 	\
+								IN_ARG_6(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_7(...)	PKVM_HC_DECLARE_IN_6(__VA_ARGS__);		\
+					register unsigned long r9_in asm("r9") = 	\
+								IN_ARG_7(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_8(...)	PKVM_HC_DECLARE_IN_7(__VA_ARGS__);		\
+					register unsigned long r10_in asm("r10") = 	\
+								IN_ARG_8(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_9(...)	PKVM_HC_DECLARE_IN_8(__VA_ARGS__);		\
+					register unsigned long r11_in asm("r11") = 	\
+								IN_ARG_9(__VA_ARGS__)
+#define PKVM_HC_DECLARE_IN_10(...)	PKVM_HC_DECLARE_IN_9(__VA_ARGS__);		\
+					register unsigned long r12_in asm("r12") = 	\
+								IN_ARG_10(__VA_ARGS__)
+
+#define PKVM_HC_IN_0(...)
+#define PKVM_HC_IN_1(...)		, "b"(IN_ARG_1(__VA_ARGS__))
+#define PKVM_HC_IN_2(...)		PKVM_HC_IN_1(__VA_ARGS__), "c"(IN_ARG_2(__VA_ARGS__))
+#define PKVM_HC_IN_3(...)		PKVM_HC_IN_2(__VA_ARGS__), "d"(IN_ARG_3(__VA_ARGS__))
+#define PKVM_HC_IN_4(...)		PKVM_HC_IN_3(__VA_ARGS__), "S"(IN_ARG_4(__VA_ARGS__))
+#define PKVM_HC_IN_5(...)		PKVM_HC_IN_4(__VA_ARGS__), "D"(IN_ARG_5(__VA_ARGS__))
+#define PKVM_HC_IN_6(...)		PKVM_HC_IN_5(__VA_ARGS__), "r" (r8_in)
+#define PKVM_HC_IN_7(...)		PKVM_HC_IN_6(__VA_ARGS__), "r" (r9_in)
+#define PKVM_HC_IN_8(...)		PKVM_HC_IN_7(__VA_ARGS__), "r" (r10_in)
+#define PKVM_HC_IN_9(...)		PKVM_HC_IN_8(__VA_ARGS__), "r" (r11_in)
+#define PKVM_HC_IN_10(...)		PKVM_HC_IN_9(__VA_ARGS__), "r" (r12_in)
+
+#define PKVM_HC_DECLARE_OUT_0
+#define PKVM_HC_DECLARE_OUT_1
+#define PKVM_HC_DECLARE_OUT_2
+#define PKVM_HC_DECLARE_OUT_3
+#define PKVM_HC_DECLARE_OUT_4
+#define PKVM_HC_DECLARE_OUT_5
+#define PKVM_HC_DECLARE_OUT_6		register unsigned long r8_out asm("r8")
+#define PKVM_HC_DECLARE_OUT_7		PKVM_HC_DECLARE_OUT_6;				\
+					register unsigned long r9_out asm("r9")
+#define PKVM_HC_DECLARE_OUT_8		PKVM_HC_DECLARE_OUT_7;				\
+					register unsigned long r10_out asm("r10")
+#define PKVM_HC_DECLARE_OUT_9		PKVM_HC_DECLARE_OUT_8;				\
+					register unsigned long r11_out asm("r11")
+#define PKVM_HC_DECLARE_OUT_10		PKVM_HC_DECLARE_OUT_9;				\
+					register unsigned long r12_out asm("r12")
+
+#define PKVM_HC_OUT_INSN_0
+#define PKVM_HC_OUT_INSN_1
+#define PKVM_HC_OUT_INSN_2
+#define PKVM_HC_OUT_INSN_3
+#define PKVM_HC_OUT_INSN_4
+#define PKVM_HC_OUT_INSN_5
+#define PKVM_HC_OUT_INSN_6		"movq %%r8, %[out5]\n\t"
+#define PKVM_HC_OUT_INSN_7		PKVM_HC_OUT_INSN_6 "movq %%r9, %[out6]\n\t"
+#define PKVM_HC_OUT_INSN_8		PKVM_HC_OUT_INSN_7 "movq %%r10, %[out7]\n\t"
+#define PKVM_HC_OUT_INSN_9		PKVM_HC_OUT_INSN_8 "movq %%r11, %[out8]\n\t"
+#define PKVM_HC_OUT_INSN_10		PKVM_HC_OUT_INSN_9 "movq %%r12, %[out9]\n\t"
 
 #define PKVM_HC_OUT_0(o)
 #define PKVM_HC_OUT_1(o)		, "=b"((o)->raw.data[0])
 #define PKVM_HC_OUT_2(o)		PKVM_HC_OUT_1(o), "=c"((o)->raw.data[1])
 #define PKVM_HC_OUT_3(o)		PKVM_HC_OUT_2(o), "=d"((o)->raw.data[2])
 #define PKVM_HC_OUT_4(o)		PKVM_HC_OUT_3(o), "=S"((o)->raw.data[3])
+#define PKVM_HC_OUT_5(o)		PKVM_HC_OUT_4(o), "=D" ((o)->raw.data[4])
+#define PKVM_HC_OUT_6(o)		PKVM_HC_OUT_5(o), "=r"(r8_out),			\
+					[out5] "=m" ((o)->raw.data[5])
+#define PKVM_HC_OUT_7(o)		PKVM_HC_OUT_6(o), "=r"(r9_out),			\
+					[out6] "=m" ((o)->raw.data[6])
+#define PKVM_HC_OUT_8(o)		PKVM_HC_OUT_7(o), "=r"(r10_out),		\
+					[out7] "=m" ((o)->raw.data[7])
+#define PKVM_HC_OUT_9(o)		PKVM_HC_OUT_8(o), "=r"(r11_out),		\
+					[out8] "=m" ((o)->raw.data[8])
+#define PKVM_HC_OUT_10(o)		PKVM_HC_OUT_9(o), "=r"(r12_out),		\
+					[out9] "=m" ((o)->raw.data[9])
 
 #define __pkvm_hypercall(f, o, n, ...)							\
 ({											\
+	CONCATENATE(PKVM_HC_DECLARE_IN_, COUNT_ARGS(__VA_ARGS__))(__VA_ARGS__);		\
+	CONCATENATE(PKVM_HC_DECLARE_OUT_, n);						\
 	int ret;									\
 	asm volatile(KVM_HYPERCALL							\
+		     PKVM_HC_OUT_INSN_##n						\
 		     : "=a"(ret) CONCATENATE(PKVM_HC_OUT_, n)(o)			\
 		     : "a"(TO_PKVM_HC(f))						\
 		       CONCATENATE(PKVM_HC_IN_, COUNT_ARGS(__VA_ARGS__))(__VA_ARGS__)	\
@@ -218,24 +299,53 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 			      __pkvm_hypercall(f, o, 3, ##__VA_ARGS__),			\
 	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 4,				\
 			      __pkvm_hypercall(f, o, 4, ##__VA_ARGS__),			\
-	PKVM_HC_UNREACHABLE(f))))))
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 5,				\
+			      __pkvm_hypercall(f, o, 5, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 6,				\
+			      __pkvm_hypercall(f, o, 6, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 7,				\
+			      __pkvm_hypercall(f, o, 7, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 8,				\
+			      __pkvm_hypercall(f, o, 8, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 9,				\
+			      __pkvm_hypercall(f, o, 9, ##__VA_ARGS__),			\
+	__builtin_choose_expr(PKVM_HC_OUTPUT_NUM(f) == 10,				\
+			      __pkvm_hypercall(f, o, 10, ##__VA_ARGS__),		\
+	PKVM_HC_UNREACHABLE(f))))))))))))
+
+#define INPUT_DATA_1(i)		(i)->raw.data[0]
+#define INPUT_DATA_2(i)		INPUT_DATA_1(i), (i)->raw.data[1]
+#define INPUT_DATA_3(i)		INPUT_DATA_2(i), (i)->raw.data[2]
+#define INPUT_DATA_4(i)		INPUT_DATA_3(i), (i)->raw.data[3]
+#define INPUT_DATA_5(i)		INPUT_DATA_4(i), (i)->raw.data[4]
+#define INPUT_DATA_6(i)		INPUT_DATA_5(i), (i)->raw.data[5]
+#define INPUT_DATA_7(i)		INPUT_DATA_6(i), (i)->raw.data[6]
+#define INPUT_DATA_8(i)		INPUT_DATA_7(i), (i)->raw.data[7]
+#define INPUT_DATA_9(i)		INPUT_DATA_8(i), (i)->raw.data[8]
+#define INPUT_DATA_10(i)	INPUT_DATA_9(i), (i)->raw.data[9]
 
 #define pkvm_hypercall_inout(f, i, o)							\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 1,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0]),		\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_1(i)),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 2,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
-						     (i)->raw.data[1]),			\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_2(i)),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 3,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
-						     (i)->raw.data[1],			\
-						     (i)->raw.data[2]),			\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_3(i)),		\
 	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 4,				\
-			      __pkvm_hypercall_inout(f, o, (i)->raw.data[0],		\
-						     (i)->raw.data[1],			\
-						     (i)->raw.data[2],			\
-						     (i)->raw.data[3]),			\
-	PKVM_HC_UNREACHABLE(f)))))
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_4(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 5,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_5(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 6,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_6(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 7,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_7(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 8,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_8(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 9,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_9(i)),		\
+	__builtin_choose_expr(PKVM_HC_INPUT_NUM(f) == 10,				\
+			      __pkvm_hypercall_inout(f, o, INPUT_DATA_10(i)),		\
+	PKVM_HC_UNREACHABLE(f)))))))))))
 
 #define pkvm_hypercall_out(f, o, ...)							\
 	__pkvm_hypercall_inout(f, o, ##__VA_ARGS__)
@@ -263,11 +373,35 @@ DEFINE_PKVM_HC_INPUT(1, RBX)
 DEFINE_PKVM_HC_INPUT(2, RCX)
 DEFINE_PKVM_HC_INPUT(3, RDX)
 DEFINE_PKVM_HC_INPUT(4, RSI)
+DEFINE_PKVM_HC_INPUT(5, RDI)
+DEFINE_PKVM_HC_INPUT(6, R8)
+DEFINE_PKVM_HC_INPUT(7, R9)
+DEFINE_PKVM_HC_INPUT(8, R10)
+DEFINE_PKVM_HC_INPUT(9, R11)
+DEFINE_PKVM_HC_INPUT(10, R12)
 
 static inline void pkvm_hc_get_input(struct kvm_vcpu *vcpu, enum pkvm_hc hc,
 				     union pkvm_hc_data *in)
 {
 	switch (pkvm_hc_input_num(hc)) {
+	case 10:
+		pkvm_hc_get_input10(vcpu, in);
+		fallthrough;
+	case 9:
+		pkvm_hc_get_input9(vcpu, in);
+		fallthrough;
+	case 8:
+		pkvm_hc_get_input8(vcpu, in);
+		fallthrough;
+	case 7:
+		pkvm_hc_get_input7(vcpu, in);
+		fallthrough;
+	case 6:
+		pkvm_hc_get_input6(vcpu, in);
+		fallthrough;
+	case 5:
+		pkvm_hc_get_input5(vcpu, in);
+		fallthrough;
 	case 4:
 		pkvm_hc_get_input4(vcpu, in);
 		fallthrough;
@@ -303,11 +437,35 @@ DEFINE_PKVM_HC_OUTPUT(1, RBX)
 DEFINE_PKVM_HC_OUTPUT(2, RCX)
 DEFINE_PKVM_HC_OUTPUT(3, RDX)
 DEFINE_PKVM_HC_OUTPUT(4, RSI)
+DEFINE_PKVM_HC_OUTPUT(5, RDI)
+DEFINE_PKVM_HC_OUTPUT(6, R8)
+DEFINE_PKVM_HC_OUTPUT(7, R9)
+DEFINE_PKVM_HC_OUTPUT(8, R10)
+DEFINE_PKVM_HC_OUTPUT(9, R11)
+DEFINE_PKVM_HC_OUTPUT(10, R12)
 
 static inline void pkvm_hc_set_output(struct kvm_vcpu *vcpu, enum pkvm_hc hc,
 				      union pkvm_hc_data *out)
 {
 	switch (pkvm_hc_output_num(hc)) {
+	case 10:
+		pkvm_hc_set_output10(vcpu, out);
+		fallthrough;
+	case 9:
+		pkvm_hc_set_output9(vcpu, out);
+		fallthrough;
+	case 8:
+		pkvm_hc_set_output8(vcpu, out);
+		fallthrough;
+	case 7:
+		pkvm_hc_set_output7(vcpu, out);
+		fallthrough;
+	case 6:
+		pkvm_hc_set_output6(vcpu, out);
+		fallthrough;
+	case 5:
+		pkvm_hc_set_output5(vcpu, out);
+		fallthrough;
 	case 4:
 		pkvm_hc_set_output4(vcpu, out);
 		fallthrough;

--- a/arch/x86/include/asm/pkvm_hypercalls.h
+++ b/arch/x86/include/asm/pkvm_hypercalls.h
@@ -11,6 +11,10 @@ BUILD_BUG_ON(1)
 #define PKVM_HC_IN PKVM_HC
 #endif
 
+#ifndef PKVM_HC_INOUT
+#define PKVM_HC_INOUT PKVM_HC
+#endif
+
 /* Hypercalls used only during pKVM initialization */
 PKVM_HC(init)
 PKVM_HC(init_finalize)
@@ -79,3 +83,4 @@ PKVM_HC(setup_mce)
 #undef PKVM_HC
 #undef PKVM_HC_OUT
 #undef PKVM_HC_IN
+#undef PKVM_HC_INOUT

--- a/arch/x86/kvm/Kconfig
+++ b/arch/x86/kvm/Kconfig
@@ -121,6 +121,7 @@ config KVM_INTEL_PROVE_VE
 
 config PKVM_X86
 	bool
+	depends on X86_64
 	depends on X86_X2APIC
 
 	help
@@ -136,7 +137,6 @@ config PKVM_X86
 config PKVM_INTEL
 	bool "pKVM for Intel processors support"
 	depends on KVM_INTEL=y
-	depends on X86_64
 	select PKVM_X86
 	help
 	  Provides support for pKVM on Intel processors.


### PR DESCRIPTION
Add macro pkvm_hypercall_inout to support sending pKVM hypercalls with using union pkvm_hc_data as both inputs and outputs. Such hypercalls should be defined by PKVM_HC_INOUT in the pkvm_hypercalls.h. And its corresponding structure in union pkvm_hc_data should be defined as something like:
    union pkvm_hc_data {
	    ......
	    union {
		    struct {
			    ......
		    } in;
		    struct {
			    ......
		    } out;
	    } hypercall_name;
    };
So that the size of the input and output can be different.