### PR TITLE
SQUASHME: pKVM: x86: Fix vmexit trace dump lockup

### DIFF
--- a/arch/x86/kvm/pkvm/trace.c
+++ b/arch/x86/kvm/pkvm/trace.c
@@ -100,8 +100,10 @@ static int __copy_guest_vm_trace(struct pkvm_vm *vm, void *param)
 		if (!vm->vcpus[i])
 			continue;
 
-		if (arg->size < sizeof(struct perf_data))
+		if (arg->size < sizeof(struct perf_data)) {
+			pkvm_spin_unlock(&vm->lock);
 			return -ENOSPC;
+		}
 
 		copy_vmexit_perf_data(arg->dst, &vm->vcpus[i]->perf);
 		arg->dst += sizeof(struct perf_data);


### PR DESCRIPTION
The vmexit trace dump path can return -ENOSPC from the hypervisor while holding vm->lock in __copy_guest_vm_trace(), which leaves the per-VM lock permanently held and can strand a CPU in hyp with interrupts disabled.

Fix it by always dropping vm->lock on the error path.

Fixes: 1ff5d9013996 ("pKVM: x86: trace: Extend PV interface to dump the guest trace")