### PR TITLE
SQUASHME: iommu/vt-d: pKVM: Fix devtlb flush enable logic

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -58,7 +58,6 @@ struct clear_ce_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_enabled: 1;
 	u8 ats_supported: 1;
 };
 
@@ -70,7 +69,6 @@ struct set_lm_ce_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_enabled: 1;
 	u8 ats_supported: 1;
 };
 
@@ -82,7 +80,6 @@ struct set_sm_ce_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_enabled: 1;
 	u8 ats_supported: 1;
 	u8 pasid_supported: 3;
 	u8 pasid_enabled: 1;
@@ -99,7 +96,6 @@ struct pasid_setup_fl_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_enabled: 1;
 	u8 ats_supported: 1;
 };
 
@@ -113,7 +109,6 @@ struct pasid_setup_sl_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_enabled: 1;
 	u8 ats_supported: 1;
 };
 
@@ -123,7 +118,6 @@ struct pasid_teardown_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_enabled: 1;
 	u8 ats_supported: 1;
 };
 

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -51,7 +51,7 @@ int pkvm_iommu_clear_ce(struct clear_ce_data *data)
 		 */
 		if (ecap_dit(iommu->ecap))
 			info.pfsid = bdf;
-	} else if (data->ats_enabled || data->ats_supported) {
+	} else if (data->ats_supported) {
 		return -EPERM;
 	}
 
@@ -60,7 +60,7 @@ int pkvm_iommu_clear_ce(struct clear_ce_data *data)
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
-	info.ats_enabled = data->ats_enabled;
+	info.ats_enabled = info.ats_supported;
 
 	pkvm_dbg("%s: dev[%x:%x], ats_qdep: %d\n",
 		 __func__, data->bus, data->devfn, data->ats_qdep);
@@ -109,7 +109,7 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 	if (is_dev_in_satc(bdf)) {
 		if (ecap_dit(iommu->ecap))
 			info.pfsid = bdf;
-	} else if (data->ats_enabled || data->ats_supported) {
+	} else if (data->ats_supported) {
 		return -EPERM;
 	}
 
