### PR TITLE
pKVM: Backport VMX host-state security fixes

### DIFF
--- a/arch/x86/include/asm/pkvm_hypercalls.h
+++ b/arch/x86/include/asm/pkvm_hypercalls.h
@@ -26,7 +26,6 @@ PKVM_HC(dump_vmexit_trace)
 
 /* KVM ops */
 PKVM_HC(check_processor_compatibility)
-PKVM_HC(enable_virtualization_cpu)
 PKVM_HC(vm_init)
 PKVM_HC(vm_finalize)
 PKVM_HC_OUT(vm_destroy)

--- a/arch/x86/kvm/pkvm/idt.c
+++ b/arch/x86/kvm/pkvm/idt.c
@@ -163,7 +163,7 @@ void handle_exception(struct pt_regs *regs, int vector, bool has_error_code)
 	if (vector >= X86_TRAP_IRET)
 		return;
 
-	if (pkvm_fixup_exception(regs))
+	if (vector == X86_TRAP_GP && pkvm_fixup_exception(regs))
 		return;
 
 	handler = exception_handlers[vector];

--- a/arch/x86/kvm/pkvm/init.c
+++ b/arch/x86/kvm/pkvm/init.c
@@ -3,6 +3,7 @@
 #include <asm/fpu/xstate.h>
 #include <asm/kvm_pkvm.h>
 #include "../cpuid.h"
+#include "../x86.h"
 #include "early_alloc.h"
 #include "fpu.h"
 #include "init.h"
@@ -300,6 +301,8 @@ int pkvm_init(struct pkvm_mem_info infos[], int nr_infos)
 		return ret;
 
 	pkvm_vcpu_perf_init(this_cpu_read(host_vcpu));
+
+	kvm_user_return_msr_cpu_online();
 
 	this_cpu_write(cpu_initialized, true);
 	return 0;

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -77,13 +77,6 @@ static struct pkvm_x86_ops pkvm_x86_ops __read_mostly;
 static int __pkvm_vcpu_free(struct pkvm_vm *pkvm_vm, int vcpu_handle,
 			    struct pkvm_memcache *mc);
 
-static int pkvm_enable_virtualization_cpu(void)
-{
-	kvm_user_return_msr_cpu_online();
-
-	return kvm_x86_call(enable_virtualization_cpu)();
-}
-
 static int allocate_pkvm_vm_handle(struct pkvm_vm *pkvm_vm)
 {
 	struct pkvm_vm_ref *pkvm_vm_ref;
@@ -2038,9 +2031,6 @@ void pkvm_handle_host_hypercall(struct kvm_vcpu *vcpu)
 		break;
 	case __pkvm__check_processor_compatibility:
 		ret = kvm_x86_call(check_processor_compatibility)();
-		break;
-	case __pkvm__enable_virtualization_cpu:
-		ret = pkvm_enable_virtualization_cpu();
 		break;
 	case __pkvm__vm_init:
 		ret = pkvm_vm_init(pkvm_host_gpa_to_phys(pkvm_hc_input1(vcpu)),

--- a/arch/x86/kvm/pkvm/pkvm.c
+++ b/arch/x86/kvm/pkvm/pkvm.c
@@ -800,14 +800,6 @@ static int pkvm_vcpu_load(int vm_handle, int vcpu_handle)
 		 */
 		BUG_ON(pkvm_vcpu != pkvm_get_vcpu(vm_handle, vcpu_handle));
 
-		/*
-		 * Save the PKRU used by the host for the pKVM hypervisor to
-		 * switch with the guest. The XCR0 and XSS are already saved in
-		 * the kvm_host structure which are not changed at the running
-		 * time.
-		 */
-		vcpu->arch.host_pkru = read_pkru();
-
 		this_cpu_write(cur_guest_vcpu, vcpu);
 	} else if (loaded_cpu == cpu) {
 		/* The guest vCPU is already loaded on this CPU. */

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <linux/kvm_types.h>
 #include <linux/memblock.h>
+#include <asm/fpu/xcr.h>
 #include <kvm_emulate.h>
 #include <vmx/x86_ops.h>
 #include "debug.h"
@@ -184,6 +185,20 @@ static int handle_write_msr(struct kvm_vcpu *vcpu)
 		}
 		break;
 	}
