### PR TITLE
pKVM: VMX: Handle unregistered user-return MSRs

### DIFF
--- a/arch/x86/kvm/pkvm/vmx/host_vmx.c
+++ b/arch/x86/kvm/pkvm/vmx/host_vmx.c
@@ -211,14 +211,14 @@ static int handle_write_msr(struct kvm_vcpu *vcpu)
 		BUG_ON(!pkvm_cpu_initialized(vcpu->cpu));
 
 		slot = kvm_find_user_return_msr(msr);
-		BUG_ON(slot < 0);
-
-		cur = kvm_get_user_return_msr(slot);
-		if (val != cur) {
-			pkvm_warn("Host attempt to modify user-return MSR 0x%lx: 0x%llx (expected 0x%llx)\n",
-				  msr, val, cur);
-			ret = X86EMUL_UNHANDLEABLE;
-			break;
+		if (slot >= 0) {
+			cur = kvm_get_user_return_msr(slot);
+			if (val != cur) {
+				pkvm_warn("Host attempt to modify user-return MSR 0x%lx: 0x%llx (expected 0x%llx)\n",
+					  msr, val, cur);
+				ret = X86EMUL_UNHANDLEABLE;
+				break;
+			}
 		}
 
 		if (wrmsr_safe(msr, low, high)) {


### PR DESCRIPTION
## Summary

Adding a patch for the changes I missed in PR #113 

This correction was included in revision 13 of the Android kernel change, but
was missed when the earlier revision was ported to the Intel tree. It follows
up merged commit `3bd17dc24aba` (`pKVM: VMX: Intercept host writes to
user-return MSRs`).

Android source:
https://android-review.googlesource.com/c/kernel/common/+/4175821/13

## Validation

- verified that the code matches the revision-13 delta exactly
- `git diff --check`
- `scripts/checkpatch.pl --strict -g HEAD`
- Build succesfully