@@ -118,7 +118,7 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 	info.iommu = iommu;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
-	info.ats_enabled = data->ats_enabled;
+	info.ats_enabled = info.ats_supported;
 	if (data->did == FLPT_DEFAULT_DID) {
 		/*
 		 * Passthrough will break pkvm security guarantees as
@@ -177,15 +177,14 @@ static int iommu_set_sm_ce(struct set_sm_ce_data *data)
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
 
-	if ((data->ats_supported || data->ats_enabled) &&
-	    !is_dev_in_satc(bdf))
+	if (data->ats_supported && !is_dev_in_satc(bdf))
 		return -EPERM;
 
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
-	info.ats_enabled = data->ats_enabled;
+	info.ats_enabled = info.ats_supported;
 	info.pasid_supported = data->pasid_supported;
 	info.pasid_enabled = data->pasid_enabled;
 	table.table = pkvm_host_gpa_to_virt(data->pasid_table_gpa);
@@ -262,7 +261,7 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	if (is_dev_in_satc(bdf)) {
 		if (ecap_dit(iommu->ecap))
 			info.pfsid = bdf;
-	} else if (data->ats_supported || data->ats_enabled) {
+	} else if (data->ats_supported) {
 		return -EPERM;
 	}
 
@@ -274,8 +273,8 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
-	info.ats_enabled = data->ats_enabled;
 	info.ats_supported = data->ats_supported;
+	info.ats_enabled = info.ats_supported;
 	info.pasid_table = &table;
 	info.iommu = iommu;
 
@@ -322,7 +321,7 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	if (is_dev_in_satc(bdf)) {
 		if (ecap_dit(iommu->ecap))
 			info.pfsid = bdf;
-	} else if (data->ats_supported || data->ats_enabled) {
+	} else if (data->ats_supported) {
 		return -EPERM;
 	}
 
@@ -336,7 +335,7 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	info.iommu = iommu;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
-	info.ats_enabled = data->ats_enabled;
+	info.ats_enabled = info.ats_supported;
 
 	if (data->did == FLPT_DEFAULT_DID) {
 		/*
@@ -394,7 +393,7 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 	if (is_dev_in_satc(bdf)) {
 		if (ecap_dit(iommu->ecap))
 			info.pfsid = bdf;
-	} else if (data->ats_supported || data->ats_enabled) {
+	} else if (data->ats_supported) {
 		return -EPERM;
 	}
 
@@ -405,8 +404,8 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
-	info.ats_enabled = data->ats_enabled;
 	info.ats_supported = data->ats_supported;
+	info.ats_enabled = info.ats_supported;
 	info.pasid_table = &table;
 	info.iommu = iommu;
 

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -130,7 +130,6 @@ int pkvm_context_clear(u64 phys, u8 bus, u8 devfn, struct device_domain_info *in
 	data->devfn = devfn;
 	data->ats_qdep = info->ats_qdep;
 	data->ats_supported = info->ats_supported;
-	data->ats_enabled = info->ats_enabled;
 
 	return pkvm_hypercall_in(iommu_clear_ce, &d);
 }
@@ -149,7 +148,6 @@ int pkvm_context_mapping(struct intel_iommu *iommu, struct device_domain_info *i
 	data->devfn = devfn;
 	data->ats_qdep = info->ats_qdep;
 	data->ats_supported = info->ats_supported;
-	data->ats_enabled = info->ats_enabled;
 
 	spin_lock(&iommu->lock);
 	ret = pkvm_hypercall_inout(iommu_set_lm_ce, &d, &d);
@@ -191,7 +189,6 @@ int pkvm_pasid_table_setup(struct intel_iommu *iommu, struct device_domain_info 
 	data->pasid_supported = info->pasid_supported;
 	data->pasid_enabled = info->pasid_enabled;
 	data->ats_supported = info->ats_supported;
-	data->ats_enabled = info->ats_enabled;
 	data->ats_qdep = info->ats_qdep;
 
 	spin_lock(&iommu->lock);
@@ -233,7 +230,6 @@ int pkvm_pasid_setup_fl(struct device_domain_info *info, phys_addr_t fsptptr,
 	data->bus = info->bus;
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;
-	data->ats_enabled = info->ats_enabled;
 	data->ats_supported = info->ats_supported;
 
 	spin_lock(&iommu->lock);
@@ -274,7 +270,6 @@ int pkvm_pasid_setup_sl(struct device_domain_info *info, phys_addr_t ssptptr,
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;
 	data->ats_supported = info->ats_supported;
-	data->ats_enabled = info->ats_enabled;
 
 	spin_lock(&iommu->lock);
 	ret = pkvm_hypercall_inout(iommu_pasid_setup_sl, &d, &d);
@@ -308,7 +303,6 @@ int pkvm_pasid_teardown(struct device_domain_info *info, u32 pasid)
 	data->bus = info->bus;
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;
-	data->ats_enabled = info->ats_enabled;
 	data->ats_supported = info->ats_supported;
 
 	return pkvm_hypercall_in(iommu_pasid_teardown, &d);


### PR DESCRIPTION
The Intel IOMMU driver assigns cache tags to a domain after completing the context or PASID table setup. At this point, the 'ats_enabled' flag is already set for devices in the domain.

In contrast, the pKVM hypervisor assigns cache tags during the context or PASID table setup process itself. Because this happens before the host has finalized the ATS state, pKVM cannot rely on 'ats_enabled' to determine if a device-TLB cache tag (CACHE_TAG_DEVTLB) should be assigned.

To resolve this, use the 'ats_supported' flag as the indicator for assigning the devtlb cache tag. This is safe because pKVM only supports ATS for devices listed in the SATC, and the host driver is expected to enable ATS for all such devices. pKVM already enforces this by failing context/PASID table setup if 'ats_supported' is set for a non-SATC device.

Clean up the hypercall interfaces by removing the redundant 'ats_enabled' field from the PASID and context setup/teardown data structures. Since the re-used IOMMU driver logic expects 'ats_enabled' to be set when assigning cache tags, the hypercall handlers now internally set 'info.ats_enabled' to 'ats_supported' before invoking the driver functions.

Fixes: 6e261a4619ed ("iommu/vt-d: pKVM: Port cache tag management logic to pkvm.")