### PR TITLE
pKVM: Consolidate memcache refill for VT-d page-table donations

### DIFF
--- a/arch/x86/include/asm/kvm_host.h
+++ b/arch/x86/include/asm/kvm_host.h
@@ -791,6 +791,7 @@ struct pkvm_memcache {
 	} head;
 	unsigned long count;
 #define PKVM_MC_ACCOUNT_PGTABLE_PAGES	BIT(1)
+#define PKVM_MC_DONATE_SHARE_RO		BIT(2)
 	unsigned long flags;
 };
 

--- a/arch/x86/kvm/pkvm/mmu.c
+++ b/arch/x86/kvm/pkvm/mmu.c
@@ -471,61 +471,6 @@ static void drain_pool(struct pkvm_pool *pool, struct pkvm_memcache *host_mc)
 	}
 }
 
-static void *admit_host_page(void *arg)
-{
-	struct pkvm_memcache *host_mc = arg;
-	void *page;
-
-	if (!host_mc->count || WARN_ON_ONCE(host_mc->head.nr_pages != 1))
-		return NULL;
-
-	/*
-	 * Should donate the page from the host memcache before pop it out
-	 * because pop will read data from this page to get the next head, and
-	 * then will write this data to the host memcache's head. Without
-	 * donating, doing that may leak sensitive data as this page may be a
-	 * private page of a pVM or the hypervisor.
-	 *
-	 * The page will be cleared by zalloc_page when allocating it from
-	 * the memcache, thus no need to clear it now.
-	 */
-	if (WARN_ON_ONCE(pkvm_host_donate_hyp(pkvm_host_gpa_to_phys(host_mc->head.addr),
-					      PAGE_SIZE, false)))
-		return NULL;
-
-	page = pop_pkvm_memcache_page(host_mc, pkvm_host_gpa_to_virt);
-	/*
-	 * The head page is already donated so the pop has no reason to fail
-	 * unless there is a code bug.
-	 */
-	BUG_ON(!page);
-
-	return page;
-}
-
-/* Refill our local memcache by popping pages from the one provided by the host. */
-static int refill_memcache(struct pkvm_memcache *mc, unsigned long min_pages,
-			   struct pkvm_memcache *host_mc)
-{
-	/*
-	 * The host mc is shared and can be modified by the host while popping.
-	 * Copy it to local and use the local one to prevent the host from
-	 * changing it with unexpected values, e.g., the host change the
-	 * host_mc->head.addr to a private page address after addr is donated
-	 * but before popping up, making the pop_pkvm_memcache_page reading
-	 * from the private page and leaking data to the host.
-	 */
-	struct pkvm_memcache tmp_mc = *(volatile typeof(*host_mc) *)host_mc;
-	int ret;
-
-	ret = topup_pkvm_memcache(mc, min_pages, admit_host_page,
-				  pkvm_virt_to_phys, &tmp_mc);
-
-	*(volatile typeof(*host_mc) *)host_mc = tmp_mc;
-
-	return ret;
-}
-
 static int host_reclaim_guest_walker(struct pkvm_pgtable_visit_ctx *ctx,
 				     unsigned long walk_flags,
 				     void *const arg)
@@ -1003,8 +948,8 @@ int pkvm_guest_mmu_refill_memcache(struct pkvm_vcpu *pkvm_vcpu)
 
 	host_mc = &pkvm_vcpu->shared_vcpu->arch.pkvm.guest_mmu_memcache;
 
