### PR TITLE
pKVM: iommu/vt-d: Reject partial unmap of superpage

### DIFF
--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -1008,6 +1008,9 @@ static bool dma_pte_clear_level(struct dmar_domain *domain, int level,
 				first_pte = pte;
 			last_pte = pte;
 		} else if (level > 1) {
+			if (WARN_ON_ONCE(dma_pte_superpage(pte)))
+				goto next;
+
 			/* Recurse down into a level that isn't *entirely* obsolete */
 			leaf_ptes_only = dma_pte_clear_level(domain, level - 1,
 							     phys_to_virt(dma_pte_addr(pte)),
@@ -1095,6 +1098,9 @@ static void dma_unuse_range(struct dmar_domain *domain, int level,
 				first_pte = pte;
 			last_pte = pte;
 		} else if (level > 1) {
+			if (WARN_ON_ONCE(dma_pte_superpage(pte)))
+				goto next;
+
 			dma_unuse_range(domain, level - 1,
 					phys_to_virt(dma_pte_addr(pte)),
 					level_pfn, start_pfn, last_pfn);


### PR DESCRIPTION
The pKVM IOMMU unmap hypercall receives its PFN range from the host, so it cannot rely on the normal host IOMMU path to have expanded partial unmaps of large mappings. If a partial range crosses a superpage leaf, the shared unmap walker can otherwise descend through the leaf and interpret DMA data page as a lower-level page table.

Add defensive checks before recursive descent so host/pKVM does not treat a superpage leaf as a page-table pointer.

Reported-by: Yi Ran <yyi@stu.pku.edu.cn>
Closes: https://github.com/intel-staging/pKVM-IA/issues/104
Fixes: 119a4e6a8273 ("iommu/vt-d: pKVM: Hypercalls for domain pagetable management")