### PR TITLE
Pkvm v6.18 fix warnings

### DIFF
--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -6235,10 +6235,14 @@ static int handle_task_switch(struct kvm_vcpu *vcpu)
 {
 	struct vcpu_vmx *vmx = to_vmx(vcpu);
 	unsigned long exit_qualification;
+#ifndef __PKVM_HYP__
 	bool has_error_code = false;
 	u32 error_code = 0;
 	u16 tss_selector;
 	int reason, type, idt_v, idt_index;
+#else
+	int reason, type, idt_v;
+#endif
 
 #ifdef __PKVM_HYP__
 	/*
@@ -6253,7 +6257,9 @@ static int handle_task_switch(struct kvm_vcpu *vcpu)
 #endif
 
 	idt_v = (vmx->idt_vectoring_info & VECTORING_INFO_VALID_MASK);
+#ifndef __PKVM_HYP__
 	idt_index = (vmx->idt_vectoring_info & VECTORING_INFO_VECTOR_MASK);
+#endif
 	type = (vmx->idt_vectoring_info & VECTORING_INFO_TYPE_MASK);
 
 	exit_qualification = vmx_get_exit_qual(vcpu);
@@ -6270,6 +6276,7 @@ static int handle_task_switch(struct kvm_vcpu *vcpu)
 			kvm_clear_interrupt_queue(vcpu);
 			break;
 		case INTR_TYPE_HARD_EXCEPTION:
+#ifndef __PKVM_HYP__
 			if (vmx->idt_vectoring_info &
 			    VECTORING_INFO_DELIVER_CODE_MASK) {
 				has_error_code = true;
@@ -6277,6 +6284,7 @@ static int handle_task_switch(struct kvm_vcpu *vcpu)
 					vmcs_read32(IDT_VECTORING_ERROR_CODE);
 			}
 			fallthrough;
+#endif
 		case INTR_TYPE_SOFT_EXCEPTION:
 			kvm_clear_exception_queue(vcpu);
 			break;
@@ -6284,7 +6292,9 @@ static int handle_task_switch(struct kvm_vcpu *vcpu)
 			break;
 		}
 	}
+#ifndef __PKVM_HYP__
 	tss_selector = exit_qualification;
+#endif
 
 	if (!idt_v || (type != INTR_TYPE_HARD_EXCEPTION &&
 		       type != INTR_TYPE_EXT_INTR &&

--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -5612,9 +5612,11 @@ static int handle_exception_nmi(struct kvm_vcpu *vcpu)
 #endif
 	u32 intr_info, ex_no, error_code;
 	unsigned long dr6;
+#ifndef __PKVM_HYP__
 	u32 vect_info;
 
 	vect_info = vmx->idt_vectoring_info;
+#endif
 	intr_info = vmx_get_intr_info(vcpu);
 
 	/* The MC and NMI will be handled by the host. */


### PR DESCRIPTION
Fix the compiling warnings of unused-but-set-variable in the vmx.c for the pKVM. This may not be that important to be fixed as the other components in the linux kernel also have such warnings as below, so the linux kernel still cannot pass the compiling even we fixed for the pKVM. But maybe it is still better to do that regardless this, although it introduced a bit more `#ifndef __PKVM_HYP__` in the code.

```
../drivers/acpi/acpica/nsaccess.c:295:6: error: variable 'num_carats' set but not used [-Werror,-Wunused-but-set-variable]
  295 |         u32 num_carats;
      |             ^
1 error generated.
make[6]: *** [../scripts/Makefile.build:287: drivers/acpi/acpica/nsaccess.o] Error 1
make[6]: *** Waiting for unfinished jobs....
../arch/x86/kernel/process.c:972:10: error: variable 'hi' set but not used [-Werror,-Wunused-but-set-variable]
  972 |         u32 lo, hi;
      |                 ^
1 error generated.       ^
```