-	return refill_memcache(&vcpu->arch.pkvm.guest_mmu_memcache,
-			       READ_ONCE(host_mc->count), host_mc);
+	return pkvm_refill_memcache(&vcpu->arch.pkvm.guest_mmu_memcache,
+				    READ_ONCE(host_mc->count), host_mc);
 }
 
 void pkvm_guest_mmu_free_memcache(struct pkvm_vcpu *pkvm_vcpu)

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -2409,7 +2409,10 @@ int pkvm_walk_each_vm(pkvm_vm_func_t func, void *arg)
 static void *admit_host_page(void *arg)
 {
 	struct pkvm_memcache *host_mc = arg;
+	bool share_ro = host_mc->flags & PKVM_MC_DONATE_SHARE_RO;
+	phys_addr_t addr;
 	void *page;
+	int ret;
 
 	if (!host_mc->count || WARN_ON_ONCE(host_mc->head.nr_pages != 1))
 		return NULL;
@@ -2424,8 +2427,10 @@ static void *admit_host_page(void *arg)
 	 * The page is donated uncleared. Consumers of the refilled memcache
 	 * are responsible for zeroing the page before use.
 	 */
-	if (WARN_ON_ONCE(pkvm_host_donate_hyp(pkvm_host_gpa_to_phys(host_mc->head.addr),
-					      PAGE_SIZE, false)))
+	addr = pkvm_host_gpa_to_phys(host_mc->head.addr);
+	ret = share_ro ? pkvm_host_donate_hyp_share_ro(addr, PAGE_SIZE, false) :
+			 pkvm_host_donate_hyp(addr, PAGE_SIZE, false);
+	if (WARN_ON_ONCE(ret))
 		return NULL;
 
 	page = pop_pkvm_memcache_page(host_mc, pkvm_host_gpa_to_virt);

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -2405,3 +2405,58 @@ int pkvm_walk_each_vm(pkvm_vm_func_t func, void *arg)
 
 	return ret;
 }
+
+static void *admit_host_page(void *arg)
+{
+	struct pkvm_memcache *host_mc = arg;
+	void *page;
+
+	if (!host_mc->count || WARN_ON_ONCE(host_mc->head.nr_pages != 1))
+		return NULL;
+
+	/*
+	 * Should donate the page from the host memcache before pop it out
+	 * because pop will read data from this page to get the next head, and
+	 * then will write this data to the host memcache's head. Without
+	 * donating, doing that may leak sensitive data as this page may be a
+	 * private page of a pVM or the hypervisor.
+	 *
+	 * The page is donated uncleared. Consumers of the refilled memcache
+	 * are responsible for zeroing the page before use.
+	 */
+	if (WARN_ON_ONCE(pkvm_host_donate_hyp(pkvm_host_gpa_to_phys(host_mc->head.addr),
+					      PAGE_SIZE, false)))
+		return NULL;
+
+	page = pop_pkvm_memcache_page(host_mc, pkvm_host_gpa_to_virt);
+	/*
+	 * The head page is already donated so the pop has no reason to fail
+	 * unless there is a code bug.
+	 */
+	BUG_ON(!page);
+
+	return page;
+}
+
+/* Refill our local memcache by popping pages from the one provided by the host. */
+int pkvm_refill_memcache(struct pkvm_memcache *mc, unsigned long min_pages,
+			 struct pkvm_memcache *host_mc)
+{
+	/*
+	 * The host mc is shared and can be modified by the host while popping.
+	 * Copy it to local and use the local one to prevent the host from
+	 * changing it with unexpected values, e.g., the host change the
+	 * host_mc->head.addr to a private page address after addr is donated
+	 * but before popping up, making the pop_pkvm_memcache_page reading
+	 * from the private page and leaking data to the host.
+	 */
+	struct pkvm_memcache tmp_mc = *(volatile typeof(*host_mc) *)host_mc;
+	int ret;
+
+	ret = topup_pkvm_memcache(mc, min_pages, admit_host_page,
+				  pkvm_virt_to_phys, &tmp_mc);
+
+	*(volatile typeof(*host_mc) *)host_mc = tmp_mc;
+
+	return ret;
+}

--- a/arch/x86/kvm/pkvm/pkvm.h
+++ b/arch/x86/kvm/pkvm/pkvm.h
@@ -213,5 +213,7 @@ void pkvm_x86_ops_init(struct pkvm_x86_ops *ops);
 int pkvm_emulate_hypercall(struct kvm_vcpu *vcpu);
 typedef int (*pkvm_vm_func_t)(struct pkvm_vm *vm, void *arg);
 int pkvm_walk_each_vm(pkvm_vm_func_t func, void *arg);
