### PR TITLE
SQUASHME: pKVM: x86: Fix the unexpected pKVM hypercall inputs

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -167,10 +167,10 @@ static inline int pkvm_hc_input_num(enum pkvm_hc hc)
 }
 
 #define PKVM_HC_IN_0()
-#define PKVM_HC_IN_1(a1)		, "b"(a1)
-#define PKVM_HC_IN_2(a1, a2)		PKVM_HC_IN_1(a1), "c"(a2)
-#define PKVM_HC_IN_3(a1, a2, a3)	PKVM_HC_IN_2(a1, a2), "d"(a3)
-#define PKVM_HC_IN_4(a1, a2, a3, a4)	PKVM_HC_IN_3(a1, a2, a3), "S"(a4)
+#define PKVM_HC_IN_1(a1)		, "b"((unsigned long)a1)
+#define PKVM_HC_IN_2(a1, a2)		PKVM_HC_IN_1(a1), "c"((unsigned long)a2)
+#define PKVM_HC_IN_3(a1, a2, a3)	PKVM_HC_IN_2(a1, a2), "d"((unsigned long)a3)
+#define PKVM_HC_IN_4(a1, a2, a3, a4)	PKVM_HC_IN_3(a1, a2, a3), "S"((unsigned long)a4)
 
 #define PKVM_HC_OUT_0(o)
 #define PKVM_HC_OUT_1(o)		, "=b"((o)->raw.data[0])


### PR DESCRIPTION
When passing for example a bool as the pKVM hypercall's input in the RBX register, the compiler may only fill the low bits of the RBX while keeps its high bits unchanged. However the pKVM hypervisor gets the input parameters from the entire 64bit registers, which can get unexpected value. To fix this, zero extend all the input arguments to make sure they can full fill the entire 64bit registers.

This can fix the kselftest kvm debug_regs test.

Fixes: 289beb3a4ede ("pKVM: x86: Define pkvm_hypercall macro to as the PV interface")