+	case MSR_IA32_XSS:
+		BUG_ON(!pkvm_cpu_initialized(vcpu->cpu));
+
+		if (val != kvm_host.xss) {
+			pkvm_warn("Host attempt to modify MSR_IA32_XSS: 0x%llx (expected 0x%llx)\n",
+				  val, kvm_host.xss);
+			ret = X86EMUL_UNHANDLEABLE;
+			break;
+		}
+		if (wrmsr_safe(msr, low, high)) {
+			ret = X86EMUL_UNHANDLEABLE;
+			break;
+		}
+		break;
 	case MSR_IA32_APICBASE:
 	case APIC_BASE_MSR ... APIC_BASE_MSR + 0xff:
 		if (pkvm_lapic_msr_write(msr, val))
@@ -219,6 +234,18 @@ static int handle_xsetbv(struct kvm_vcpu *vcpu)
 	u32 eax = (u32)(vcpu->arch.regs[VCPU_REGS_RAX] & -1u);
 	u32 edx = (u32)(vcpu->arch.regs[VCPU_REGS_RDX] & -1u);
 	u32 ecx = (u32)(vcpu->arch.regs[VCPU_REGS_RCX] & -1u);
+
+	BUG_ON(!pkvm_cpu_initialized(vcpu->cpu));
+
+	if (ecx == XCR_XFEATURE_ENABLED_MASK) {
+		u64 xcr0 = (u64)eax | ((u64)edx << 32);
+
+		if (xcr0 != kvm_host.xcr0) {
+			pkvm_warn("Host attempt to modify XCR0: 0x%llx (expected 0x%llx)\n",
+				  xcr0, kvm_host.xcr0);
+			goto fault;
+		}
+	}
 
 	asm goto("1: xsetbv\n\t"
 		 _ASM_EXTABLE(1b, %l[fault])

--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -199,6 +199,34 @@ static int handle_write_msr(struct kvm_vcpu *vcpu)
 			break;
 		}
 		break;
+	case MSR_SYSCALL_MASK:
+	case MSR_LSTAR:
+	case MSR_CSTAR:
+	case MSR_TSC_AUX:
+	case MSR_STAR:
+	case MSR_IA32_TSX_CTRL: {
+		int slot;
+		u64 cur;
+
+		BUG_ON(!pkvm_cpu_initialized(vcpu->cpu));
+
+		slot = kvm_find_user_return_msr(msr);
+		BUG_ON(slot < 0);
+
+		cur = kvm_get_user_return_msr(slot);
+		if (val != cur) {
+			pkvm_warn("Host attempt to modify user-return MSR 0x%lx: 0x%llx (expected 0x%llx)\n",
+				  msr, val, cur);
+			ret = X86EMUL_UNHANDLEABLE;
+			break;
+		}
+
+		if (wrmsr_safe(msr, low, high)) {
+			ret = X86EMUL_UNHANDLEABLE;
+			break;
+		}
+		break;
+	}
 	case MSR_IA32_APICBASE:
 	case APIC_BASE_MSR ... APIC_BASE_MSR + 0xff:
 		if (pkvm_lapic_msr_write(msr, val))