+int pkvm_refill_memcache(struct pkvm_memcache *mc, unsigned long min_pages,
+			 struct pkvm_memcache *host_mc);
 
 #endif /* __PKVM_X86_PKVM_H */

--- a/drivers/iommu/intel/pkvm/domain.c
+++ b/drivers/iommu/intel/pkvm/domain.c
@@ -4,6 +4,7 @@
 
 #include <linux/hashtable.h>
 #include <asm/pkvm_spinlock.h>
+#include "pkvm.h"
 #include "pkvm/debug.h"
 #include "pkvm/memory.h"
 #include "../iommu.h"
@@ -117,23 +118,6 @@ void pkvm_put_domain_cache_tag_unassign(void *pgd, int did, u32 pasid,
 	pkvm_put_iommu_domain(domain);
 }
 
-static void *admit_host_domain_page(void *arg)
-{
-	struct pkvm_memcache *host_mc = (struct pkvm_memcache *)arg;
-	void *page;
-
-	page = pop_pkvm_memcache_page(host_mc, pkvm_host_gpa_to_virt);
-	if (!page)
-		return NULL;
-
-	if (WARN_ON(pkvm_host_donate_hyp_share_ro(__pkvm_pa(page), VTD_PAGE_SIZE, true))) {
-		push_pkvm_memcache_page(host_mc, page, pkvm_virt_to_host_gpa);
-		return NULL;
-	}
-
-	return page;
-}
-
 static int refill_domain_memcache(struct dmar_domain *domain,
 				  struct pkvm_memcache *host_mc)
 {
@@ -148,9 +132,8 @@ static int refill_domain_memcache(struct dmar_domain *domain,
 	 * provides a memcache if the hypervisor's memcache doesn't already
 	 * have enough pages.
 	 */
-	min_pages = mc->count + host_mc->count;
-	return topup_pkvm_memcache(mc, min_pages, admit_host_domain_page,
-				   pkvm_virt_to_phys, host_mc);
+	min_pages = mc->count + READ_ONCE(host_mc->count);
+	return pkvm_refill_memcache(mc, min_pages, host_mc);
 }
 
 static void free_domain_memcache(struct dmar_domain *domain,

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -393,6 +393,7 @@ int pkvm_domain_map(struct dmar_domain *domain, unsigned long iov_pfn,
 	data->phys_pfn = phys_pfn;
 	data->nr_pages = nr_pages;
 	data->prot = prot;
+	data->mc.flags = PKVM_MC_DONATE_SHARE_RO;
 
 	ret = pkvm_hypercall_inout(iommu_domain_map, &d, &d);
 	if (ret == -ENOMEM) {


### PR DESCRIPTION
## Summary

Consolidate the pKVM memcache refill path and use it for Intel VT-d page-table page donations.

This series:

- exposes `pkvm_refill_memcache()` for use outside the guest MMU path;
- adds `PKVM_MC_DONATE_SHARE_RO` so callers can retain host read-only access after donating pages to the hypervisor; and
- replaces the duplicated VT-d domain memcache refill implementation with the common helper.

## Motivation

The Intel pKVM IOMMU code maintained a separate memcache refill implementation. As a result, security fixes in the common pKVM refill path—most notably the TOCTOU and donation-ordering hardening from commit 4dc9c4dbfea5 ("ANDROID: pKVM: x86: Fix TOCTOU and donate ordering in memcache refill")—did not automatically apply to VT-d.

Using the common helper keeps the host-provided memcache snapshot and donate-before-pop ordering in one place. The new flag preserves the VT-d contract: donated IOMMU page-table pages remain readable, but not writable, by the host.

## Impact

There is no intended user-visible behavior change. The change removes duplicated security-sensitive code and ensures the guest MMU and VT-d paths share future memcache refill fixes.

## Validation

- `git diff --check intel/pkvm-v6.18...HEAD`
- `scripts/checkpatch.pl --git` for all three commits: 0 errors; three warnings in the first commit for `BUG_ON()` and volatile accesses moved from the existing implementation

