### PR TITLE
SQUASHME: KVM: x86/mmu: pKVM: Don't skip kvm_arch_flush_shadow_all()

### DIFF
--- a/arch/x86/kvm/mmu/mmu.c
+++ b/arch/x86/kvm/mmu/mmu.c
@@ -1645,7 +1645,7 @@ static bool __kvm_rmap_zap_gfn_range(struct kvm *kvm,
 				 start, end - 1, can_yield, true, flush);
 }
 #ifdef CONFIG_PKVM_X86
-static bool pkvm_unmap_gfn_range(struct kvm *kvm, struct kvm_gfn_range *range)
+static bool __pkvm_unmap_gfn_range(struct kvm *kvm, gfn_t start, gfn_t end)
 {
 	struct pkvm_mapping *m;
 
@@ -1654,7 +1654,7 @@ static bool pkvm_unmap_gfn_range(struct kvm *kvm, struct kvm_gfn_range *range)
 	if (pkvm_is_protected_vm(kvm))
 		return false;
 
-	for_each_pkvm_mapping(kvm, range->start, range->end, m) {
+	for_each_pkvm_mapping(kvm, start, end, m) {
 		int err = pkvm_hypercall(vm_mmu_unmap, kvm->arch.pkvm.handle,
 					 m->gfn << PAGE_SHIFT,
 					 m->nr_pages << PAGE_SHIFT);
@@ -1667,6 +1667,11 @@ static bool pkvm_unmap_gfn_range(struct kvm *kvm, struct kvm_gfn_range *range)
 
 	/* pKVM itself always flushes TLB on unmap */
 	return false;
+}
+
+static bool pkvm_unmap_gfn_range(struct kvm *kvm, struct kvm_gfn_range *range)
+{
+	return __pkvm_unmap_gfn_range(kvm, range->start, range->end);
 }
 
 static bool pkvm_age_gfn_range(struct kvm *kvm, struct kvm_gfn_range *range,
@@ -7488,6 +7493,15 @@ static void kvm_mmu_zap_all(struct kvm *kvm)
 	LIST_HEAD(invalid_list);
 	int ign;
 
+#ifdef CONFIG_PKVM_X86
+	if (enable_pkvm) {
+		write_lock(&kvm->mmu_lock);
+		__pkvm_unmap_gfn_range(kvm, 0, U64_MAX);
+		write_unlock(&kvm->mmu_lock);
+		return;
+	}
+#endif
+
 	write_lock(&kvm->mmu_lock);
 restart:
 	list_for_each_entry_safe(sp, node, &kvm->arch.active_mmu_pages, link) {
@@ -7509,10 +7523,6 @@ restart:
 
 void kvm_arch_flush_shadow_all(struct kvm *kvm)
 {
-	/* pKVM hypervisor takes care of MMU teardown when destroying VM. */
-	if (enable_pkvm)
-		return;
-
 	kvm_mmu_zap_all(kvm);
 }
 


### PR DESCRIPTION
Currently host KVM skips zapping all guest mappings in kvm_arch_flush_shadow_all() during VM teardown is pKVM is enabled, assuming that it is not needed since pKVM hypervisor is about to destroy the guest MMU anyway, when handling the vm_destroy hypercall.

However, the host kernel may start using guest pages for other needs right after kvm_arch_flush_shadow_all(), before vm_destroy, since KVM executes kvm_arch_flush_shadow_all() as a part of the MMU notifier release, thus telling the host kernel's MM that the pages are available to use for other needs.

This is not an issue for pVMs, since pVM pages are still pinned (they are only unpinned after vm_destroy). However, this is an issue for npVMs, since npVM pages state for the host is still SHARED_OWNED, not OWNED, thus the host will fail e.g. to donate those pages to a pVM if it tries to do that immediately after kvm_arch_flush_shadow_all().

So don't skip kvm_arch_flush_shadow_all() but let it properly ask pKVM to unmap guest pages and thus properly update their host state to OWNED, so that the host kernel can immediately start using them for other needs.

Fixes: 30e9a30c5f52 ("KVM: x86/mmu: pKVM: Skip kvm_arch_flush_shadow_all()")