### PR TITLE
pKVM: x86: Expose TSC frequency to pVM

### DIFF
--- a/arch/x86/kvm/cpuid.c
+++ b/arch/x86/kvm/cpuid.c
@@ -2138,6 +2138,38 @@ bool kvm_cpuid(struct kvm_vcpu *vcpu, u32 *eax, u32 *ebx,
 				*eax = vcpu->arch.hw_tsc_khz;
 			}
 #endif
+		} else if (pkvm_is_protected_vcpu(vcpu) && function == 0x15) {
+			/*
+			 * Since protected VMs cannot use kvmclock to find out the
+			 * TSC frequency, expose the native TSC frequency directly
+			 * via cpuid. For now this is not for security (pKVM does not
+			 * provide secure TSC yet) but just to let the guest know the
+			 * TSC frequency so that it doesn't need to calibrate the TSC
+			 * against host-emulated PIT/HPET timers which are inherently
+			 * inaccurate as they are sensitive to the system load in the
+			 * host.
+			 */
+			if (tsc_khz) {
+				/*
+				 * TSC crystal clock must match the LAPIC clock.
+				 * See native_calibrate_tsc().
+				 */
+				*ecx = 1000000000 / vcpu->kvm->arch.apic_bus_cycle_ns;
+				/*
+				 * Try to minimize calculation error: use 38.4 MHz
+				 * which is the typical TSC crystal clock frequency
+				 * on today's Intel's desktop CPUs.
+				 *
+				 * TODO: we could avoid any calculation error, by
+				 * exposing tsc_khz via some PV (akin to kvmclock)
+				 * instead of cpuid.
+				 */
+				*eax = *ecx / 38400000;	/* denominator */
+				*ebx = tsc_khz / 38400;	/* numerator */
+				*edx = 0;
+			} else {
+				*eax = *ebx = *ecx = *edx = 0;
+			}
 		}
 	} else {
 		*eax = *ebx = *ecx = *edx = 0;

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -163,6 +163,7 @@ static int pkvm_vm_init(phys_addr_t host_kvm_pa, phys_addr_t pkvm_vm_pa,
 		kvm->arch.disabled_quirks = (kvm_caps.inapplicable_quirks |
 					     pkvm_vm->shared_kvm->arch.disabled_quirks) &
 					    kvm_caps.supported_quirks;
+	kvm->arch.apic_bus_cycle_ns = APIC_BUS_CYCLE_NS_DEFAULT;
 	kvm->arch.pkvm.pvmfw_load_addr = INVALID_GPA;
 
 	pkvm_spin_lock_init(&pkvm_vm->lock);
@@ -462,6 +463,8 @@ static int __vcpu_create(struct kvm *kvm, struct kvm_vcpu *vcpu, struct fpstate 
 		kvm->arch.notify_window = pkvm_vm->shared_kvm->arch.notify_window;
 		kvm->arch.notify_vmexit_flags = pkvm_vm->shared_kvm->arch.notify_vmexit_flags;
 	}
+	if (pkvm_vm->shared_kvm->arch.apic_bus_cycle_ns)
+		kvm->arch.apic_bus_cycle_ns = pkvm_vm->shared_kvm->arch.apic_bus_cycle_ns;
 	if (!pkvm_is_protected_vm(kvm))
 		kvm->arch.disabled_exits = pkvm_vm->shared_kvm->arch.disabled_exits;
 


### PR DESCRIPTION
Since pKVM does not support kvmclock for protected VMs, a pVM can't find out the TSC frequency from the host directly. So Linux pVMs find it out by calibrating the TSC against a PIT or HPET timer emulated by the host, which is inherently unreliable: if the host is under a heavy load during this calibration, the calibration will produce inaccurate results or, more likely, will just fail. And if the calibration fails, the guest will deem the TSC unstable (whereas actually it is the timer that is inaccurate, while the TSC is accurate, since it is native), and will fall back to using a jiffies-based clocksource instead of TSC, thus requiring periodic timer interrupts and thus causing permanently high CPU usage as long as the pVM is running.

Furthermore, on PTL (not on older CPUs) for some reason this problem (failed TSC calibration) is observed all the time, even if the system is not under a high load when the pVM starts.

So to avoid this problem and yet avoid special changes on the guest side, enforce exposing the TSC frequency info to the pVM via the CPUID leaf 0x15, so that the pVM doesn't need to calibrate the TSC.

In the future this enforcement might be also reused for security purposes, as a part of providing secure TSC for pVMs (which pKVM doesn't provide yet).