--- a/arch/x86/kvm/vmx/pkvm_host.c
+++ b/arch/x86/kvm/vmx/pkvm_host.c
@@ -605,7 +605,12 @@ static int pkvm_check_processor_compat(void)
 
 static int pkvm_enable_virtualization_cpu(void)
 {
-	return pkvm_hypercall(enable_virtualization_cpu);
+	/*
+	 * There is nothing to do here as virtualization was already enabled
+	 * during pKVM initialization and is never disabled or re-enabled later.
+	 */
+
+	return 0;
 }
 
 static void pkvm_disable_virtualization_cpu(void)

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -69,6 +69,7 @@ static unsigned int intercept_w_msrs[] = {
 	MSR_CORE_PERF_GLOBAL_CTRL,
 	MSR_IA32_APICBASE,
 	X2APIC_MSR(APIC_ID),
+	MSR_IA32_XSS,
 };
 
 u64 pkvm_total_reserve_pages(void)

--- a/arch/x86/kvm/vmx/pkvm_init.c
+++ b/arch/x86/kvm/vmx/pkvm_init.c
@@ -70,6 +70,13 @@ static unsigned int intercept_w_msrs[] = {
 	MSR_IA32_APICBASE,
 	X2APIC_MSR(APIC_ID),
 	MSR_IA32_XSS,
+	/* User-return MSRs (except MSR_EFER which is isolated via VMCS): */
+	MSR_SYSCALL_MASK,
+	MSR_LSTAR,
+	MSR_CSTAR,
+	MSR_TSC_AUX,
+	MSR_STAR,
+	MSR_IA32_TSX_CTRL,
 };
 
 u64 pkvm_total_reserve_pages(void)

