### PR TITLE
pKVM: VMX: Respect the host KVM's enable_apicv/enable_ipiv params

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -350,6 +350,8 @@ extern unsigned int pkvm_sym(tsc_khz);
 extern bool pkvm_sym(pvmfw_present);
 extern phys_addr_t pkvm_sym(pvmfw_base);
 extern phys_addr_t pkvm_sym(pvmfw_size);
+extern bool __read_mostly pkvm_sym(enable_apicv);
+extern bool __read_mostly pkvm_sym(enable_ipiv);
 
 u64 pkvm_total_reserve_pages(void);
 PKVM_DECLARE(void *, pkvm_early_alloc_page, (struct pkvm_memcache *mc));

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -352,6 +352,7 @@ extern phys_addr_t pkvm_sym(pvmfw_base);
 extern phys_addr_t pkvm_sym(pvmfw_size);
 extern bool __read_mostly pkvm_sym(enable_apicv);
 extern bool __read_mostly pkvm_sym(enable_ipiv);
+extern bool __read_mostly pkvm_sym(enable_vpid);
 
 u64 pkvm_total_reserve_pages(void);
 PKVM_DECLARE(void *, pkvm_early_alloc_page, (struct pkvm_memcache *mc));

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -118,6 +118,10 @@ static __init void pkvm_setup_syms(void)
 #endif
 	pkvm_sym(x86_pred_cmd) = x86_pred_cmd;
 	pkvm_sym(tsc_khz) = tsc_khz;
+
+	/* Respect below host KVM's module parameters */
+	pkvm_sym(enable_apicv) = enable_apicv;
+	pkvm_sym(enable_ipiv) = enable_ipiv;
 }
 
 static __init int pkvm_setup_host_vmcs_config(void)

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -122,6 +122,7 @@ static __init void pkvm_setup_syms(void)
 	/* Respect below host KVM's module parameters */
 	pkvm_sym(enable_apicv) = enable_apicv;
 	pkvm_sym(enable_ipiv) = enable_ipiv;
+	pkvm_sym(enable_vpid) = enable_vpid;
 }
 
 static __init int pkvm_setup_host_vmcs_config(void)


### PR DESCRIPTION
The host can boot with kvm_intel.enable_apicv=0, kvm_intel.enable_ipiv=0 or both. In this case, the enable_apicv/enable_ipiv from the pKVM hypervisor side still have the default true value, which makes the pKVM expects to host KVM to use apicv/ipiv and causes the failure to boot up a guest VM. Resolve this by making the pKVM's enable_apicv/enable_ipiv aligned with the host KVM's value before deprivilege.

Reported-by: Masanori Misono <m.misono760@gmail.com>
Closes: https://github.com/intel-staging/pKVM-IA/issues/78