### PR TITLE
Pkvm v6.18: vmexit perf fixes

### DIFF
--- a/arch/x86/kvm/pkvm/trace.c
+++ b/arch/x86/kvm/pkvm/trace.c
@@ -25,8 +25,10 @@ static inline struct vmexit_perf *vcpu_to_perf(struct kvm_vcpu *vcpu)
 
 static void refresh_vmexit_perf(struct perf_ctrl *pctrl, struct vmexit_perf *perf)
 {
+	pkvm_spin_lock(&perf->lock);
 	memset(perf->data.vmexit_reasons, 0, sizeof(perf->data.vmexit_reasons));
 	memset(perf->data.hypercalls, 0, sizeof(perf->data.hypercalls));
+	pkvm_spin_unlock(&perf->lock);
 
 	perf->age = pctrl->age;
 }

--- a/arch/x86/kvm/pkvm/trace.c
+++ b/arch/x86/kvm/pkvm/trace.c
@@ -5,12 +5,10 @@
 #include "pkvm.h"
 #include "trace.h"
 
-struct perf_ctrl {
-	unsigned int age;
-	bool on;
-};
+static bool trace_on;
+static atomic_t trace_age;
+
 static DEFINE_PER_CPU(struct vmexit_perf, hvcpu_perf);
-static DEFINE_PER_CPU(struct perf_ctrl, perf_ctrl);
 
 static inline bool is_host_vcpu(struct kvm_vcpu *vcpu)
 {
@@ -23,14 +21,41 @@ static inline struct vmexit_perf *vcpu_to_perf(struct kvm_vcpu *vcpu)
 				    &to_pkvm_vcpu(vcpu)->perf;
 }
 
-static void refresh_vmexit_perf(struct perf_ctrl *pctrl, struct vmexit_perf *perf)
+static void refresh_vmexit_perf(struct vmexit_perf *perf)
 {
 	pkvm_spin_lock(&perf->lock);
 	memset(perf->data.vmexit_reasons, 0, sizeof(perf->data.vmexit_reasons));
 	memset(perf->data.hypercalls, 0, sizeof(perf->data.hypercalls));
 	pkvm_spin_unlock(&perf->lock);
+}
 
-	perf->age = pctrl->age;
+static void refresh_host_vm_trace(void)
+{
+	int cpu;
+
+	for_each_possible_cpu(cpu)
+		refresh_vmexit_perf(per_cpu_ptr(&hvcpu_perf, cpu));
+}
+
+static int __refresh_guest_vm_trace(struct pkvm_vm *vm, void *param)
+{
+	int i;
+
+	pkvm_spin_lock(&vm->lock);
+	for (i = 0; i < vm->kvm.created_vcpus; i++) {
+		if (!vm->vcpus[i])
+			continue;
+
+		refresh_vmexit_perf(&vm->vcpus[i]->perf);
+	}
+	pkvm_spin_unlock(&vm->lock);
+
+	return 0;
+}
+
+static void refresh_guest_vm_trace(void)
+{
+	pkvm_walk_each_vm(__refresh_guest_vm_trace, NULL);
 }
 
 static void copy_vmexit_perf_data(struct perf_data *dst, struct vmexit_perf *perf)
@@ -105,37 +130,40 @@ static void copy_guest_vm_trace(int vm_handle, void *dst, unsigned long size)
 
 void pkvm_trace_vmexit_start(struct kvm_vcpu *vcpu)
 {
-	struct perf_ctrl *pctrl = this_cpu_ptr(&perf_ctrl);
 	struct vmexit_perf *perf;
 
-	if (!pctrl->on)
+	/*
+	 * Read trace_on before trace_age. Pairs with smp_store_release() in
+	 * pkvm_enable_vmexit_trace().
+	 */
+	if (likely(!smp_load_acquire(&trace_on)))
 		return;
 
 	perf = vcpu_to_perf(vcpu);
-	if (pctrl->age != perf->age)
-		refresh_vmexit_perf(pctrl, perf);
 
 	perf->rax = vcpu->arch.regs[VCPU_REGS_RAX];
 	perf->tsc = rdtsc_ordered();
+	perf->age = atomic_read(&trace_age);
 }
 
 void pkvm_trace_vmexit_end(struct kvm_vcpu *vcpu, u32 reason)
 {
-	struct perf_ctrl *pctrl = this_cpu_ptr(&perf_ctrl);
 	struct vmexit_perf *perf;
 	unsigned long long cycles;
 
-	if (!pctrl->on)
+	/*
+	 * Read trace_on before trace_age. Pairs with smp_store_release() in
+	 * pkvm_enable_vmexit_trace().
+	 */
+	if (likely(!smp_load_acquire(&trace_on)))
 		return;
 
 	if (reason >= MAX_EXIT_REASONS)
 		return;
 
 	perf = vcpu_to_perf(vcpu);
-	if (pctrl->age != perf->age) {
-		refresh_vmexit_perf(pctrl, perf);
+	if (perf->age != atomic_read(&trace_age))
 		return;
-	}
 
 	cycles = rdtsc_ordered() - perf->tsc;
 
@@ -165,14 +193,18 @@ void pkvm_vcpu_perf_init(struct kvm_vcpu *vcpu)
 
 void pkvm_enable_vmexit_trace(bool en)
 {
-	struct perf_ctrl *pctrl = this_cpu_ptr(&perf_ctrl);
+	if (en) {
+		refresh_host_vm_trace();
+		refresh_guest_vm_trace();
 
-	if (en && !pctrl->on) {
-		pctrl->age++;
-		pctrl->on = true;
-	} else if (!en && pctrl->on) {
-		pctrl->on = false;
+		atomic_inc(&trace_age);
 	}
+
+	/*
+	 * Update trace_on after updating trace_age. Pairs with smp_load_acquire()
+	 * in pkvm_trace_vmexit_start()/pkvm_trace_vmexit_end().
+	 */
+	smp_store_release(&trace_on, en);
 }
 
 int pkvm_dump_vmexit_trace(phys_addr_t phys, unsigned long size, int vm_handle)

--- a/arch/x86/kvm/pkvm_debugfs.c
+++ b/arch/x86/kvm/pkvm_debugfs.c
@@ -6,25 +6,9 @@
 #include <asm/kvm_pkvm.h>
 #include <asm/pkvm_trace.h>
 
-static void enable_vmexit_trace_func(void *data)
-{
-	u64 val;
-
-	if (!data)
-		return;
-
-	val = *(u64 *)data;
-	pkvm_hypercall(enable_vmexit_trace, val);
-}
-
 static int enable_vmexit_trace(void *data, u64 val)
 {
-	int cpu;
-
-	for_each_possible_cpu(cpu)
-		smp_call_function_single(cpu, enable_vmexit_trace_func, &val, true);
-
-	return 0;
+	return pkvm_hypercall(enable_vmexit_trace, val);
 }
 DEFINE_SIMPLE_ATTRIBUTE(enable_vmexit_trace_fops, NULL, enable_vmexit_trace, "%llu\n");
 


### PR DESCRIPTION
Fix minor issue in pKVM vmexit perf tracing which was discussed in https://github.com/intel-staging/pKVM-IA/pull/60#discussion_r2733700332 : vmexit perf counters are not reset (i.e. remain with their outdated values) in case there are no new vmexits triggered on the given vCPU.