### PR TITLE
x86/pkvm: Add dependency with CONFIG_PARAVIRT

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -919,6 +919,7 @@ config INTEL_TDX_GUEST
 
 config PKVM_X86_GUEST
 	bool "pKVM Protected Guest Support"
+	depends on PARAVIRT
 	select ARCH_HAS_CC_PLATFORM
 	select X86_MEM_ENCRYPT
 	help


### PR DESCRIPTION
As the pKVM guest kernel will hook its own mmio operations to the pv_ops, add dependency with CONFIG_PARAVIRT to make sure the pv_ops is enabled.

Fixes: 056f607f79d1 ("x86/pkvm: Use hypercalls to access MMIO")
Reported-by: kernel test robot <lkp@intel.com>