--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -9780,11 +9780,20 @@ static void update_protected_vcpu_state(struct kvm_vcpu *vcpu,
 					struct kvm_vcpu *shared_vcpu)
 {
 	switch (vmx_get_exit_reason(vcpu).basic) {
-	case EXIT_REASON_IO_INSTRUCTION:
-		/* Only need to update RAX for the input data */
-		if ((vmx_get_exit_qual(vcpu) & 8) != 0)
-			kvm_rax_write(vcpu, shared_vcpu->arch.regs[VCPU_REGS_RAX]);
+	case EXIT_REASON_IO_INSTRUCTION: {
+		unsigned long exit_qual = vmx_get_exit_qual(vcpu);
+
+		/* Only need to update RAX for the input data (IN) */
+		if ((exit_qual & 8) != 0) {
+			unsigned int size = (exit_qual & 7) + 1;
+			unsigned long val = (size < 4) ? kvm_rax_read(vcpu) : 0;
+			unsigned long host_rax = shared_vcpu->arch.regs[VCPU_REGS_RAX];
+
+			memcpy(&val, &host_rax, size);
+			kvm_rax_write(vcpu, val);
+		}
 		fallthrough;
+	}
 	case EXIT_REASON_WBINVD:
 	case EXIT_REASON_PAUSE_INSTRUCTION:
 		WARN_ON_ONCE(kvm_skip_emulated_instruction(vcpu) != 1);
@@ -9919,10 +9928,21 @@ static void share_protected_vcpu_state(struct kvm_vcpu *vcpu,
 	int reg;
 
 	switch (vmx_get_exit_reason(vcpu).basic) {
-	case EXIT_REASON_IO_INSTRUCTION:
-		/* IO output/Input data */
-		shared_vcpu->arch.regs[VCPU_REGS_RAX] = kvm_rax_read(vcpu);
+	case EXIT_REASON_IO_INSTRUCTION: {
+		unsigned long exit_qual = vmx_get_exit_qual(vcpu);
+
+		/*
+		 * Only share RAX for OUT instructions to prevent leaking
+		 * register residue, and mask it to the I/O operand size.
+		 */
+		if ((exit_qual & 8) == 0) { /* OUT */
+			unsigned int size = (exit_qual & 7) + 1;
+
+			shared_vcpu->arch.regs[VCPU_REGS_RAX] =
+				kvm_rax_read(vcpu) & GENMASK(size * 8 - 1, 0);
+		}
 		break;
+	}
 	case EXIT_REASON_MSR_WRITE:
 		shared_vcpu->arch.regs[VCPU_REGS_RAX] = kvm_rax_read(vcpu);
 		shared_vcpu->arch.regs[VCPU_REGS_RDX] = kvm_rdx_read(vcpu);

--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -9805,8 +9805,8 @@ static void update_protected_vcpu_state(struct kvm_vcpu *vcpu,
 
 		if (vmx_get_exit_reason(vcpu).basic == EXIT_REASON_MSR_READ &&
 		    !to_pkvm_vcpu(vcpu)->host_emulated_msr_err) {
-			kvm_rax_write(vcpu, shared_vcpu->arch.regs[VCPU_REGS_RAX]);
-			kvm_rdx_write(vcpu, shared_vcpu->arch.regs[VCPU_REGS_RDX]);
+			kvm_rax_write(vcpu, (u32)shared_vcpu->arch.regs[VCPU_REGS_RAX]);
+			kvm_rdx_write(vcpu, (u32)shared_vcpu->arch.regs[VCPU_REGS_RDX]);
 		}
 
 		WARN_ON_ONCE(kvm_complete_insn_gp(vcpu,
@@ -9944,11 +9944,11 @@ static void share_protected_vcpu_state(struct kvm_vcpu *vcpu,
 		break;
 	}
 	case EXIT_REASON_MSR_WRITE:
-		shared_vcpu->arch.regs[VCPU_REGS_RAX] = kvm_rax_read(vcpu);
-		shared_vcpu->arch.regs[VCPU_REGS_RDX] = kvm_rdx_read(vcpu);
+		shared_vcpu->arch.regs[VCPU_REGS_RAX] = (u32)kvm_rax_read(vcpu);
+		shared_vcpu->arch.regs[VCPU_REGS_RDX] = (u32)kvm_rdx_read(vcpu);
 		fallthrough;
 	case EXIT_REASON_MSR_READ:
-		shared_vcpu->arch.regs[VCPU_REGS_RCX] = kvm_rcx_read(vcpu);
+		shared_vcpu->arch.regs[VCPU_REGS_RCX] = (u32)kvm_rcx_read(vcpu);
 		break;
 	case EXIT_REASON_EPT_VIOLATION:
 		to_vmx(shared_vcpu)->exit_gpa = vmcs_read64(GUEST_PHYSICAL_ADDRESS);

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -709,13 +709,13 @@ int kvm_set_user_return_msr(unsigned slot, u64 value, u64 mask)
 }
 EXPORT_SYMBOL_FOR_KVM_INTERNAL(kvm_set_user_return_msr);
 
-#ifndef __PKVM_HYP__
 u64 kvm_get_user_return_msr(unsigned int slot)
 {
 	return this_cpu_ptr(user_return_msrs)->values[slot].curr;
 }
 EXPORT_SYMBOL_FOR_KVM_INTERNAL(kvm_get_user_return_msr);
 
+#ifndef __PKVM_HYP__
 static void drop_user_return_notifiers(void)
 {
 	struct kvm_user_return_msrs *msrs = this_cpu_ptr(user_return_msrs);

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -15030,6 +15030,9 @@ int pkvm_vcpu_enter_guest(struct kvm_vcpu *vcpu, bool force_immediate_exit,
 
 	vcpu->arch.last_vmentry_cpu = vcpu->cpu;
 
+	/* Snapshot host PKRU on every entry to prevent host-tampering bypasses */
+	vcpu->arch.host_pkru = read_pkru();
+
 	kvm_load_guest_fpu(vcpu);
 
 	/* Save the host debug registers */


### PR DESCRIPTION
## Summary

Backport seven reviewed pKVM/VMX security fixes for host register state,
exception fixup, PKRU handling, XCR0/XSS protection, and user-return MSR
handling.

## Source

- Android common Gerrit series:
  https://android-review.googlesource.com/c/kernel/common/+/4175821

## Validation

- Replayed independently onto `intel-staging/pKVM-IA:pkvm-v6.18`.
- Built successfully.
- Verified every `Fixes:` target is an earlier commit with the quoted subject.
- Verified clean pairwise merges with the other two backport series.
