### PR TITLE
SQUASHME: pKVM: x86: Fix dependency on !BLK_DEV_FD

### DIFF
--- a/arch/x86/kvm/Kconfig
+++ b/arch/x86/kvm/Kconfig
@@ -138,7 +138,7 @@ config PKVM_INTEL
 	bool "pKVM for Intel processors support"
 	depends on KVM_INTEL=y
 	depends on INTEL_IOMMU
-	depends on !BLK_DEV_FD
+	depends on BLK_DEV_FD=n
 	select PKVM_X86
 	help
 	  Provides support for pKVM on Intel processors.


### PR DESCRIPTION
!BLK_DEV_FD doesn't cover the CONFIG_BLK_DEV_FD=m case, it only covers the CONFIG_BLK_DEV_FD=y case.
See Documentation/kbuild/kconfig-language.rst:

>            '!' <expr>                           (6)
>
> ...
>
> (6) Returns the result of (2-/expr/).
>
> ...
>
> An expression can have a value of 'n', 'm' or 'y' (or 0, 1, 2
> respectively for calculations).

So !BLK_DEV_FD doesn't prevent enabling pKVM together with the floppy driver if the floppy driver is enabled as a module.

So change it to BLK_DEV_FD=n to prevent both =y and =m cases.

Fixes: 38ed4e8f61ec ("pKVM: x86: set PKVM_INTEL depend on !BLK_DEV_FD")
Reported-by: Masanori Misono <m.misono760@gmail.com>
Link: https://github.com/intel-staging/pKVM-IA/issues/92