### PR TITLE
x86: Mark all CPUs as non-hotpluggable if pKVM is enabled

### DIFF
--- a/arch/x86/kernel/setup.c
+++ b/arch/x86/kernel/setup.c
@@ -1316,6 +1316,6 @@ __initcall(register_kernel_offset_dumper);
 #ifdef CONFIG_HOTPLUG_CPU
 bool arch_cpu_is_hotpluggable(int cpu)
 {
-	return cpu > 0;
+	return cpu > 0 && !enable_pkvm;
 }
 #endif /* CONFIG_HOTPLUG_CPU */


### PR DESCRIPTION
pKVM-IA does not currently support offlining/onlining CPUs at runtime (i.e. when CPUs are already deprivileged, i.e. running in VMX non-root mode). It is possible to support it, but it would require adding quite some extra complexity to the pKVM hypervisor, to virtualize or paravirtualize INIT-SIPI for host vCPUs and to reset and bring up host vCPUs in pKVM when onlining them.

At the same time, there are no known use cases for CPU hotplug on Intel platforms using pKVM. For power saving, we are using cpuidle instead, which provides similar power savings as CPU offlining while is more flexible (it works for all CPUs, including CPU0) and more lightweight (no need to bring up the CPU from 16-bit real mode when waking it up).

So just mark all CPUs as not supporting hotplug if pKVM is enabled, to prevent userspace from unsuccessfully trying to offline/online them.