### PR TITLE
Pkvm v6.18 fix

### DIFF
--- a/arch/x86/kvm/pkvm/vmx/host_vmentry.S
+++ b/arch/x86/kvm/pkvm/vmx/host_vmentry.S
@@ -79,10 +79,6 @@ SYM_FUNC_START(pkvm_host_vmexit_entry)
 	wrmsr
 
 .Lspec_ctrl_done:
-	cmpb $1, PER_CPU_VAR(host_vcpu_fixup)
-	je .Lfixup
-
-.Lresume:
 	/*
 	 * Restore registers to reflect the vm-exit handling/emulation result
 	 * before vmresume.
@@ -117,9 +113,5 @@ SYM_FUNC_START(pkvm_host_vmexit_entry)
 	vmread %_ASM_CX, %_ASM_AX
 failed:
 	jmp failed			/* should never come here */
-.Lfixup:
-	mov WORD_SIZE*1(%_ASM_SP), %_ASM_DI
-	call pkvm_host_vmx_fixup
-	jmp .Lresume
 SYM_FUNC_END(pkvm_host_vmexit_entry)
 STACK_FRAME_NON_STANDARD(pkvm_host_vmexit_entry);

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -299,6 +299,25 @@ static inline void set_vcpu_mode(struct kvm_vcpu *vcpu, int mode)
 	smp_wmb();
 }
 
+static void fixup_host_vmx(struct vcpu_vmx *vmx)
+{
+	if (boot_cpu_has(X86_FEATURE_INTEL_PT)) {
+		/*
+		 * The VM_ENTRY_LOAD_IA32_RTIT_CTL bit may be cleared due to the
+		 * MSR_IA32_RTIT_CTL TRACEEN bit is set before deprivileging. See
+		 * comments in init_vmentry_control in pkvm_init.c.
+		 *
+		 * Ensure this bit is set after the host exits to the root mode.
+		 * This can be done safely as VM_EXIT_CLEAR_IA32_RTIT_CTL is
+		 * guaranteed to be set which causes the MSR_IA32_RTIT_CTL is 0.
+		 */
+		if (!(vm_entry_controls_get(vmx) & VM_ENTRY_LOAD_IA32_RTIT_CTL))
+			vm_entry_controls_setbit(vmx, VM_ENTRY_LOAD_IA32_RTIT_CTL);
+	}
+
+	this_cpu_write(host_vcpu_fixup, false);
+}
+
 void pkvm_host_vmexit_main(struct vcpu_vmx *vmx)
 {
 	struct kvm_vcpu *vcpu = &vmx->vcpu;
@@ -398,24 +417,8 @@ handle_events:
 	if (vcpu->arch.cr2 != native_read_cr2())
 		native_write_cr2(vcpu->arch.cr2);
 
+	if (unlikely(this_cpu_read(host_vcpu_fixup)))
+		fixup_host_vmx(vmx);
+
 	pkvm_trace_vmexit_end(vcpu, vt->exit_reason.basic);
-}
-
-void pkvm_host_vmx_fixup(struct vcpu_vmx *vmx)
-{
-	if (boot_cpu_has(X86_FEATURE_INTEL_PT)) {
-		/*
-		 * The VM_ENTRY_LOAD_IA32_RTIT_CTL bit may be cleared due to the
-		 * MSR_IA32_RTIT_CTL TRACEEN bit is set before deprivileging. See
-		 * comments in init_vmentry_control in pkvm_init.c.
-		 *
-		 * Ensure this bit is set after the host exits to the root mode.
-		 * This can be done safely as VM_EXIT_CLEAR_IA32_RTIT_CTL is
-		 * guaranteed to be set which causes the MSR_IA32_RTIT_CTL is 0.
-		 */
-		if (!(vm_entry_controls_get(vmx) & VM_ENTRY_LOAD_IA32_RTIT_CTL))
-			vm_entry_controls_setbit(vmx, VM_ENTRY_LOAD_IA32_RTIT_CTL);
-	}
-
-	this_cpu_write(host_vcpu_fixup, false);
 }

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.h
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.h
@@ -14,6 +14,4 @@ void pkvm_host_vmexit_main(struct vcpu_vmx *vmx);
 
 void pkvm_vmx_reprivilege_cpu(unsigned long *vcpu_regs);
 
-void pkvm_host_vmx_fixup(struct vcpu_vmx *vmx);
-
 #endif /* __PKVM_VMX_HOST_VMX_H */

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -229,11 +229,17 @@ static __init int pkvm_setup_host_vmcs_config(void)
 		 * has the MPX, enable the MPX vmexit control to guarantee the
 		 * MSR_IA32_BNDCFGS will be cleared for the pKVM hypervisor.
 		 *
-		 * No need to enable vmentry control to load IA32_BNDCFGS for
-		 * the deprivileged host as the linux kernel will not use the
-		 * MPX even if the CPU supports it.
+		 * From the security/function point of view, there is no need to
+		 * enable VM-Entry control to load IA32_BNDCFGS for the
+		 * deprivileged host as the linux kernel will not use the MPX
+		 * even if the CPU supports it. But as the code setup the VMCS
+		 * config via reusing KVM's setup_vmcs_config_common() which
+		 * checks if MPX VM-Entry and VM-Exit configs are in pair of
+		 * not, it still needs to set VM_ENTRY_LOAD_BNDCFGS to pass
+		 * this check.
 		 */
 		setting.vmexit_ctrl_req |= VM_EXIT_CLEAR_BNDCFGS;
+		setting.vmentry_ctrl_req |= VM_ENTRY_LOAD_BNDCFGS;
 	}
 
 	if (setup_vmcs_config_common(vmcs_config, vmx_cap, &setting))


### PR DESCRIPTION
Backport two fixes from https://android.googlesource.com/kernel/common/+/refs/heads/android17-6.18 to fix the issues of calling fixup and MPX enforcement.