### PR TITLE
iommu/vt-d: Backport pKVM security fixes

### DIFF
--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -93,12 +93,12 @@ struct pasid_setup_fl_data {
 	u64 fsptptr_gpa;
 	u64 donation_page_gpa;
 	u32 pasid;
-	u32 flags;
 	u16 did;
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
 	u8 ats_supported: 1;
+	u8 force_snoop: 1;
 };
 
 struct pasid_setup_sl_data {

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -61,7 +61,6 @@ struct clear_ce_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_supported: 1;
 };
 
 struct set_lm_ce_data {
@@ -97,7 +96,6 @@ struct pasid_setup_fl_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_supported: 1;
 	u8 force_snoop: 1;
 };
 
@@ -110,7 +108,6 @@ struct pasid_setup_sl_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_supported: 1;
 };
 
 struct pasid_teardown_data {
@@ -119,7 +116,6 @@ struct pasid_teardown_data {
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
-	u8 ats_supported: 1;
 };
 
 struct alloc_domain_data {

--- a/arch/x86/include/asm/kvm_pkvm.h
+++ b/arch/x86/include/asm/kvm_pkvm.h
@@ -95,7 +95,6 @@ struct pasid_setup_fl_data {
 	u32 pasid;
 	u32 flags;
 	u16 did;
-	u16 old_did; /* replace_fl */
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;
@@ -108,7 +107,6 @@ struct pasid_setup_sl_data {
 	u64 donation_page_gpa;
 	u32 pasid;
 	u16 did;
-	u16 old_did; /* replace_sl */
 	u8 bus;
 	u8 devfn;
 	u8 ats_qdep;

--- a/drivers/iommu/intel/cache.c
+++ b/drivers/iommu/intel/cache.c
@@ -58,7 +58,8 @@ static bool cache_tage_match(struct cache_tag *tag, u16 domain_id,
 #else
 		struct device_domain_info *info = dev_iommu_priv_get(dev);
 
-		return info->bus == tag->bus && info->devfn == tag->devfn;
+		return info->bus == tag->bus && info->devfn == tag->devfn &&
+		       tag->iommu == iommu;
 #endif
 	}
 

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -1373,6 +1373,18 @@ static int qi_check_fault(struct intel_iommu *iommu, int index, int wait_index)
 		 *
 		 * 0 value of ite_sid means old VT-d device, no ite_sid value.
 		 * see Intel VT-d spec r4.1, section 11.4.9.9
+		 *
+		 * NOTE: with pKVM, ATS is only enabled for devices listed in
+		 * SATC (see is_dev_in_satc() gating in iommu_set_lm_ce()/
+		 * iommu_set_sm_ce()), and SATC devices are SoC-integrated and
+		 * not hot-removable, so the device-released/not-present
+		 * scenario handled here cannot occur as a result of device
+		 * unplug by the user. It may still occur if the device is
+		 * malfunctioning or if an abrupt device removal is triggered
+		 * by host kernel or (importantly!) by privileged host userspace
+		 * via sysfs. Thus it may still cause a hard lockup of the
+		 * system due to an infinite ATS invalidate retry loop in these
+		 * cases.
 		 */
 		if (ite_sid) {
 			dev = device_rbtree_find(iommu, ite_sid);

--- a/drivers/iommu/intel/dmar.c
+++ b/drivers/iommu/intel/dmar.c
@@ -1645,8 +1645,12 @@ void qi_flush_dev_iotlb(struct intel_iommu *iommu, u16 sid, u16 pfsid,
 	if (!(iommu->gcmd & DMA_GCMD_TE))
 		return;
 #else
-	if (!(iommu->vgsts & DMA_GSTS_TES))
-		return;
+	/*
+	 * Translation is never disabled after enabling during initialization.
+	 * And this is not called before IOMMU is initialized in pKVM.
+	 * If this is called with translation disabled, it means a bug in pKVM!
+	 */
+	BUG_ON(!(iommu->vgsts & DMA_GSTS_TES));
 #endif
 
 	qi_desc_dev_iotlb(sid, pfsid, qdep, addr, mask, &desc);
@@ -1689,8 +1693,12 @@ void qi_flush_dev_iotlb_pasid(struct intel_iommu *iommu, u16 sid, u16 pfsid,
 	if (!(iommu->gcmd & DMA_GCMD_TE))
 		return;
 #else
-	if (!(iommu->vgsts & DMA_GSTS_TES))
-		return;
+	/*
+	 * Translation is never disabled after enabling during initialization.
+	 * And this is not called before IOMMU is initialized in pKVM.
+	 * If this is called with translation disabled, it means a bug in pKVM!
+	 */
+	BUG_ON(!(iommu->vgsts & DMA_GSTS_TES));
 #endif
 
 	qi_desc_dev_iotlb_pasid(sid, pfsid, pasid,

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -2067,9 +2067,14 @@ void domain_context_clear_one(struct device_domain_info *info, u8 bus, u8 devfn,
 	did = context_domain_id(context);
 	context_clear_present(context);
 	__iommu_flush_cache(iommu, context, sizeof(*context));
+#ifndef __PKVM_HYP__
 	spin_unlock(&iommu->lock);
+#endif
 	intel_context_flush_no_pasid(info, context, did);
 	context_clear_entry(context);
+#ifdef __PKVM_HYP__
+	spin_unlock(&iommu->lock);
+#endif
 	__iommu_flush_cache(iommu, context, sizeof(*context));
 
 #ifdef __PKVM_HYP__

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -747,7 +747,7 @@ static struct dma_pte *pfn_to_dma_pte(struct dmar_domain *domain,
 
 	if (!domain_pfn_supported(domain, pfn))
 		/* Address beyond IOMMU's addressing capabilities. */
-		return NULL;
+		return ERR_PTR(-EINVAL);
 
 	parent = domain->pgd;
 
@@ -769,11 +769,11 @@ static struct dma_pte *pfn_to_dma_pte(struct dmar_domain *domain,
 							     SZ_4K);
 
 			if (!tmp_page)
-				return NULL;
+				return ERR_PTR(-ENOMEM);
 #else
 			tmp_page = pop_pkvm_memcache_page(&domain->mc, pkvm_phys_to_virt);
 			if (!tmp_page)
-				return NULL;
+				return ERR_PTR(-ENOMEM);
 			memset(tmp_page, 0, VTD_PAGE_SIZE);
 #endif
 
@@ -798,7 +798,10 @@ static struct dma_pte *pfn_to_dma_pte(struct dmar_domain *domain,
 			}
 			else
 				domain_flush_cache(domain, pte, sizeof(*pte));
+		} else if (WARN_ON_ONCE(dma_pte_superpage(pte))) {
+			return ERR_PTR(-EEXIST);
 		}
+
 		if (level == 1)
 			break;
 
@@ -1883,8 +1886,8 @@ int domain_map(struct dmar_domain *domain, unsigned long iov_pfn,
 
 			pte = pfn_to_dma_pte(domain, iov_pfn, &largepage_lvl,
 					     gfp);
-			if (!pte) {
-				ret = -ENOMEM;
+			if (IS_ERR(pte)) {
+				ret = PTR_ERR(pte);
 				goto out;
 			}
 			first_pte = pte;
@@ -4077,12 +4080,14 @@ static size_t intel_iommu_unmap(struct iommu_domain *domain,
 {
 	struct dmar_domain *dmar_domain = to_dmar_domain(domain);
 	unsigned long start_pfn, last_pfn;
+	struct dma_pte *pte;
 	int level = 0;
 
 	/* Cope with horrid API which requires us to unmap more than the
 	   size argument if it happens to be a large-page mapping. */
-	if (unlikely(!pfn_to_dma_pte(dmar_domain, iova >> VTD_PAGE_SHIFT,
-				     &level, GFP_ATOMIC)))
+	pte = pfn_to_dma_pte(dmar_domain, iova >> VTD_PAGE_SHIFT, &level,
+			     GFP_ATOMIC);
+	if (IS_ERR(pte))
 		return 0;
 
 	if (size < VTD_PAGE_SIZE << level_to_offset_bits(level))
@@ -4153,7 +4158,7 @@ static phys_addr_t intel_iommu_iova_to_phys(struct iommu_domain *domain,
 
 	pte = pfn_to_dma_pte(dmar_domain, iova >> VTD_PAGE_SHIFT, &level,
 			     GFP_ATOMIC);
-	if (pte && dma_pte_present(pte))
+	if (!IS_ERR(pte) && dma_pte_present(pte))
 		phys = dma_pte_addr(pte) +
 			(iova & (BIT_MASK(level_to_offset_bits(level) +
 						VTD_PAGE_SHIFT) - 1));
@@ -4804,7 +4809,7 @@ static int intel_iommu_read_and_clear_dirty(struct iommu_domain *domain,
 		pte = pfn_to_dma_pte(dmar_domain, iova >> VTD_PAGE_SHIFT, &lvl,
 				     GFP_ATOMIC);
 		pgsize = level_size(lvl) << VTD_PAGE_SHIFT;
-		if (!pte || !dma_pte_present(pte)) {
+		if (IS_ERR(pte) || !dma_pte_present(pte)) {
 			iova += pgsize;
 			continue;
 		}

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -2049,6 +2049,7 @@ void domain_context_clear_one(struct device_domain_info *info, u8 bus, u8 devfn,
 
 #ifdef __PKVM_HYP__
 	if (context_present(context)) {
+		pkvm_populate_dev_info_from_ce(info, context);
 		if (sm) {
 			pasid_dir = __pkvm_va(context->lo & VTD_PAGE_MASK);
 			pasid_dir_sz = get_pasid_dir_size(context);

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -1654,6 +1654,8 @@ int domain_context_mapping_one(struct dmar_domain *domain,
 	struct device_domain_info *info =
 			domain_lookup_dev_info(domain, iommu, bus, devfn);
 	u16 did = domain_id_iommu(domain, iommu);
+#else
+	struct pkvm_device dev = { .info = info };
 #endif
 	int translation = CONTEXT_TT_MULTI_LEVEL;
 	struct dma_pte *pgd = domain->pgd;
@@ -1683,7 +1685,11 @@ int domain_context_mapping_one(struct dmar_domain *domain,
 	if (!context)
 		goto out_unlock;
 
+#ifndef __PKVM_HYP__
 	ret = 0;
+#else
+	ret = -EEXIST;
+#endif
 	if (context_present(context) && !context_copied(iommu, bus, devfn))
 		goto out_unlock;
 
@@ -1692,13 +1698,9 @@ int domain_context_mapping_one(struct dmar_domain *domain,
 #endif
 
 #ifdef __PKVM_HYP__
-	ret = pkvm_get_domain_cache_tag_assign(pgd, did,
-					       IOMMU_NO_PASID, info);
-	if (ret) {
-		pr_err("iommu%d: failed to get the domain for pgd: %p\n",
-		       iommu->seq_id, pgd);
+	ret = cache_tag_assign_domain(domain, did, &dev, IOMMU_NO_PASID);
+	if (ret)
 		goto out_unlock;
-	}
 #endif
 	context_clear_entry(context);
 	context_set_domain_id(context, did);
@@ -2005,7 +2007,12 @@ static void pasid_free_table(struct pasid_dir_entry *dir, int max_pde)
 }
 #endif /* __PKVM_HYP__ */
 
+#ifndef __PKVM_HYP__
 void domain_context_clear_one(struct device_domain_info *info, u8 bus, u8 devfn)
+#else
+void domain_context_clear_one(struct device_domain_info *info, u8 bus, u8 devfn,
+			      struct dmar_domain **domain)
+#endif
 {
 	struct intel_iommu *iommu = info->iommu;
 	struct context_entry *context;
@@ -2014,6 +2021,8 @@ void domain_context_clear_one(struct device_domain_info *info, u8 bus, u8 devfn)
 	bool sm = sm_supported(iommu);
 	u64 pasid_dir_sz;
 	void *pgd = NULL;
+
+	*domain = NULL;
 #endif
 	u16 did;
 
@@ -2063,9 +2072,12 @@ void domain_context_clear_one(struct device_domain_info *info, u8 bus, u8 devfn)
 #ifdef __PKVM_HYP__
 	if (pasid_dir)
 		pasid_free_table(pasid_dir, pasid_dir_sz);
-	else if (pgd)
-		pkvm_put_domain_cache_tag_unassign(pgd, did,
-						   IOMMU_NO_PASID, info);
+	else if (pgd) {
+		struct pkvm_device dev = { .info = info };
+
+		*domain = pkvm_get_iommu_domain_noref(pgd, did);
+		cache_tag_unassign_domain(*domain, did, &dev, IOMMU_NO_PASID);
+	}
 #endif
 }
 

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -2053,10 +2053,12 @@ void domain_context_clear_one(struct device_domain_info *info, u8 bus, u8 devfn)
 #endif
 
 	did = context_domain_id(context);
-	context_clear_entry(context);
+	context_clear_present(context);
 	__iommu_flush_cache(iommu, context, sizeof(*context));
 	spin_unlock(&iommu->lock);
 	intel_context_flush_no_pasid(info, context, did);
+	context_clear_entry(context);
+	__iommu_flush_cache(iommu, context, sizeof(*context));
 
 #ifdef __PKVM_HYP__
 	if (pasid_dir)

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -1465,6 +1465,9 @@ static void iommu_disable_translation(struct intel_iommu *iommu)
 	u32 sts;
 	unsigned long flag;
 
+	if (pkvm_enabled())
+		return;
+
 	if (iommu_skip_te_disable && iommu->drhd->gfx_dedicated &&
 	    (cap_read_drain(iommu->cap) || cap_write_drain(iommu->cap)))
 		return;

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -2074,12 +2074,10 @@ int __domain_setup_first_level(struct intel_iommu *iommu, struct device *dev,
 			       ioasid_t pasid, u16 did, phys_addr_t fsptptr,
 			       int flags, struct iommu_domain *old)
 {
-	if (!old)
-		return intel_pasid_setup_first_level(iommu, dev, fsptptr, pasid,
-						     did, flags);
-	return intel_pasid_replace_first_level(iommu, dev, fsptptr, pasid, did,
-					       iommu_domain_did(old, iommu),
-					       flags);
+	if (old)
+		intel_pasid_tear_down_entry(iommu, dev, pasid, false);
+
+	return intel_pasid_setup_first_level(iommu, dev, fsptptr, pasid, did, flags);
 }
 
 static int domain_setup_second_level(struct intel_iommu *iommu,
@@ -2087,23 +2085,20 @@ static int domain_setup_second_level(struct intel_iommu *iommu,
 				     struct device *dev, ioasid_t pasid,
 				     struct iommu_domain *old)
 {
-	if (!old)
-		return intel_pasid_setup_second_level(iommu, domain,
-						      dev, pasid);
-	return intel_pasid_replace_second_level(iommu, domain, dev,
-						iommu_domain_did(old, iommu),
-						pasid);
+	if (old)
+		intel_pasid_tear_down_entry(iommu, dev, pasid, false);
+
+	return intel_pasid_setup_second_level(iommu, domain, dev, pasid);
 }
 
 static int domain_setup_passthrough(struct intel_iommu *iommu,
 				    struct device *dev, ioasid_t pasid,
 				    struct iommu_domain *old)
 {
-	if (!old)
-		return intel_pasid_setup_pass_through(iommu, dev, pasid);
-	return intel_pasid_replace_pass_through(iommu, dev,
-						iommu_domain_did(old, iommu),
-						pasid);
+	if (old)
+		intel_pasid_tear_down_entry(iommu, dev, pasid, false);
+
+	return intel_pasid_setup_pass_through(iommu, dev, pasid);
 }
 
 static int domain_setup_first_level(struct intel_iommu *iommu,

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -1796,34 +1796,32 @@ static int hardware_largepage_caps(struct dmar_domain *domain, unsigned long iov
  */
 static void switch_to_super_page(struct dmar_domain *domain,
 				 unsigned long start_pfn,
-				 unsigned long end_pfn, int level)
+				 unsigned long end_pfn, int level,
+				 struct dma_pte *pte)
 {
 	unsigned long lvl_pages = lvl_to_nr_pages(level);
-	struct dma_pte *pte = NULL;
+	unsigned long orig_start_pfn = start_pfn;
+	bool flush = false;
 
 	if (WARN_ON(!IS_ALIGNED(start_pfn, lvl_pages) ||
 		    !IS_ALIGNED(end_pfn + 1, lvl_pages)))
 		return;
 
 	while (start_pfn <= end_pfn) {
-		if (!pte)
-			pte = pfn_to_dma_pte(domain, start_pfn, &level,
-					     GFP_ATOMIC);
-
 		if (dma_pte_present(pte)) {
 			dma_pte_free_pagetable(domain, start_pfn,
 					       start_pfn + lvl_pages - 1,
 					       level + 1);
-
-			cache_tag_flush_range(domain, start_pfn << VTD_PAGE_SHIFT,
-					      end_pfn << VTD_PAGE_SHIFT, 0);
+			flush = true;
 		}
 
 		pte++;
 		start_pfn += lvl_pages;
-		if (first_pte_in_page(pte))
-			pte = NULL;
 	}
+
+	if (flush)
+		cache_tag_flush_range(domain, orig_start_pfn << VTD_PAGE_SHIFT,
+				      end_pfn << VTD_PAGE_SHIFT, 0);
 }
 
 int domain_map(struct dmar_domain *domain, unsigned long iov_pfn,
@@ -1903,7 +1901,7 @@ int domain_map(struct dmar_domain *domain, unsigned long iov_pfn,
 							round_down(nr_pages, lvl_pages),
 							nr_pte_to_next_page(pte) * lvl_pages);
 				end_pfn = iov_pfn + pages_to_remove - 1;
-				switch_to_super_page(domain, iov_pfn, end_pfn, largepage_lvl);
+				switch_to_super_page(domain, iov_pfn, end_pfn, largepage_lvl, pte);
 			} else {
 				pteval &= ~(uint64_t)DMA_PTE_LARGE_PAGE;
 			}

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -960,6 +960,8 @@ struct dev_pasid_info {
 #endif
 };
 #else
+/* Pull in struct pasid_table definition for _pasid_table */
+#include "pasid.h"
 struct device_domain_info {
 	u8 bus;			/* PCI bus number */
 	u8 devfn;		/* PCI devfn number */
@@ -972,6 +974,7 @@ struct device_domain_info {
 	u8 ats_enabled:1;
 	u8 ats_qdep;
 	struct intel_iommu *iommu; /* IOMMU used by this device */
+	struct pasid_table _pasid_table;
 	struct pasid_table *pasid_table; /* pasid table */
 };
 #endif /* !__PKVM_HYP__ */

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -977,6 +977,20 @@ struct device_domain_info {
 	struct pasid_table _pasid_table;
 	struct pasid_table *pasid_table; /* pasid table */
 };
+
+static inline void pkvm_populate_dev_info_from_ce(struct device_domain_info *info,
+						  struct context_entry *ce)
+{
+	/*
+	 * Derive the device's ATS state from the live context entry so
+	 * the device-TLB flush below is driven by hardware state rather
+	 * than a host-supplied flag. Bit 2 is CE.DTE in scalable mode;
+	 * in legacy mode the only translation type that sets it is
+	 * CONTEXT_TT_DEV_IOTLB, so the same test is valid for both.
+	 */
+	info->ats_supported = !!(ce->lo & BIT_ULL(2));
+	info->ats_enabled = info->ats_supported;
+}
 #endif /* !__PKVM_HYP__ */
 
 static inline void __iommu_flush_cache(

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -1181,7 +1181,26 @@ static inline unsigned long lvl_to_nr_pages(unsigned int lvl)
 
 static inline void context_set_present(struct context_entry *context)
 {
-	context->lo |= 1;
+	u64 val;
+
+	dma_wmb();
+	val = READ_ONCE(context->lo) | 1;
+	WRITE_ONCE(context->lo, val);
+}
+
+/*
+ * Clear the Present (P) bit (bit 0) of a context table entry. This initiates
+ * the transition of the entry's ownership from hardware to software. The
+ * caller is responsible for fulfilling the invalidation handshake recommended
+ * by the VT-d spec, Section 6.5.3.3 (Guidance to Software for Invalidations).
+ */
+static inline void context_clear_present(struct context_entry *context)
+{
+	u64 val;
+
+	val = READ_ONCE(context->lo) & GENMASK_ULL(63, 1);
+	WRITE_ONCE(context->lo, val);
+	dma_wmb();
 }
 
 static inline void context_set_fault_enable(struct context_entry *context)

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -1250,8 +1250,14 @@ static inline void context_clear_entry(struct context_entry *context)
 	context->hi = 0;
 }
 
+#ifndef __PKVM_HYP__
 void domain_context_clear_one(struct device_domain_info *info,
 			      u8 bus, u8 devfn);
+#else
+void domain_context_clear_one(struct device_domain_info *info,
+			      u8 bus, u8 devfn,
+			      struct dmar_domain **domain);
+#endif
 int domain_context_mapping_one(struct dmar_domain *domain,
 			       struct intel_iommu *iommu,
 #ifdef __PKVM_HYP__

--- a/drivers/iommu/intel/iommu.h
+++ b/drivers/iommu/intel/iommu.h
@@ -978,6 +978,21 @@ struct device_domain_info {
 	struct pasid_table *pasid_table; /* pasid table */
 };
 
+static inline void pkvm_populate_pfsid(struct device_domain_info *info)
+{
+	if (info->ats_supported && ecap_dit(info->iommu->ecap)) {
+		/*
+		 * Device is in SATC and optimistically assuming that a well crafted SATC
+		 * would contain only physical functions, its safe to set pfsid = bdf.
+		 * TODO: We should probably be verifying SATC for existence of only
+		 * physical functions during pkvm initialization.
+		 */
+		info->pfsid = PCI_DEVID(info->bus, info->devfn);
+	} else {
+		info->pfsid = 0;
+	}
+}
+
 static inline void pkvm_populate_dev_info_from_ce(struct device_domain_info *info,
 						  struct context_entry *ce)
 {
@@ -990,6 +1005,8 @@ static inline void pkvm_populate_dev_info_from_ce(struct device_domain_info *inf
 	 */
 	info->ats_supported = !!(ce->lo & BIT_ULL(2));
 	info->ats_enabled = info->ats_supported;
+
+	pkvm_populate_pfsid(info);
 }
 #endif /* !__PKVM_HYP__ */
 

--- a/drivers/iommu/intel/irq_remapping.c
+++ b/drivers/iommu/intel/irq_remapping.c
@@ -1021,6 +1021,10 @@ static void disable_irq_remapping(void)
 	struct dmar_drhd_unit *drhd;
 	struct intel_iommu *iommu = NULL;
 
+	/* pKVM doesn't support S3 suspend. */
+	if (WARN_ON(pkvm_enabled()))
+		return;
+
 	/*
 	 * Disable Interrupt-remapping for all the DRHD's now.
 	 */
@@ -1043,6 +1047,10 @@ static int reenable_irq_remapping(int eim)
 	struct dmar_drhd_unit *drhd;
 	bool setup = false;
 	struct intel_iommu *iommu = NULL;
+
+	/* pKVM doesn't support S3 resume. */
+	if (WARN_ON(pkvm_enabled()))
+		return -EOPNOTSUPP;
 
 	for_each_iommu(iommu, drhd)
 		if (iommu->qi)

--- a/drivers/iommu/intel/nested.c
+++ b/drivers/iommu/intel/nested.c
@@ -141,11 +141,10 @@ static int domain_setup_nested(struct intel_iommu *iommu,
 			       struct device *dev, ioasid_t pasid,
 			       struct iommu_domain *old)
 {
-	if (!old)
-		return intel_pasid_setup_nested(iommu, dev, pasid, domain);
-	return intel_pasid_replace_nested(iommu, dev, pasid,
-					  iommu_domain_did(old, iommu),
-					  domain);
+	if (old)
+		intel_pasid_tear_down_entry(iommu, dev, pasid, false);
+
+	return intel_pasid_setup_nested(iommu, dev, pasid, domain);
 }
 
 static int intel_nested_set_dev_pasid(struct iommu_domain *domain,

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -411,6 +411,7 @@ static void pasid_flush_caches(struct intel_iommu *iommu,
 	}
 }
 
+#ifndef __PKVM_HYP__
 /*
  * This function is supposed to be used after caller updates the fields
  * except for the SSADE and P bit of a pasid table entry. It does the
@@ -420,11 +421,7 @@ static void pasid_flush_caches(struct intel_iommu *iommu,
  *   of VT-d spec 5.0.
  */
 static void intel_pasid_flush_present(struct intel_iommu *iommu,
-#ifndef __PKVM_HYP__
 				      struct device *dev,
-#else
-				      struct pkvm_device *dev,
-#endif
 				      u32 pasid, u16 did,
 				      struct pasid_entry *pte)
 {
@@ -447,6 +444,7 @@ static void intel_pasid_flush_present(struct intel_iommu *iommu,
 
 	devtlb_invalidation_with_pasid(iommu, dev, pasid);
 }
+#endif /* !__PKVM_HYP__ */
 
 /*
  * Set up the scalable mode pasid table entry for first only
@@ -511,7 +509,7 @@ int intel_pasid_setup_first_level(struct intel_iommu *iommu, struct pkvm_device 
 		if (!info || !info->pasid_table)
 			return -ENODEV;
 
-		ret = pkvm_pasid_setup_fl(info, fsptptr, pasid, did, 0, flags);
+		ret = pkvm_pasid_setup_fl(info, fsptptr, pasid, did, flags);
 		if (ret)
 			pr_err("%s: iommu%d: pkvm_pasid_setup_fl failed(err=%d)\n",
 			       __func__, iommu->seq_id, ret);
@@ -547,105 +545,6 @@ int intel_pasid_setup_first_level(struct intel_iommu *iommu, struct pkvm_device 
 	spin_unlock(&iommu->lock);
 
 	pasid_flush_caches(iommu, pte, pasid, did);
-
-	return 0;
-}
-
-int intel_pasid_replace_first_level(struct intel_iommu *iommu,
-#ifndef __PKVM_HYP__
-				    struct device *dev, phys_addr_t fsptptr,
-#else
-				    struct pkvm_device *dev, phys_addr_t fsptptr,
-#endif
-				    u32 pasid, u16 did, u16 old_did,
-				    int flags)
-{
-	struct pasid_entry *pte, new_pte;
-#ifdef __PKVM_HYP__
-	void *old_pgd;
-	int pgtt;
-#endif
-	int ret;
-
-	if (!ecap_flts(iommu->ecap)) {
-		pr_err("No first level translation support on iommu%d\n",
-		       iommu->seq_id);
-		return -EINVAL;
-	}
-
-	if ((flags & PASID_FLAG_FL5LP) && !cap_fl5lp_support(iommu->cap)) {
-		pr_err("No 5-level paging support for first-level on iommu%d\n",
-		       iommu->seq_id);
-		return -EINVAL;
-	}
-
-#ifndef __PKVM_HYP__
-	if (pkvm_enabled()) {
-		struct device_domain_info *info = dev_iommu_priv_get(dev);
-
-		if (!info || !info->pasid_table)
-			return -ENODEV;
-
-		ret = pkvm_pasid_setup_fl(info, fsptptr, pasid, did, old_did, flags);
-		if (ret)
-			pr_err("%s: iommu%d: pkvm_pasid_setup_fl failed(err=%d)\n",
-			       __func__, iommu->seq_id, ret);
-
-		return ret;
-	}
-#endif
-
-	pasid_pte_config_first_level(iommu, &new_pte, fsptptr, did, flags);
-
-	spin_lock(&iommu->lock);
-	pte = intel_pasid_get_entry(dev, pasid);
-	if (IS_ERR(pte)) {
-		spin_unlock(&iommu->lock);
-		return PTR_ERR(pte);
-	}
-
-	if (!pasid_pte_is_present(pte)) {
-		spin_unlock(&iommu->lock);
-		return -EINVAL;
-	}
-
-
-#ifdef __PKVM_HYP__
-	if (WARN_ON(old_did != pasid_get_domain_id(pte))) {
-		spin_unlock(&iommu->lock);
-		return -EINVAL;
-	}
-
-	pgtt = pasid_pte_get_pgtt(pte);
-	if (pgtt == PASID_ENTRY_PGTT_FL_ONLY)
-		old_pgd = __pkvm_va(pasid_get_flptr(pte));
-	else if (pgtt == PASID_ENTRY_PGTT_SL_ONLY)
-		old_pgd = __pkvm_va(pasid_get_slptr(pte));
-	else
-		BUG();
-
-	ret = pkvm_get_domain_cache_tag_assign(__pkvm_va(fsptptr), did,
-					       pasid, dev_iommu_priv_get(dev));
-	if (ret) {
-		pr_err("iommu%d: failed to get the domain for did: %d, fsptptr: %llx\n",
-		       iommu->seq_id, did, fsptptr);
-		spin_unlock(&iommu->lock);
-		return ret;
-	}
-#else
-	WARN_ON(old_did != pasid_get_domain_id(pte));
-#endif
-
-	*pte = new_pte;
-	spin_unlock(&iommu->lock);
-
-	intel_pasid_flush_present(iommu, dev, pasid, old_did, pte);
-#ifndef __PKVM_HYP__
-	intel_iommu_drain_pasid_prq(dev, pasid);
-#else
-	pkvm_put_domain_cache_tag_unassign(old_pgd, old_did,
-					   pasid, dev_iommu_priv_get(dev));
-#endif
 
 	return 0;
 }
@@ -714,7 +613,7 @@ int intel_pasid_setup_second_level(struct intel_iommu *iommu,
 		if (!info || !info->pasid_table)
 			return -ENODEV;
 
-		ret = pkvm_pasid_setup_sl(info, pgd_val, pasid, did, 0);
+		ret = pkvm_pasid_setup_sl(info, pgd_val, pasid, did);
 		if (ret)
 			pr_err("%s: iommu%d: pkvm_pasid_setup_sl failed(err=%d)\n",
 			       __func__, iommu->seq_id, ret);
@@ -748,115 +647,6 @@ int intel_pasid_setup_second_level(struct intel_iommu *iommu,
 	spin_unlock(&iommu->lock);
 
 	pasid_flush_caches(iommu, pte, pasid, did);
-
-	return 0;
-}
-
-int intel_pasid_replace_second_level(struct intel_iommu *iommu,
-				     struct dmar_domain *domain,
-#ifndef __PKVM_HYP__
-				     struct device *dev, u16 old_did,
-#else
-				     struct pkvm_device *dev, u16 did, u16 old_did,
-#endif
-				     u32 pasid)
-{
-	struct pasid_entry *pte, new_pte;
-	struct dma_pte *pgd;
-	u64 pgd_val;
-#ifndef __PKVM_HYP__
-	u16 did;
-#else
-	void *old_pgd;
-	int pgtt;
-#endif
-	int ret;
-
-	/*
-	 * If hardware advertises no support for second level
-	 * translation, return directly.
-	 */
-	if (!ecap_slts(iommu->ecap)) {
-		pr_err("No second level translation support on iommu%d\n",
-		       iommu->seq_id);
-		return -EINVAL;
-	}
-
-	pgd = domain->pgd;
-	pgd_val = virt_to_phys(pgd);
-#ifndef __PKVM_HYP__
-	did = domain_id_iommu(domain, iommu);
-#endif
-
-#ifndef __PKVM_HYP__
-	if (pkvm_enabled()) {
-		struct device_domain_info *info = dev_iommu_priv_get(dev);
-
-		if (!info || !info->pasid_table)
-			return -ENODEV;
-
-		ret = pkvm_pasid_setup_sl(info, pgd_val, pasid, did, old_did);
-		if (ret)
-			pr_err("%s: iommu%d: pkvm_pasid_setup_sl failed(err=%d)\n",
-			       __func__, iommu->seq_id, ret);
-
-		return ret;
-	}
-#endif
-
-	pasid_pte_config_second_level(iommu, &new_pte, pgd_val,
-				      domain->agaw, did,
-				      domain->dirty_tracking);
-
-	spin_lock(&iommu->lock);
-	pte = intel_pasid_get_entry(dev, pasid);
-	if (IS_ERR(pte)) {
-		spin_unlock(&iommu->lock);
-		return PTR_ERR(pte);
-	}
-
-	if (!pasid_pte_is_present(pte)) {
-		spin_unlock(&iommu->lock);
-		return -EINVAL;
-	}
-
-
-#ifdef __PKVM_HYP__
-	if (WARN_ON(old_did != pasid_get_domain_id(pte))) {
-		spin_unlock(&iommu->lock);
-		return -EINVAL;
-	}
-
-	pgtt = pasid_pte_get_pgtt(pte);
-	if (pgtt == PASID_ENTRY_PGTT_FL_ONLY)
-		old_pgd = __pkvm_va(pasid_get_flptr(pte));
-	else if (pgtt == PASID_ENTRY_PGTT_SL_ONLY)
-		old_pgd = __pkvm_va(pasid_get_slptr(pte));
-	else
-		BUG();
-
-	ret = pkvm_get_domain_cache_tag_assign(domain->pgd, did, pasid,
-					       dev_iommu_priv_get(dev));
-	if (ret) {
-		pr_err("iommu%d: failed to get the domain for did: %d, pgd: %p\n",
-		       iommu->seq_id, did, domain->pgd);
-		spin_unlock(&iommu->lock);
-		return ret;
-	}
-#else
-	WARN_ON(old_did != pasid_get_domain_id(pte));
-#endif
-
-	*pte = new_pte;
-	spin_unlock(&iommu->lock);
-
-	intel_pasid_flush_present(iommu, dev, pasid, old_did, pte);
-#ifndef __PKVM_HYP__
-	intel_iommu_drain_pasid_prq(dev, pasid);
-#else
-	pkvm_put_domain_cache_tag_unassign(old_pgd, old_did,
-					   pasid, dev_iommu_priv_get(dev));
-#endif
 
 	return 0;
 }
@@ -961,7 +751,7 @@ int intel_pasid_setup_pass_through(struct intel_iommu *iommu,
 		if (!info || !info->pasid_table)
 			return -ENODEV;
 
-		ret = pkvm_pasid_setup_sl(info, 0, pasid, did, 0);
+		ret = pkvm_pasid_setup_sl(info, 0, pasid, did);
 		if (ret)
 			pr_err("%s: iommu%d: pkvm_pasid_setup_sl failed(err=%d)\n",
 			       __func__, iommu->seq_id, ret);
@@ -985,53 +775,6 @@ int intel_pasid_setup_pass_through(struct intel_iommu *iommu,
 	spin_unlock(&iommu->lock);
 
 	pasid_flush_caches(iommu, pte, pasid, did);
-
-	return 0;
-}
-
-int intel_pasid_replace_pass_through(struct intel_iommu *iommu,
-				     struct device *dev, u16 old_did,
-				     u32 pasid)
-{
-	struct pasid_entry *pte, new_pte;
-	u16 did = FLPT_DEFAULT_DID;
-
-	if (pkvm_enabled()) {
-		struct device_domain_info *info = dev_iommu_priv_get(dev);
-		int ret;
-
-		if (!info || !info->pasid_table)
-			return -ENODEV;
-
-		ret = pkvm_pasid_setup_sl(info, 0, pasid, did, old_did);
-		if (ret)
-			pr_err("%s: iommu%d: pkvm_pasid_setup_sl failed(err=%d)\n",
-			       __func__, iommu->seq_id, ret);
-
-		return ret;
-	}
-
-	pasid_pte_config_pass_through(iommu, &new_pte, did);
-
-	spin_lock(&iommu->lock);
-	pte = intel_pasid_get_entry(dev, pasid);
-	if (IS_ERR(pte)) {
-		spin_unlock(&iommu->lock);
-		return PTR_ERR(pte);
-	}
-
-	if (!pasid_pte_is_present(pte)) {
-		spin_unlock(&iommu->lock);
-		return -EINVAL;
-	}
-
-	WARN_ON(old_did != pasid_get_domain_id(pte));
-
-	*pte = new_pte;
-	spin_unlock(&iommu->lock);
-
-	intel_pasid_flush_present(iommu, dev, pasid, old_did, pte);
-	intel_iommu_drain_pasid_prq(dev, pasid);
 
 	return 0;
 }
@@ -1162,69 +905,6 @@ int intel_pasid_setup_nested(struct intel_iommu *iommu, struct device *dev,
 	spin_unlock(&iommu->lock);
 
 	pasid_flush_caches(iommu, pte, pasid, did);
-
-	return 0;
-}
-
-int intel_pasid_replace_nested(struct intel_iommu *iommu,
-			       struct device *dev, u32 pasid,
-			       u16 old_did, struct dmar_domain *domain)
-{
-	struct iommu_hwpt_vtd_s1 *s1_cfg = &domain->s1_cfg;
-	struct dmar_domain *s2_domain = domain->s2_domain;
-	u16 did = domain_id_iommu(domain, iommu);
-	struct pasid_entry *pte, new_pte;
-
-	/* Address width should match the address width supported by hardware */
-	switch (s1_cfg->addr_width) {
-	case ADDR_WIDTH_4LEVEL:
-		break;
-	case ADDR_WIDTH_5LEVEL:
-		if (!cap_fl5lp_support(iommu->cap)) {
-			dev_err_ratelimited(dev,
-					    "5-level paging not supported\n");
-			return -EINVAL;
-		}
-		break;
-	default:
-		dev_err_ratelimited(dev, "Invalid stage-1 address width %d\n",
-				    s1_cfg->addr_width);
-		return -EINVAL;
-	}
-
-	if ((s1_cfg->flags & IOMMU_VTD_S1_SRE) && !ecap_srs(iommu->ecap)) {
-		pr_err_ratelimited("No supervisor request support on %s\n",
-				   iommu->name);
-		return -EINVAL;
-	}
-
-	if ((s1_cfg->flags & IOMMU_VTD_S1_EAFE) && !ecap_eafs(iommu->ecap)) {
-		pr_err_ratelimited("No extended access flag support on %s\n",
-				   iommu->name);
-		return -EINVAL;
-	}
-
-	pasid_pte_config_nestd(iommu, &new_pte, s1_cfg, s2_domain, did);
-
-	spin_lock(&iommu->lock);
-	pte = intel_pasid_get_entry(dev, pasid);
-	if (IS_ERR(pte)) {
-		spin_unlock(&iommu->lock);
-		return PTR_ERR(pte);
-	}
-
-	if (!pasid_pte_is_present(pte)) {
-		spin_unlock(&iommu->lock);
-		return -EINVAL;
-	}
-
-	WARN_ON(old_did != pasid_get_domain_id(pte));
-
-	*pte = new_pte;
-	spin_unlock(&iommu->lock);
-
-	intel_pasid_flush_present(iommu, dev, pasid, old_did, pte);
-	intel_iommu_drain_pasid_prq(dev, pasid);
 
 	return 0;
 }

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -282,15 +282,20 @@ devtlb_invalidation_with_pasid(struct intel_iommu *iommu,
 
 #ifndef __PKVM_HYP__
 void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct device *dev,
-#else
-void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct pkvm_device *dev,
-#endif
 				 u32 pasid, bool fault_ignore)
+#else
+void intel_pasid_tear_down_entry(struct intel_iommu *iommu,
+				 struct pkvm_device *dev, u32 pasid,
+				 bool fault_ignore,
+				 struct dmar_domain **domain)
+#endif
 {
 	struct pasid_entry *pte;
 	u16 did, pgtt;
 #ifdef __PKVM_HYP__
 	void *pgd = NULL;
+
+	*domain = NULL;
 #endif
 
 #ifndef __PKVM_HYP__
@@ -377,6 +382,9 @@ void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct pkvm_device *
 	 */
 	pasid_clear_entry(pte);
 	spin_unlock(&iommu->lock);
+
+	*domain = pkvm_get_iommu_domain_noref(pgd, did);
+	cache_tag_unassign_domain(*domain, did, dev, pasid);
 #endif
 	if (!ecap_coherent(iommu->ecap))
 		clflush_cache_range(pte, sizeof(*pte));
@@ -386,10 +394,6 @@ void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct pkvm_device *
 		intel_iommu_drain_pasid_prq(dev, pasid);
 #endif
 
-#ifdef __PKVM_HYP__
-	pkvm_put_domain_cache_tag_unassign(pgd, did, pasid,
-					   dev_iommu_priv_get(dev));
-#endif
 }
 
 /*
@@ -482,7 +486,9 @@ static void pasid_pte_config_first_level(struct intel_iommu *iommu,
 #ifndef __PKVM_HYP__
 int intel_pasid_setup_first_level(struct intel_iommu *iommu, struct device *dev,
 #else
-int intel_pasid_setup_first_level(struct intel_iommu *iommu, struct pkvm_device *dev,
+int intel_pasid_setup_first_level(struct intel_iommu *iommu,
+				  struct dmar_domain *domain,
+				  struct pkvm_device *dev,
 #endif
 				  phys_addr_t fsptptr, u32 pasid, u16 did,
 				  int flags)
@@ -531,11 +537,8 @@ int intel_pasid_setup_first_level(struct intel_iommu *iommu, struct pkvm_device 
 	}
 
 #ifdef __PKVM_HYP__
-	ret = pkvm_get_domain_cache_tag_assign(__pkvm_va(fsptptr), did,
-					       pasid, dev_iommu_priv_get(dev));
+	ret = cache_tag_assign_domain(domain, did, dev, pasid);
 	if (ret) {
-		pr_err("iommu%d: failed to get the domain for did: %d, fsptptr: %llx\n",
-		       iommu->seq_id, did, fsptptr);
 		spin_unlock(&iommu->lock);
 		return ret;
 	}
@@ -635,8 +638,7 @@ int intel_pasid_setup_second_level(struct intel_iommu *iommu,
 	}
 
 #ifdef __PKVM_HYP__
-	ret = pkvm_get_domain_cache_tag_assign(domain->pgd, did, pasid,
-					       dev_iommu_priv_get(dev));
+	ret = cache_tag_assign_domain(domain, did, dev, pasid);
 	if (ret) {
 		spin_unlock(&iommu->lock);
 		return ret;

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -351,7 +351,7 @@ void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct pkvm_device *
 	else
 		BUG();
 #endif
-	intel_pasid_clear_entry(dev, pasid, fault_ignore);
+	pasid_clear_present(pte);
 	spin_unlock(&iommu->lock);
 
 	if (!ecap_coherent(iommu->ecap))
@@ -365,6 +365,10 @@ void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct pkvm_device *
 		iommu->flush.flush_iotlb(iommu, did, 0, 0, DMA_TLB_DSI_FLUSH);
 
 	devtlb_invalidation_with_pasid(iommu, dev, pasid);
+	intel_pasid_clear_entry(dev, pasid, fault_ignore);
+	if (!ecap_coherent(iommu->ecap))
+		clflush_cache_range(pte, sizeof(*pte));
+
 #ifndef __PKVM_HYP__
 	if (!fault_ignore)
 		intel_iommu_drain_pasid_prq(dev, pasid);

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -120,9 +120,6 @@ void intel_pasid_free_table(struct device *dev)
 
 #ifndef __PKVM_HYP__
 struct pasid_table *intel_pasid_get_table(struct device *dev)
-#else
-struct pasid_table *intel_pasid_get_table(struct pkvm_device *dev)
-#endif
 {
 	struct device_domain_info *info;
 
@@ -132,6 +129,28 @@ struct pasid_table *intel_pasid_get_table(struct pkvm_device *dev)
 
 	return info->pasid_table;
 }
+#else
+struct pasid_table *intel_pasid_get_table(struct pkvm_device *dev)
+{
+	struct device_domain_info *info = dev_iommu_priv_get(dev);
+	struct context_entry *context;
+	u32 pds;
+
+	if (!info || !info->iommu || !sm_supported(info->iommu))
+		return NULL;
+
+	context = iommu_context_addr(info->iommu, info->bus, info->devfn, false);
+	if (!context || !context_present(context))
+		return NULL;
+
+	pds = get_pasid_dir_size(context);
+	info->_pasid_table.table = __pkvm_va(context->lo & VTD_PAGE_MASK);
+	info->_pasid_table.max_pasid = pds << PASID_PDE_SHIFT;
+	info->pasid_table = &info->_pasid_table;
+
+	return info->pasid_table;
+}
+#endif
 
 #ifndef __PKVM_HYP__
 static struct pasid_entry *intel_pasid_get_entry(struct device *dev, u32 pasid)

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -1054,7 +1054,11 @@ int device_pasid_table_setup(struct pkvm_device *dev, u8 bus, u8 devfn)
 
 	if (context_present(context) && !context_copied(iommu, bus, devfn)) {
 		spin_unlock(&iommu->lock);
+#ifndef __PKVM_HYP__
 		return 0;
+#else
+		return -EEXIST;
+#endif
 	}
 
 #ifndef __PKVM_HYP__

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -1360,7 +1360,7 @@ int device_pasid_table_setup(struct pkvm_device *dev, u8 bus, u8 devfn)
 #ifndef __PKVM_HYP__
 	BUG_ON(pkvm_enabled() && context_copied(iommu, bus, devfn));
 	if (context_copied(iommu, bus, devfn)) {
-		context_clear_entry(context);
+		context_clear_present(context);
 		__iommu_flush_cache(iommu, context, sizeof(*context));
 
 		/*
@@ -1379,6 +1379,9 @@ int device_pasid_table_setup(struct pkvm_device *dev, u8 bus, u8 devfn)
 		qi_flush_pasid_cache(iommu, 0, QI_PC_GLOBAL, 0);
 		iommu->flush.flush_iotlb(iommu, 0, 0, 0, DMA_TLB_GLOBAL_FLUSH);
 		devtlb_invalidation_with_pasid(iommu, dev, IOMMU_NO_PASID);
+
+		context_clear_entry(context);
+		__iommu_flush_cache(iommu, context, sizeof(*context));
 
 		/*
 		 * At this point, the device is supposed to finish reset at

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -212,12 +212,9 @@ retry:
 /*
  * Interfaces for PASID table entry manipulation:
  */
-static void
 #ifndef __PKVM_HYP__
+static void
 intel_pasid_clear_entry(struct device *dev, u32 pasid, bool fault_ignore)
-#else
-intel_pasid_clear_entry(struct pkvm_device *dev, u32 pasid, bool fault_ignore)
-#endif
 {
 	struct pasid_entry *pe;
 
@@ -230,6 +227,7 @@ intel_pasid_clear_entry(struct pkvm_device *dev, u32 pasid, bool fault_ignore)
 	else
 		pasid_clear_entry(pe);
 }
+#endif
 
 static void
 pasid_cache_invalidation_with_pasid(struct intel_iommu *iommu,
@@ -352,7 +350,9 @@ void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct pkvm_device *
 		BUG();
 #endif
 	pasid_clear_present(pte);
+#ifndef __PKVM_HYP__
 	spin_unlock(&iommu->lock);
+#endif
 
 	if (!ecap_coherent(iommu->ecap))
 		clflush_cache_range(pte, sizeof(*pte));
@@ -365,7 +365,19 @@ void intel_pasid_tear_down_entry(struct intel_iommu *iommu, struct pkvm_device *
 		iommu->flush.flush_iotlb(iommu, did, 0, 0, DMA_TLB_DSI_FLUSH);
 
 	devtlb_invalidation_with_pasid(iommu, dev, pasid);
+#ifndef __PKVM_HYP__
 	intel_pasid_clear_entry(dev, pasid, fault_ignore);
+#else
+	/*
+	 * iommu->lock has been held continuously since the present bit was
+	 * cleared above, so no racing setup could have swapped the PASID
+	 * table or reinstalled this entry in the interim. It is therefore
+	 * safe to clear it directly instead of re-deriving and re-validating
+	 * it from scratch.
+	 */
+	pasid_clear_entry(pte);
+	spin_unlock(&iommu->lock);
+#endif
 	if (!ecap_coherent(iommu->ecap))
 		clflush_cache_range(pte, sizeof(*pte));
 

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -148,6 +148,8 @@ struct pasid_table *intel_pasid_get_table(struct pkvm_device *dev)
 	info->_pasid_table.max_pasid = pds << PASID_PDE_SHIFT;
 	info->pasid_table = &info->_pasid_table;
 
+	pkvm_populate_dev_info_from_ce(info, context);
+
 	return info->pasid_table;
 }
 #endif

--- a/drivers/iommu/intel/pasid.c
+++ b/drivers/iommu/intel/pasid.c
@@ -134,21 +134,6 @@ struct pasid_table *intel_pasid_get_table(struct pkvm_device *dev)
 }
 
 #ifndef __PKVM_HYP__
-static int intel_pasid_get_dev_max_id(struct device *dev)
-#else
-static int intel_pasid_get_dev_max_id(struct pkvm_device *dev)
-#endif
-{
-	struct device_domain_info *info;
-
-	info = dev_iommu_priv_get(dev);
-	if (!info || !info->pasid_table)
-		return 0;
-
-	return info->pasid_table->max_pasid;
-}
-
-#ifndef __PKVM_HYP__
 static struct pasid_entry *intel_pasid_get_entry(struct device *dev, u32 pasid)
 #else
 static struct pasid_entry *intel_pasid_get_entry(struct pkvm_device *dev, u32 pasid)
@@ -161,7 +146,7 @@ static struct pasid_entry *intel_pasid_get_entry(struct pkvm_device *dev, u32 pa
 	int dir_index, index;
 
 	pasid_table = intel_pasid_get_table(dev);
-	if (WARN_ON(!pasid_table || pasid >= intel_pasid_get_dev_max_id(dev)))
+	if (WARN_ON(!pasid_table || pasid >= pasid_table->max_pasid))
 		return ERR_PTR(-ENODEV);
 
 	dir = pasid_table->table;

--- a/drivers/iommu/intel/pasid.h
+++ b/drivers/iommu/intel/pasid.h
@@ -251,7 +251,21 @@ static inline void pasid_set_wpe(struct pasid_entry *pe)
  */
 static inline void pasid_set_present(struct pasid_entry *pe)
 {
+	dma_wmb();
 	pasid_set_bits(&pe->val[0], 1 << 0, 1);
+}
+
+/*
+ * Clear the Present (P) bit (bit 0) of a scalable-mode PASID table entry.
+ * This initiates the transition of the entry's ownership from hardware
+ * to software. The caller is responsible for fulfilling the invalidation
+ * handshake recommended by the VT-d spec, Section 6.5.3.3 (Guidance to
+ * Software for Invalidations).
+ */
+static inline void pasid_clear_present(struct pasid_entry *pe)
+{
+	pasid_set_bits(&pe->val[0], 1 << 0, 0);
+	dma_wmb();
 }
 
 /*

--- a/drivers/iommu/intel/pasid.h
+++ b/drivers/iommu/intel/pasid.h
@@ -344,30 +344,6 @@ int intel_pasid_setup_pass_through(struct intel_iommu *iommu,
 int intel_pasid_setup_nested(struct intel_iommu *iommu, struct device *dev,
 			     u32 pasid, struct dmar_domain *domain);
 #ifndef __PKVM_HYP__
-int intel_pasid_replace_first_level(struct intel_iommu *iommu,
-				    struct device *dev, phys_addr_t fsptptr,
-				    u32 pasid, u16 did, u16 old_did, int flags);
-int intel_pasid_replace_second_level(struct intel_iommu *iommu,
-				     struct dmar_domain *domain,
-				     struct device *dev, u16 old_did,
-				     u32 pasid);
-#else
-int intel_pasid_replace_first_level(struct intel_iommu *iommu,
-				    struct pkvm_device *dev, phys_addr_t fsptptr,
-				    u32 pasid, u16 did, u16 old_did, int flags);
-int intel_pasid_replace_second_level(struct intel_iommu *iommu,
-				     struct dmar_domain *domain,
-				     struct pkvm_device *dev, u16 did, u16 old_did,
-				     u32 pasid);
-#endif
-int intel_pasid_replace_pass_through(struct intel_iommu *iommu,
-				     struct device *dev, u16 old_did,
-				     u32 pasid);
-int intel_pasid_replace_nested(struct intel_iommu *iommu,
-			       struct device *dev, u32 pasid,
-			       u16 old_did, struct dmar_domain *domain);
-
-#ifndef __PKVM_HYP__
 void intel_pasid_tear_down_entry(struct intel_iommu *iommu,
 				 struct device *dev, u32 pasid,
 				 bool fault_ignore);

--- a/drivers/iommu/intel/pasid.h
+++ b/drivers/iommu/intel/pasid.h
@@ -329,7 +329,9 @@ int intel_pasid_setup_second_level(struct intel_iommu *iommu,
 				   struct device *dev, u32 pasid);
 #else
 struct pasid_table *intel_pasid_get_table(struct pkvm_device *dev);
-int intel_pasid_setup_first_level(struct intel_iommu *iommu, struct pkvm_device *dev,
+int intel_pasid_setup_first_level(struct intel_iommu *iommu,
+				  struct dmar_domain *domain,
+				  struct pkvm_device *dev,
 				  phys_addr_t fsptptr, u32 pasid, u16 did,
 				  int flags);
 int intel_pasid_setup_second_level(struct intel_iommu *iommu,
@@ -350,7 +352,8 @@ void intel_pasid_tear_down_entry(struct intel_iommu *iommu,
 #else
 void intel_pasid_tear_down_entry(struct intel_iommu *iommu,
 				 struct pkvm_device *dev, u32 pasid,
-				 bool fault_ignore);
+				 bool fault_ignore,
+				 struct dmar_domain **domain);
 #endif
 void intel_pasid_setup_page_snoop_control(struct intel_iommu *iommu,
 					  struct device *dev, u32 pasid);

--- a/drivers/iommu/intel/pkvm/domain.c
+++ b/drivers/iommu/intel/pkvm/domain.c
@@ -7,6 +7,7 @@
 #include "pkvm.h"
 #include "pkvm/debug.h"
 #include "pkvm/memory.h"
+#include "pkvm/vmx/ept.h"
 #include "../iommu.h"
 
 /*
@@ -17,6 +18,13 @@ static DEFINE_HASHTABLE(iommu_domain_hasht, 8);
 static DECLARE_BITMAP(iommu_domains_bitmap, MAX_IOMMU_DOMAIN_NUM);
 static struct dmar_domain iommu_domains[MAX_IOMMU_DOMAIN_NUM];
 static DEFINE_PKVM_SPINLOCK(iommu_domain_lock);
+
+/*
+ * Passthrough domain for implementing passthrough (identity) mode for the host,
+ * signified by the default DID (FLPT_DEFAULT_DID). A real passthrough mode
+ * (no translation) would allow devices to access all physical memory. So model
+ * passthrough mode as a second-stage domain backed by the host EPT instead.
+ */
 struct dmar_domain pt_domain;
 
 void init_pt_domain(void)
@@ -24,6 +32,8 @@ void init_pt_domain(void)
 	INIT_LIST_HEAD(&pt_domain.cache_tags);
 	pkvm_spin_lock_init(&pt_domain.cache_lock);
 	pt_domain.qi_batch = &pt_domain._qi_batch;
+	pt_domain.pgd = __pkvm_va(pkvm_host_ept_root());
+	pt_domain.agaw = level_to_agaw(pkvm_host_ept_level());
 }
 
 static struct dmar_domain *__pkvm_get_iommu_domain_locked(void *pgd, bool inc_ref)

--- a/drivers/iommu/intel/pkvm/domain.c
+++ b/drivers/iommu/intel/pkvm/domain.c
@@ -109,39 +109,6 @@ void pkvm_put_iommu_domain(struct dmar_domain *domain)
 	WARN_ON_ONCE(atomic_dec_if_positive(&domain->refcount) <= 0);
 }
 
-int pkvm_get_domain_cache_tag_assign(void *pgd, int did, u32 pasid,
-				     struct device_domain_info *info)
-{
-	struct pkvm_device dev = { .info = info };
-	struct dmar_domain *domain;
-	int ret;
-
-	domain = pkvm_get_iommu_domain(pgd, did);
-	if (!domain) {
-		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
-			 __func__, pgd);
-		return -EFAULT;
-	}
-
-	ret = cache_tag_assign_domain(domain, did, &dev, pasid);
-	if (ret) {
-		pkvm_put_iommu_domain(domain);
-		return ret;
-	}
-	return 0;
-}
-
-void pkvm_put_domain_cache_tag_unassign(void *pgd, int did, u32 pasid,
-					struct device_domain_info *info)
-{
-	struct pkvm_device dev = { .info = info };
-	struct dmar_domain *domain;
-
-	domain = pkvm_get_iommu_domain_noref(pgd, did);
-	cache_tag_unassign_domain(domain, did, &dev, pasid);
-	pkvm_put_iommu_domain(domain);
-}
-
 static int refill_domain_memcache(struct dmar_domain *domain,
 				  struct pkvm_memcache *host_mc)
 {

--- a/drivers/iommu/intel/pkvm/domain.c
+++ b/drivers/iommu/intel/pkvm/domain.c
@@ -85,12 +85,62 @@ static struct dmar_domain *__pkvm_get_iommu_domain_noref(void *pgd)
 	return domain;
 }
 
-struct dmar_domain *pkvm_get_iommu_domain(void *pgd, u16 did)
+/*
+ * Check the domain properties that affect how an IOMMU walks and caches the
+ * domain page tables. A domain may be shared by multiple IOMMUs, but only if
+ * each IOMMU is compatible with the properties selected at allocation time.
+ */
+static bool iommu_domain_compatible(struct intel_iommu *iommu,
+				    struct dmar_domain *domain)
 {
+	int addr_width;
+
+	if (domain->use_first_level) {
+		if (!sm_supported(iommu) || !ecap_flts(iommu->ecap))
+			return false;
+	} else {
+		if (sm_supported(iommu) && !ecap_slts(iommu->ecap))
+			return false;
+
+		if (cap_caching_mode(iommu->cap) && !domain->iotlb_sync_map)
+			return false;
+	}
+
+	if (domain->iommu_superpage >
+	    iommu_superpage_capability(iommu, domain->use_first_level))
+		return false;
+
+	if (domain->iommu_coherency !=
+	    iommu_paging_structure_coherency(iommu))
+		return false;
+
+	addr_width = agaw_to_width(iommu->agaw);
+	if (addr_width > cap_mgaw(iommu->cap))
+		addr_width = cap_mgaw(iommu->cap);
+	if (domain->gaw > addr_width || domain->agaw > iommu->agaw)
+		return false;
+
+	return true;
+}
+
+struct dmar_domain *pkvm_get_iommu_domain(void *pgd, u16 did,
+					  struct intel_iommu *iommu)
+{
+	struct dmar_domain *domain;
+
 	if (did == FLPT_DEFAULT_DID)
 		return &pt_domain;
 
-	return __pkvm_get_iommu_domain(pgd);
+	domain = __pkvm_get_iommu_domain(pgd);
+
+	if (domain && !iommu_domain_compatible(iommu, domain)) {
+		pkvm_err("%s: domain[pgd:%p] is incompatible with iommu%d\n",
+			 __func__, pgd, iommu->seq_id);
+		pkvm_put_iommu_domain(domain);
+		domain = NULL;
+	}
+
+	return domain;
 }
 
 struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd, u16 did)

--- a/drivers/iommu/intel/pkvm/domain.c
+++ b/drivers/iommu/intel/pkvm/domain.c
@@ -53,7 +53,7 @@ static struct dmar_domain *__pkvm_get_iommu_domain_locked(void *pgd, bool inc_re
 	return NULL;
 }
 
-struct dmar_domain *pkvm_get_iommu_domain(void *pgd)
+static struct dmar_domain *__pkvm_get_iommu_domain(void *pgd)
 {
 	struct dmar_domain *domain;
 
@@ -69,7 +69,7 @@ struct dmar_domain *pkvm_get_iommu_domain(void *pgd)
  * This is useful when there is a refcount on the domain which is guaranteed
  * to be >1 (at least one reference).
  */
-struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd)
+static struct dmar_domain *__pkvm_get_iommu_domain_noref(void *pgd)
 {
 	struct dmar_domain *domain;
 
@@ -85,8 +85,27 @@ struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd)
 	return domain;
 }
 
+struct dmar_domain *pkvm_get_iommu_domain(void *pgd, u16 did)
+{
+	if (did == FLPT_DEFAULT_DID)
+		return &pt_domain;
+
+	return __pkvm_get_iommu_domain(pgd);
+}
+
+struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd, u16 did)
+{
+	if (did == FLPT_DEFAULT_DID)
+		return &pt_domain;
+
+	return __pkvm_get_iommu_domain_noref(pgd);
+}
+
 void pkvm_put_iommu_domain(struct dmar_domain *domain)
 {
+	if (domain == &pt_domain)
+		return;
+
 	WARN_ON_ONCE(atomic_dec_if_positive(&domain->refcount) <= 0);
 }
 
@@ -97,10 +116,7 @@ int pkvm_get_domain_cache_tag_assign(void *pgd, int did, u32 pasid,
 	struct dmar_domain *domain;
 	int ret;
 
-	if (did == FLPT_DEFAULT_DID)
-		return cache_tag_assign_domain(&pt_domain, did, &dev, pasid);
-
-	domain = pkvm_get_iommu_domain(pgd);
+	domain = pkvm_get_iommu_domain(pgd, did);
 	if (!domain) {
 		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
 			 __func__, pgd);
@@ -121,12 +137,7 @@ void pkvm_put_domain_cache_tag_unassign(void *pgd, int did, u32 pasid,
 	struct pkvm_device dev = { .info = info };
 	struct dmar_domain *domain;
 
-	if (did == FLPT_DEFAULT_DID) {
-		cache_tag_unassign_domain(&pt_domain, did, &dev, pasid);
-		return;
-	}
-
-	domain = pkvm_get_iommu_domain_noref(pgd);
+	domain = pkvm_get_iommu_domain_noref(pgd, did);
 	cache_tag_unassign_domain(domain, did, &dev, pasid);
 	pkvm_put_iommu_domain(domain);
 }
@@ -273,7 +284,7 @@ static int iommu_domain_map(struct domain_map_data *data)
 	if (check_add_overflow(phys, size, &end))
 		return -EINVAL;
 
-	domain = pkvm_get_iommu_domain(pkvm_host_gpa_to_virt(data->pgd_gpa));
+	domain = __pkvm_get_iommu_domain(pkvm_host_gpa_to_virt(data->pgd_gpa));
 	if (!domain) {
 		pkvm_err("%s: failed to get the domain [pgd:%llx]\n",
 			 __func__, data->pgd_gpa);
@@ -316,7 +327,7 @@ int pkvm_iommu_domain_unmap(u64 pgd_gpa, u64 start_pfn, u64 last_pfn)
 {
 	struct dmar_domain *domain;
 
-	domain = pkvm_get_iommu_domain(pkvm_host_gpa_to_virt(pgd_gpa));
+	domain = __pkvm_get_iommu_domain(pkvm_host_gpa_to_virt(pgd_gpa));
 	if (!domain) {
 		pkvm_err("%s, failed to get the domain [pgd:%llx]\n",
 			 __func__, pgd_gpa);

--- a/drivers/iommu/intel/pkvm/domain.c
+++ b/drivers/iommu/intel/pkvm/domain.c
@@ -56,8 +56,8 @@ struct dmar_domain *pkvm_get_iommu_domain(void *pgd)
 
 /*
  * Retrieve the domain without incrementing refcount.
- * This api is useful when there is a refcount on the domain
- * and refcount is guaranteed to be not dropped.
+ * This is useful when there is a refcount on the domain which is guaranteed
+ * to be >1 (at least one reference).
  */
 struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd)
 {
@@ -65,6 +65,11 @@ struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd)
 
 	pkvm_spin_lock(&iommu_domain_lock);
 	domain = __pkvm_get_iommu_domain_locked(pgd, false);
+	/*
+	 * pgd passed in here is derived from a valid context/pasid entry.
+	 * Hence it's a pKVM bug if this pgd can't resolve to a domain.
+	 */
+	BUG_ON(!domain || atomic_read(&domain->refcount) <= 1);
 	pkvm_spin_unlock(&iommu_domain_lock);
 
 	return domain;
@@ -112,8 +117,6 @@ void pkvm_put_domain_cache_tag_unassign(void *pgd, int did, u32 pasid,
 	}
 
 	domain = pkvm_get_iommu_domain_noref(pgd);
-	BUG_ON(!domain);
-
 	cache_tag_unassign_domain(domain, did, &dev, pasid);
 	pkvm_put_iommu_domain(domain);
 }
@@ -149,13 +152,34 @@ static void free_domain_memcache(struct dmar_domain *domain,
 	}
 }
 
-int pkvm_free_iommu_domain(struct dmar_domain *domain, struct pkvm_memcache *teardown_mc)
+int pkvm_free_iommu_domain(u64 pgd_gpa, struct pkvm_memcache *teardown_mc)
 {
+	void *pgd = pkvm_host_gpa_to_virt(pgd_gpa);
+	struct dmar_domain *domain;
+
+	pkvm_spin_lock(&iommu_domain_lock);
+
+	domain = __pkvm_get_iommu_domain_locked(pgd, false);
+	if (!domain) {
+		pkvm_spin_unlock(&iommu_domain_lock);
+		pkvm_err("%s: no domain exist for pgd: %p\n", __func__, pgd);
+		return -EINVAL;
+	}
+
 	if (atomic_cmpxchg(&domain->refcount, 1, 0) != 1) {
 		pkvm_err("%s: domain[pgd:%p] has users, refcount %d\n",
 			 __func__, domain->pgd, atomic_read(&domain->refcount));
+		pkvm_spin_unlock(&iommu_domain_lock);
 		return -EBUSY;
 	}
+
+	/*
+	 * Remove the domain from the hash list while still holding the lock,
+	 * to prevent someone else from getting this domain while freeing it.
+	 */
+	hash_del(&domain->hnode);
+
+	pkvm_spin_unlock(&iommu_domain_lock);
 
 	/* Unmap any remaining mappings. */
 	domain_unmap(domain, 0, DOMAIN_MAX_PFN(domain->gaw), NULL);
@@ -172,7 +196,6 @@ int pkvm_free_iommu_domain(struct dmar_domain *domain, struct pkvm_memcache *tea
 		 __func__, domain->pgd, teardown_mc->count);
 
 	pkvm_spin_lock(&iommu_domain_lock);
-	hash_del(&domain->hnode);
 	__clear_bit(domain->index, iommu_domains_bitmap);
 	memset(domain, 0, sizeof(struct dmar_domain));
 	pkvm_spin_unlock(&iommu_domain_lock);

--- a/drivers/iommu/intel/pkvm/iommu.c
+++ b/drivers/iommu/intel/pkvm/iommu.c
@@ -149,23 +149,22 @@ static int iommu_direct_mmio_write(struct intel_iommu *iommu, u64 phys,
 
 static int handle_gcmd_direct(struct intel_iommu *iommu, u32 gcmd_bit, bool set)
 {
-	u32 gcmd = readl(iommu->reg + DMAR_GSTS_REG) & DMAR_GSTS_EN_BITS;
+	u32 gsts = readl(iommu->reg + DMAR_GSTS_REG);
+	u32 gcmd = gsts & DMAR_GSTS_EN_BITS;
 	u32 sts;
+
+	BUG_ON(gsts != iommu->vgsts);
 
 	if ((gcmd_bit & DMAR_GCMD_ONESHOT) && !set)
 		return -EINVAL;
 
 	if (set) {
-		if (gcmd & gcmd_bit) {
-			iommu->vgsts |= gcmd_bit;
+		if (gcmd & gcmd_bit)
 			return 0;
-		}
 		gcmd |= gcmd_bit;
 	} else {
-		if (!(gcmd & gcmd_bit)) {
-			iommu->vgsts &= ~gcmd_bit;
+		if (!(gcmd & gcmd_bit))
 			return 0;
-		}
 		gcmd &= ~gcmd_bit;
 	}
 
@@ -248,10 +247,12 @@ static int handle_gcmd_qie(struct intel_iommu *iommu, bool enable)
 
 		ret = initialize_qi(iommu);
 	} else {
-		if (!iommu->qi)
+		if (!iommu->qi) {
 			ret = handle_gcmd_direct(iommu, DMA_GCMD_QIE, false);
-		else
-			iommu->vgsts &= ~DMA_GSTS_QIES;
+		} else {
+			pkvm_warn("iommu%d: Disabling QI is not allowed!\n", iommu->seq_id);
+			return -EPERM;
+		}
 	}
 
 	pkvm_dbg("iommu%d: Quueued Invalidation %s!\n", iommu->seq_id,
@@ -279,8 +280,7 @@ static int handle_gcmd_srtp(struct intel_iommu *iommu)
 	u64 root_pa;
 	int ret;
 
-	if (WARN_ON(gsts != iommu->vgsts))
-		iommu->vgsts = gsts;
+	BUG_ON(gsts != iommu->vgsts);
 
 	if (!iommu->vrta) {
 		pkvm_warn("iommu%d: host RTADDR_REG not set", iommu->seq_id);
@@ -361,11 +361,10 @@ static int handle_gcmd_te(struct intel_iommu *iommu, bool enable)
 		pkvm_dbg("iommu%d: Translation enabled!\n", iommu->seq_id);
 	} else {
 		/*
-		 * Translation is not really disabled as it would
-		 * compromise pKVM security guarantees.
+		 * Translation is not allowed to be disabled under pKVM.
 		 */
-		iommu->vgsts &= ~DMA_GSTS_TES;
-		pkvm_dbg("iommu%d: Translation marked as disabled!\n", iommu->seq_id);
+		pkvm_warn("iommu%d: Disabling Translation is not allowed!\n", iommu->seq_id);
+		return -EPERM;
 	}
 
 	return 0;

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -212,9 +212,16 @@ static int iommu_set_sm_ce(struct set_sm_ce_data *data)
 		 data->bus, data->devfn, info.ats_qdep, data->pasid_table_gpa);
 	ret = device_pasid_table_setup(&dev, data->bus, data->devfn);
 
-	if (ret)
+	if (ret) {
 		pkvm_hyp_donate_host(pkvm_host_gpa_to_phys(data->pasid_table_gpa),
 				     pasid_dir_size(data->max_pasid), false);
+		/*
+		 * If entry already exists, the host expects
+		 * the hypercall to succeed.
+		 */
+		if (ret == -EEXIST)
+			ret = 0;
+	}
 	return ret;
 }
 

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -59,8 +59,6 @@ int pkvm_iommu_clear_ce(struct clear_ce_data *data)
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
-	info.ats_supported = data->ats_supported;
-	info.ats_enabled = info.ats_supported;
 
 	pkvm_dbg("%s: dev[%x:%x], ats_qdep: %d\n",
 		 __func__, data->bus, data->devfn, data->ats_qdep);
@@ -279,8 +277,6 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
-	info.ats_supported = data->ats_supported;
-	info.ats_enabled = info.ats_supported;
 	info.iommu = iommu;
 
 	ret = accept_page_donation(iommu, &data->donation_page_gpa);
@@ -365,8 +361,6 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	info.devfn = data->devfn;
 	info.iommu = iommu;
 	info.ats_qdep = data->ats_qdep;
-	info.ats_supported = data->ats_supported;
-	info.ats_enabled = info.ats_supported;
 
 	ret = accept_page_donation(iommu, &data->donation_page_gpa);
 	if (ret)
@@ -426,8 +420,6 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
-	info.ats_supported = data->ats_supported;
-	info.ats_enabled = info.ats_supported;
 	info.iommu = iommu;
 
 	pkvm_dbg("%s: dev[%x:%x], pasid: %x, ats_qdep: %d\n", __func__,

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -264,6 +264,11 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 		return -EPERM;
 	}
 
+	if (data->did == FLPT_DEFAULT_DID) {
+		pkvm_err("%s: First-level setup not allowed for default domain\n", __func__);
+		return -EPERM;
+	}
+
 	ret = __get_pasid_table(iommu, data->bus, data->devfn, &table);
 	if (ret)
 		return ret;

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -286,16 +286,11 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	if (ret)
 		return ret;
 
-	pkvm_dbg("%s: dev[%x:%x], pasid: %x, fsptptr_gpa: %llx, did: %d, old_did: %d\n", __func__,
-		 data->bus, data->devfn, data->pasid, data->fsptptr_gpa, data->did, data->old_did);
-	if (!data->old_did) {
-		return intel_pasid_setup_first_level(iommu, &dev, fsptptr,
-						     data->pasid, data->did,
-						     data->flags);
-	}
-	return intel_pasid_replace_first_level(iommu, &dev, fsptptr,
-					       data->pasid, data->did,
-					       data->old_did, data->flags);
+	pkvm_dbg("%s: dev[%x:%x], pasid: %x, fsptptr_gpa: %llx, did: %d\n", __func__,
+		 data->bus, data->devfn, data->pasid, data->fsptptr_gpa, data->did);
+
+	return intel_pasid_setup_first_level(iommu, &dev, fsptptr,
+					     data->pasid, data->did, data->flags);
 }
 
 int pkvm_iommu_pasid_setup_fl(struct pasid_setup_fl_data *in, struct pasid_setup_fl_data *out)
@@ -360,15 +355,11 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	if (ret)
 		return ret;
 
-	pkvm_dbg("%s: dev[%x:%x], pasid: %x ssptptr_gpa: %llx, did: %d, old_did: %d\n", __func__,
-		 data->bus, data->devfn, data->pasid, data->ssptptr_gpa, data->did, data->old_did);
-	if (!data->old_did) {
-		return intel_pasid_setup_second_level(iommu, &domain, &dev,
-						      data->did, data->pasid);
-	}
-	return intel_pasid_replace_second_level(iommu, &domain, &dev,
-						data->did, data->old_did,
-						data->pasid);
+	pkvm_dbg("%s: dev[%x:%x], pasid: %x ssptptr_gpa: %llx, did: %d\n", __func__,
+		 data->bus, data->devfn, data->pasid, data->ssptptr_gpa, data->did);
+
+	return intel_pasid_setup_second_level(iommu, &domain, &dev,
+					      data->did, data->pasid);
 }
 
 int pkvm_iommu_pasid_setup_sl(struct pasid_setup_sl_data *in, struct pasid_setup_sl_data *out)

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -233,31 +233,12 @@ int pkvm_iommu_set_sm_ce(struct set_sm_ce_data *in, struct set_sm_ce_data *out)
 	return ret;
 }
 
-static int __get_pasid_table(struct intel_iommu *iommu, u8 bus, u8 devfn, struct pasid_table *table)
-{
-	struct context_entry *context = iommu_context_addr(iommu, bus, devfn, false);
-	u32 pds;
-
-	if (!context || !context_present(context)) {
-		pkvm_err("%s: pasid directory table not found: device[%x:%x]\n",
-			 __func__, bus, devfn);
-		return -EINVAL;
-	}
-
-	pds = get_pasid_dir_size(context);
-	table->table = __pkvm_va(context->lo & VTD_PAGE_MASK);
-	table->max_pasid = pds << PASID_PDE_SHIFT;
-
-	return 0;
-}
-
 static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 {
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
 	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
-	struct pasid_table table = { 0 };
 	struct dmar_domain *domain;
 	int flags = 0, level, ret;
 	void *pgd;
@@ -286,16 +267,11 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 		return -EINVAL;
 	}
 
-	ret = __get_pasid_table(iommu, data->bus, data->devfn, &table);
-	if (ret)
-		return ret;
-
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
 	info.ats_enabled = info.ats_supported;
-	info.pasid_table = &table;
 	info.iommu = iommu;
 
 	ret = accept_page_donation(iommu, &data->donation_page_gpa);
@@ -356,7 +332,6 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
-	struct pasid_table table = { 0 };
 	struct dmar_domain *domain;
 	void *pgd;
 	int ret;
@@ -374,13 +349,8 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 		return -EPERM;
 	}
 
-	ret = __get_pasid_table(iommu, data->bus, data->devfn, &table);
-	if (ret)
-		return ret;
-
 	info.bus = data->bus;
 	info.devfn = data->devfn;
-	info.pasid_table = &table;
 	info.iommu = iommu;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
@@ -423,8 +393,6 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
-	struct pasid_table table = { 0 };
-	int ret;
 	struct dmar_domain *domain;
 
 	if (!iommu)
@@ -440,16 +408,11 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 		return -EPERM;
 	}
 
-	ret = __get_pasid_table(iommu, data->bus, data->devfn, &table);
-	if (ret)
-		return ret;
-
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
 	info.ats_enabled = info.ats_supported;
-	info.pasid_table = &table;
 	info.iommu = iommu;
 
 	pkvm_dbg("%s: dev[%x:%x], pasid: %x, ats_qdep: %d\n", __func__,

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -482,25 +482,8 @@ int pkvm_iommu_alloc_domain(struct alloc_domain_data *data)
 
 int pkvm_iommu_free_domain(u64 pgd_gpa, struct pkvm_memcache *mc)
 {
-	struct dmar_domain *domain;
-	void *pgd = pkvm_host_gpa_to_virt(pgd_gpa);
-	int ret;
-
-	domain = pkvm_get_iommu_domain_noref(pgd);
-	if (!domain) {
-		pkvm_err("%s: no domain exist for pgd: %p\n", __func__, pgd);
-		return -EINVAL;
-	}
-
 	memset(mc, 0, sizeof(*mc));
-	ret = pkvm_free_iommu_domain(domain, mc);
-	if (ret) {
-		pkvm_err("%s: failed to free the domain[pgd:%p] (err=%d)\n",
-			 __func__, pgd, ret);
-		return ret;
-	}
-
-	return ret;
+	return pkvm_free_iommu_domain(pgd_gpa, mc);
 }
 
 int pkvm_iommu_modify_irte(struct modify_irte_data *data)

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -32,7 +32,6 @@ int pkvm_iommu_iec_flush(u64 phys, int index, int mask, bool global)
 int pkvm_iommu_clear_ce(struct clear_ce_data *data)
 {
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
-	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct dmar_domain *domain;
 
@@ -41,19 +40,6 @@ int pkvm_iommu_clear_ce(struct clear_ce_data *data)
 
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
-
-	if (is_dev_in_satc(bdf)) {
-		/*
-		 * Device is in SATC and optimistically assuming that a well crafted SATC
-		 * would contain only physical functions, its safe to set pfsid = bdf.
-		 * TODO: We should probably be verifying SATC for existence of only
-		 * physical functions during pkvm initialization.
-		 */
-		if (ecap_dit(iommu->ecap))
-			info.pfsid = bdf;
-	} else if (data->ats_supported) {
-		return -EPERM;
-	}
 
 	info.iommu = iommu;
 	info.bus = data->bus;
@@ -110,12 +96,8 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
 
-	if (is_dev_in_satc(bdf)) {
-		if (ecap_dit(iommu->ecap))
-			info.pfsid = bdf;
-	} else if (data->ats_supported) {
+	if (data->ats_supported && !is_dev_in_satc(bdf))
 		return -EPERM;
-	}
 
 	info.bus = data->bus;
 	info.devfn = data->devfn;
@@ -123,6 +105,7 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
 	info.ats_enabled = info.ats_supported;
+	pkvm_populate_pfsid(&info);
 
 	ret = accept_page_donation(iommu, &data->donation_page_gpa);
 	if (ret)
@@ -195,15 +178,16 @@ static int iommu_set_sm_ce(struct set_sm_ce_data *data)
 
 	info.bus = data->bus;
 	info.devfn = data->devfn;
+	info.iommu = iommu;
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
 	info.ats_enabled = info.ats_supported;
+	pkvm_populate_pfsid(&info);
 	info.pasid_supported = data->pasid_supported;
 	info.pasid_enabled = data->pasid_enabled;
 	table.table = pkvm_host_gpa_to_virt(data->pasid_table_gpa);
 	table.max_pasid = data->max_pasid;
 	info.pasid_table = &table;
-	info.iommu = iommu;
 
 	ret = accept_page_donation(iommu, &data->donation_page_gpa);
 	if (ret)
@@ -240,7 +224,6 @@ int pkvm_iommu_set_sm_ce(struct set_sm_ce_data *in, struct set_sm_ce_data *out)
 static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 {
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
-	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
 	struct dmar_domain *domain;
@@ -255,13 +238,6 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
-
-	if (is_dev_in_satc(bdf)) {
-		if (ecap_dit(iommu->ecap))
-			info.pfsid = bdf;
-	} else if (data->ats_supported) {
-		return -EPERM;
-	}
 
 	if (data->did == FLPT_DEFAULT_DID) {
 		pkvm_err("%s: First-level setup not allowed for default domain\n", __func__);
@@ -334,7 +310,6 @@ int pkvm_iommu_pasid_setup_fl(struct pasid_setup_fl_data *in, struct pasid_setup
 static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 {
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
-	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
 	struct dmar_domain *domain;
@@ -349,13 +324,6 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
-
-	if (is_dev_in_satc(bdf)) {
-		if (ecap_dit(iommu->ecap))
-			info.pfsid = bdf;
-	} else if (data->ats_supported) {
-		return -EPERM;
-	}
 
 	info.bus = data->bus;
 	info.devfn = data->devfn;
@@ -396,7 +364,6 @@ int pkvm_iommu_pasid_setup_sl(struct pasid_setup_sl_data *in, struct pasid_setup
 int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 {
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
-	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
 	struct dmar_domain *domain;
@@ -409,13 +376,6 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
-
-	if (is_dev_in_satc(bdf)) {
-		if (ecap_dit(iommu->ecap))
-			info.pfsid = bdf;
-	} else if (data->ats_supported) {
-		return -EPERM;
-	}
 
 	info.bus = data->bus;
 	info.devfn = data->devfn;

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -259,8 +259,8 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	struct pkvm_device dev = { .info = &info };
 	struct pasid_table table = { 0 };
 	struct dmar_domain *domain;
+	int flags = 0, level, ret;
 	void *pgd;
-	int ret;
 
 	if (!iommu)
 		return -EINVAL;
@@ -278,6 +278,12 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	if (data->did == FLPT_DEFAULT_DID) {
 		pkvm_err("%s: First-level setup not allowed for default domain\n", __func__);
 		return -EPERM;
+	}
+
+	if (data->force_snoop && !ecap_sc_support(iommu->ecap)) {
+		pkvm_err("%s: iommu%d does not support snoop control\n",
+			 __func__, iommu->seq_id);
+		return -EINVAL;
 	}
 
 	ret = __get_pasid_table(iommu, data->bus, data->devfn, &table);
@@ -304,12 +310,32 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 		return -EINVAL;
 	}
 
+	ret = -EINVAL;
+	if (!domain->use_first_level) {
+		pkvm_err("%s: Domain did %d does not use first-level translation\n",
+			 __func__, data->did);
+		goto put_domain;
+	}
+
+	level = agaw_to_level(domain->agaw);
+	if (level != 4 && level != 5) {
+		pkvm_err("%s: Domain has invalid level %d\n",
+			 __func__, level);
+		goto put_domain;
+	}
+
 	pkvm_dbg("%s: dev[%x:%x], pasid: %x, fsptptr_gpa: %llx, did: %d\n", __func__,
 		 data->bus, data->devfn, data->pasid, data->fsptptr_gpa, data->did);
 
+	if (data->force_snoop)
+		flags |= PASID_FLAG_PAGE_SNOOP;
+	if (level == 5)
+		flags |= PASID_FLAG_FL5LP;
 	ret = intel_pasid_setup_first_level(iommu, domain, &dev,
 					    __pkvm_pa(pgd),
-					    data->pasid, data->did, data->flags);
+					    data->pasid, data->did, flags);
+
+put_domain:
 	if (ret)
 		pkvm_put_iommu_domain(domain);
 

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -34,6 +34,7 @@ int pkvm_iommu_clear_ce(struct clear_ce_data *data)
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
 	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
+	struct dmar_domain *domain;
 
 	if (!iommu)
 		return -EINVAL;
@@ -63,7 +64,9 @@ int pkvm_iommu_clear_ce(struct clear_ce_data *data)
 
 	pkvm_dbg("%s: dev[%x:%x], ats_qdep: %d\n",
 		 __func__, data->bus, data->devfn, data->ats_qdep);
-	domain_context_clear_one(&info, data->bus, data->devfn);
+	domain_context_clear_one(&info, data->bus, data->devfn, &domain);
+	if (domain)
+		pkvm_put_iommu_domain(domain);
 
 	return 0;
 }
@@ -96,7 +99,8 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 	struct intel_iommu *iommu = iommu_from_phys(data->phys);
 	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
-	struct dmar_domain domain = { 0 };
+	struct dmar_domain *domain;
+	void *pgd;
 	int ret;
 
 	if (!iommu)
@@ -118,29 +122,35 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 	info.ats_qdep = data->ats_qdep;
 	info.ats_supported = data->ats_supported;
 	info.ats_enabled = info.ats_supported;
-	if (data->did == FLPT_DEFAULT_DID) {
-		/*
-		 * Passthrough will break pkvm security guarantees as
-		 * device would be able to access the whole physical
-		 * memory range. Use Second stage translation with host ept
-		 * as second stage pagetable so as to limit device access
-		 * to host memory.
-		 */
-		domain.pgd = __pkvm_va(pkvm_host_ept_root());
-		domain.agaw = level_to_agaw(pkvm_host_ept_level());
-	} else {
-		domain.pgd = pkvm_host_gpa_to_virt(data->pgd_gpa);
-		domain.agaw = iommu->agaw;
-	}
 
 	ret = accept_page_donation(iommu, &data->donation_page_gpa);
 	if (ret)
 		return ret;
 
+	pgd = pkvm_host_gpa_to_virt(data->pgd_gpa);
+	domain = pkvm_get_iommu_domain(pgd, data->did);
+	if (!domain) {
+		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
+			 __func__, pgd);
+		return -EINVAL;
+	}
+
 	pkvm_dbg("%s: dev[%x:%x], did: %d, pgd: %p, agaw: %d\n", __func__,
-		 data->bus, data->devfn, data->did, domain.pgd, domain.agaw);
-	return domain_context_mapping_one(&domain, iommu, &info, data->did,
-					  data->bus, data->devfn);
+		 data->bus, data->devfn, data->did, domain->pgd,
+		 domain->agaw);
+	ret = domain_context_mapping_one(domain, iommu, &info, data->did,
+					 data->bus, data->devfn);
+	if (ret) {
+		pkvm_put_iommu_domain(domain);
+		/*
+		 * If entry already exists, the host expects
+		 * the hypercall to succeed.
+		 */
+		if (ret == -EEXIST)
+			ret = 0;
+	}
+
+	return ret;
 }
 
 int pkvm_iommu_set_lm_ce(struct set_lm_ce_data *in, struct set_lm_ce_data *out)
@@ -248,7 +258,8 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
 	struct pasid_table table = { 0 };
-	u64 fsptptr;
+	struct dmar_domain *domain;
+	void *pgd;
 	int ret;
 
 	if (!iommu)
@@ -273,7 +284,6 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	if (ret)
 		return ret;
 
-	fsptptr = pkvm_host_gpa_to_phys(data->fsptptr_gpa);
 	info.bus = data->bus;
 	info.devfn = data->devfn;
 	info.ats_qdep = data->ats_qdep;
@@ -286,11 +296,24 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	if (ret)
 		return ret;
 
+	pgd = pkvm_host_gpa_to_virt(data->fsptptr_gpa);
+	domain = pkvm_get_iommu_domain(pgd, data->did);
+	if (!domain) {
+		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
+			 __func__, pgd);
+		return -EINVAL;
+	}
+
 	pkvm_dbg("%s: dev[%x:%x], pasid: %x, fsptptr_gpa: %llx, did: %d\n", __func__,
 		 data->bus, data->devfn, data->pasid, data->fsptptr_gpa, data->did);
 
-	return intel_pasid_setup_first_level(iommu, &dev, fsptptr,
-					     data->pasid, data->did, data->flags);
+	ret = intel_pasid_setup_first_level(iommu, domain, &dev,
+					    __pkvm_pa(pgd),
+					    data->pasid, data->did, data->flags);
+	if (ret)
+		pkvm_put_iommu_domain(domain);
+
+	return ret;
 }
 
 int pkvm_iommu_pasid_setup_fl(struct pasid_setup_fl_data *in, struct pasid_setup_fl_data *out)
@@ -307,8 +330,9 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	u16 bdf = PCI_DEVID(data->bus, data->devfn);
 	struct device_domain_info info = { 0 };
 	struct pkvm_device dev = { .info = &info };
-	struct dmar_domain domain = { 0 };
 	struct pasid_table table = { 0 };
+	struct dmar_domain *domain;
+	void *pgd;
 	int ret;
 
 	if (!iommu)
@@ -336,30 +360,27 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	info.ats_supported = data->ats_supported;
 	info.ats_enabled = info.ats_supported;
 
-	if (data->did == FLPT_DEFAULT_DID) {
-		/*
-		 * Passthrough will break pkvm security guarantees as
-		 * device would be able to access the whole physical
-		 * memory range. Use Second stage translation with host ept
-		 * as second stage pagetable so as to limit device access
-		 * to host memory.
-		 */
-		domain.pgd = __pkvm_va(pkvm_host_ept_root());
-		domain.agaw = level_to_agaw(pkvm_host_ept_level());
-	} else {
-		domain.pgd = pkvm_host_gpa_to_virt(data->ssptptr_gpa);
-		domain.agaw = iommu->agaw;
-	}
-
 	ret = accept_page_donation(iommu, &data->donation_page_gpa);
 	if (ret)
 		return ret;
 
+	pgd = pkvm_host_gpa_to_virt(data->ssptptr_gpa);
+	domain = pkvm_get_iommu_domain(pgd, data->did);
+	if (!domain) {
+		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
+			 __func__, pgd);
+		return -EINVAL;
+	}
+
 	pkvm_dbg("%s: dev[%x:%x], pasid: %x ssptptr_gpa: %llx, did: %d\n", __func__,
 		 data->bus, data->devfn, data->pasid, data->ssptptr_gpa, data->did);
 
-	return intel_pasid_setup_second_level(iommu, &domain, &dev,
-					      data->did, data->pasid);
+	ret = intel_pasid_setup_second_level(iommu, domain, &dev,
+					     data->did, data->pasid);
+	if (ret)
+		pkvm_put_iommu_domain(domain);
+
+	return ret;
 }
 
 int pkvm_iommu_pasid_setup_sl(struct pasid_setup_sl_data *in, struct pasid_setup_sl_data *out)
@@ -378,6 +399,7 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 	struct pkvm_device dev = { .info = &info };
 	struct pasid_table table = { 0 };
 	int ret;
+	struct dmar_domain *domain;
 
 	if (!iommu)
 		return -EINVAL;
@@ -406,7 +428,10 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 
 	pkvm_dbg("%s: dev[%x:%x], pasid: %x, ats_qdep: %d\n", __func__,
 		 data->bus, data->devfn, data->pasid, data->ats_qdep);
-	intel_pasid_tear_down_entry(iommu, &dev, data->pasid, false);
+	intel_pasid_tear_down_entry(iommu, &dev, data->pasid, false, &domain);
+	if (domain)
+		pkvm_put_iommu_domain(domain);
+
 	return 0;
 }
 

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -118,6 +118,11 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 			 __func__, pgd);
 		return -EINVAL;
 	}
+	if (domain->use_first_level) {
+		pkvm_err("%s: Domain has use_first_level set, expected SL\n", __func__);
+		pkvm_put_iommu_domain(domain);
+		return -EINVAL;
+	}
 
 	pkvm_dbg("%s: dev[%x:%x], did: %d, pgd: %p, agaw: %d\n", __func__,
 		 data->bus, data->devfn, data->did, domain->pgd,
@@ -339,6 +344,11 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	if (!domain) {
 		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
 			 __func__, pgd);
+		return -EINVAL;
+	}
+	if (domain->use_first_level) {
+		pkvm_err("%s: Domain has use_first_level set, expected SL\n", __func__);
+		pkvm_put_iommu_domain(domain);
 		return -EINVAL;
 	}
 

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -106,6 +106,9 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 	if (!iommu)
 		return -EINVAL;
 
+	if (sm_supported(iommu))
+		return -EINVAL;
+
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
 
@@ -183,6 +186,9 @@ static int iommu_set_sm_ce(struct set_sm_ce_data *data)
 	if (!iommu)
 		return -EINVAL;
 
+	if (!sm_supported(iommu))
+		return -EINVAL;
+
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
 
@@ -244,6 +250,9 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 	void *pgd;
 
 	if (!iommu)
+		return -EINVAL;
+
+	if (!sm_supported(iommu))
 		return -EINVAL;
 
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
@@ -339,6 +348,9 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 	if (!iommu)
 		return -EINVAL;
 
+	if (!sm_supported(iommu))
+		return -EINVAL;
+
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)
 		return -EINVAL;
 
@@ -396,6 +408,9 @@ int pkvm_iommu_pasid_teardown(struct pasid_teardown_data *data)
 	struct dmar_domain *domain;
 
 	if (!iommu)
+		return -EINVAL;
+
+	if (!sm_supported(iommu))
 		return -EINVAL;
 
 	if (data->ats_qdep > PCI_ATS_MAX_QDEP)

--- a/drivers/iommu/intel/pkvm/iommu_hc.c
+++ b/drivers/iommu/intel/pkvm/iommu_hc.c
@@ -112,7 +112,7 @@ static int iommu_set_lm_ce(struct set_lm_ce_data *data)
 		return ret;
 
 	pgd = pkvm_host_gpa_to_virt(data->pgd_gpa);
-	domain = pkvm_get_iommu_domain(pgd, data->did);
+	domain = pkvm_get_iommu_domain(pgd, data->did, iommu);
 	if (!domain) {
 		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
 			 __func__, pgd);
@@ -260,7 +260,7 @@ static int iommu_pasid_setup_fl(struct pasid_setup_fl_data *data)
 		return ret;
 
 	pgd = pkvm_host_gpa_to_virt(data->fsptptr_gpa);
-	domain = pkvm_get_iommu_domain(pgd, data->did);
+	domain = pkvm_get_iommu_domain(pgd, data->did, iommu);
 	if (!domain) {
 		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
 			 __func__, pgd);
@@ -335,7 +335,7 @@ static int iommu_pasid_setup_sl(struct pasid_setup_sl_data *data)
 		return ret;
 
 	pgd = pkvm_host_gpa_to_virt(data->ssptptr_gpa);
-	domain = pkvm_get_iommu_domain(pgd, data->did);
+	domain = pkvm_get_iommu_domain(pgd, data->did, iommu);
 	if (!domain) {
 		pkvm_err("%s: Failed to locate domain with pgd: %p\n",
 			 __func__, pgd);

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -224,7 +224,7 @@ int pkvm_pasid_table_setup(struct intel_iommu *iommu, struct device_domain_info 
 }
 
 int pkvm_pasid_setup_fl(struct device_domain_info *info, phys_addr_t fsptptr,
-		      u32 pasid, u16 did, u16 old_did, int flags)
+		      u32 pasid, u16 did, int flags)
 {
 	union pkvm_hc_data d = { 0 };
 	struct pasid_setup_fl_data *data = &d.iommu_pasid_setup_fl.in;
@@ -236,7 +236,6 @@ int pkvm_pasid_setup_fl(struct device_domain_info *info, phys_addr_t fsptptr,
 	data->pasid = pasid;
 	data->flags = flags;
 	data->did = did;
-	data->old_did = old_did;
 	data->bus = info->bus;
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;
@@ -264,7 +263,7 @@ int pkvm_pasid_setup_fl(struct device_domain_info *info, phys_addr_t fsptptr,
 }
 
 int pkvm_pasid_setup_sl(struct device_domain_info *info, phys_addr_t ssptptr,
-			u32 pasid, u16 did, u16 old_did)
+			u32 pasid, u16 did)
 {
 	union pkvm_hc_data d = { 0 };
 	struct pasid_setup_sl_data *data = &d.iommu_pasid_setup_sl.in;
@@ -275,7 +274,6 @@ int pkvm_pasid_setup_sl(struct device_domain_info *info, phys_addr_t ssptptr,
 	data->ssptptr_gpa = ssptptr;
 	data->pasid = pasid;
 	data->did = did;
-	data->old_did = old_did;
 	data->bus = info->bus;
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -234,7 +234,7 @@ int pkvm_pasid_setup_fl(struct device_domain_info *info, phys_addr_t fsptptr,
 	data->phys = iommu->reg_phys;
 	data->fsptptr_gpa = fsptptr;
 	data->pasid = pasid;
-	data->flags = flags;
+	data->force_snoop = !!(flags & PASID_FLAG_PAGE_SNOOP);
 	data->did = did;
 	data->bus = info->bus;
 	data->devfn = info->devfn;

--- a/drivers/iommu/intel/pkvm_iommu.c
+++ b/drivers/iommu/intel/pkvm_iommu.c
@@ -139,7 +139,6 @@ int pkvm_context_clear(u64 phys, u8 bus, u8 devfn, struct device_domain_info *in
 	data->bus = bus;
 	data->devfn = devfn;
 	data->ats_qdep = info->ats_qdep;
-	data->ats_supported = info->ats_supported;
 
 	return pkvm_hypercall_in(iommu_clear_ce, &d);
 }
@@ -239,7 +238,6 @@ int pkvm_pasid_setup_fl(struct device_domain_info *info, phys_addr_t fsptptr,
 	data->bus = info->bus;
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;
-	data->ats_supported = info->ats_supported;
 
 	spin_lock(&iommu->lock);
 	ret = pkvm_hypercall_inout(iommu_pasid_setup_fl, &d, &d);
@@ -277,7 +275,6 @@ int pkvm_pasid_setup_sl(struct device_domain_info *info, phys_addr_t ssptptr,
 	data->bus = info->bus;
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;
-	data->ats_supported = info->ats_supported;
 
 	spin_lock(&iommu->lock);
 	ret = pkvm_hypercall_inout(iommu_pasid_setup_sl, &d, &d);
@@ -311,7 +308,6 @@ int pkvm_pasid_teardown(struct device_domain_info *info, u32 pasid)
 	data->bus = info->bus;
 	data->devfn = info->devfn;
 	data->ats_qdep = info->ats_qdep;
-	data->ats_supported = info->ats_supported;
 
 	return pkvm_hypercall_in(iommu_pasid_teardown, &d);
 }

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -185,8 +185,8 @@ bool pkvm_iommu_paging_structure_coherency(void);
 
 struct dmar_domain *pkvm_alloc_iommu_domain(struct alloc_domain_data *data,
 					    bool need_iotlb_sync_map);
-struct dmar_domain *pkvm_get_iommu_domain(void *pgd);
-struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd);
+struct dmar_domain *pkvm_get_iommu_domain(void *pgd, u16 did);
+struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd, u16 did);
 void pkvm_put_iommu_domain(struct dmar_domain *domain);
 int pkvm_free_iommu_domain(u64 pgd_gpa, struct pkvm_memcache *teardown_mc);
 

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -194,11 +194,6 @@ struct cache_tag *pkvm_alloc_cache_tag(void);
 void pkvm_free_cache_tag(struct cache_tag *cache_tag);
 void pkvm_iommu_pt_flush(unsigned long paddr, unsigned long size);
 
-int pkvm_get_domain_cache_tag_assign(void *pgd, int did, u32 pasid,
-				     struct device_domain_info *info);
-void pkvm_put_domain_cache_tag_unassign(void *pgd, int did, u32 pasid,
-					struct device_domain_info *info);
-
 int pkvm_intel_iommu_init(void);
 
 int pkvm_iommu_mmio_read(u64 phys, int len, u64 *val);

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -185,7 +185,8 @@ bool pkvm_iommu_paging_structure_coherency(void);
 
 struct dmar_domain *pkvm_alloc_iommu_domain(struct alloc_domain_data *data,
 					    bool need_iotlb_sync_map);
-struct dmar_domain *pkvm_get_iommu_domain(void *pgd, u16 did);
+struct dmar_domain *pkvm_get_iommu_domain(void *pgd, u16 did,
+					  struct intel_iommu *iommu);
 struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd, u16 did);
 void pkvm_put_iommu_domain(struct dmar_domain *domain);
 int pkvm_free_iommu_domain(u64 pgd_gpa, struct pkvm_memcache *teardown_mc);

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -188,7 +188,7 @@ struct dmar_domain *pkvm_alloc_iommu_domain(struct alloc_domain_data *data,
 struct dmar_domain *pkvm_get_iommu_domain(void *pgd);
 struct dmar_domain *pkvm_get_iommu_domain_noref(void *pgd);
 void pkvm_put_iommu_domain(struct dmar_domain *domain);
-int pkvm_free_iommu_domain(struct dmar_domain *domain, struct pkvm_memcache *teardown_mc);
+int pkvm_free_iommu_domain(u64 pgd_gpa, struct pkvm_memcache *teardown_mc);
 
 struct cache_tag *pkvm_alloc_cache_tag(void);
 void pkvm_free_cache_tag(struct cache_tag *cache_tag);

--- a/drivers/iommu/intel/pkvm_iommu.h
+++ b/drivers/iommu/intel/pkvm_iommu.h
@@ -121,9 +121,9 @@ int pkvm_context_mapping(struct intel_iommu *iommu, struct device_domain_info *i
 int pkvm_pasid_table_setup(struct intel_iommu *iommu, struct device_domain_info *info,
 			   u8 bus, u8 devfn);
 int pkvm_pasid_setup_fl(struct device_domain_info *info, phys_addr_t fsptptr,
-			u32 pasid, u16 did, u16 old_did, int flags);
+			u32 pasid, u16 did, int flags);
 int pkvm_pasid_setup_sl(struct device_domain_info *info, phys_addr_t ssptptr,
-			u32 pasid, u16 did, u16 old_did);
+			u32 pasid, u16 did);
 int pkvm_pasid_teardown(struct device_domain_info *info, u32 pasid);
 int pkvm_alloc_domain(struct device_domain_info *info, struct dmar_domain *domain);
 int pkvm_free_domain(struct dmar_domain *domain);
@@ -261,13 +261,13 @@ static inline int pkvm_pasid_table_setup(struct intel_iommu *iommu,
 }
 static inline int pkvm_pasid_setup_fl(struct device_domain_info *info,
 				      phys_addr_t fsptptr, u32 pasid,
-				      u16 did, u16 old_did, int flags)
+				      u16 did, int flags)
 {
 	return -EOPNOTSUPP;
 }
 static inline int pkvm_pasid_setup_sl(struct device_domain_info *info,
 				      phys_addr_t ssptptr, u32 pasid,
-				      u16 did, u16 old_did)
+				      u16 did)
 {
 	return -EOPNOTSUPP;
 }


### PR DESCRIPTION
## Summary

Backport 23 reviewed security and correctness fixes for the protected Intel
VT-d implementation, including PASID/context teardown serialization, IOMMU
domain lifetime, translation controls, cache-tag handling, and validation of
host-supplied domain state.

## Source

- Android common Gerrit series:
  https://android-review.googlesource.com/c/kernel/common/+/4172676

## VT-d prerequisite backports

The following two commits were cherry-picked from the upstream
`linux-6.18.y` stable tree before the 23-patch pKVM IOMMU series. They align
the PASID/context teardown logic with the source series and avoid conflicts
while applying its IOMMU fixes. The same commit objects also appear in the
Android common tree, so their object IDs are identical in both repositories:

- `821807c167b7` — iommu/vt-d: Clear Present bit before tearing down PASID entry
  https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.18.y&id=821807c167b7
- `d2138abc8f0a` — iommu/vt-d: Clear Present bit before tearing down context entry
  https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.18.y&id=d2138abc8f0a

## Validation

- Replayed all 25 commits independently onto
  `intel-staging/pKVM-IA:pkvm-v6.18`.
- Built successfully.
- Verified every `Fixes:` target is an earlier commit with the quoted subject.
- Verified clean pairwise merges with the other two backport series.
