### PR TITLE
pKVM: x86: prevent hypervisor stack leaking

### DIFF
--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -1803,7 +1803,8 @@ static int pkvm_vcpu_handle_host_hypercall(struct kvm_vcpu *hvcpu, enum pkvm_hc 
 void pkvm_handle_host_hypercall(struct kvm_vcpu *vcpu)
 {
 	enum pkvm_hc hc = pkvm_hc(vcpu);
-	union pkvm_hc_data in, out;
+	/* Zero 'out' to prevent leaking stack data on error */
+	union pkvm_hc_data in, out = {0};
 	int ret = 0;
 
 	pkvm_hc_get_input(vcpu, hc, &in);


### PR DESCRIPTION
When pKVM handles host hypercalls it allocates an output structure on the stack, fills it accordingly during hypercall handling and finally use pkvm_hc_set_output() to map the data to the proper host vCPU registers so the host can read it back.

However, during hypercalls handling, some errors may occur that prevent the output data from being set. Because the pkvm_handle_host_hypercall() unconditionally copies the 'out' structure to the vCPU registers, uninitialized hyp stack (which potentially has sensitive data) can be leaked to the host.

To prevent described hypervisor stack leaking, zero initialize pkvm_hc_data 'out'.

Fixes: b0738f54947b ("pKVM: x86: Return hypercall outputs to the host")