### PR TITLE
SQUASHME: pKVM: x86: Use pkvm_is_protected_vm() before vcpu is initia…

### DIFF
--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -391,7 +391,7 @@ static int __vcpu_create(struct kvm *kvm, struct kvm_vcpu *vcpu, struct fpstate 
 		kvm->arch.notify_window = pkvm_vm->shared_kvm->arch.notify_window;
 		kvm->arch.notify_vmexit_flags = pkvm_vm->shared_kvm->arch.notify_vmexit_flags;
 	}
-	if (!pkvm_is_protected_vcpu(vcpu))
+	if (!pkvm_is_protected_vm(kvm))
 		kvm->arch.disabled_exits = pkvm_vm->shared_kvm->arch.disabled_exits;
 
 	pkvm_spin_unlock(&pkvm_vm->lock);


### PR DESCRIPTION
…lized.

Since vcpu->kvm is initialized after this check,
pkvm_is_protected_vcpu() is not functional at this stage.

Fixes: 6fdd05cd1022 ("pKVM: VMX: Synchronize host disabled_exits to pKVM in npVMs")