### PR TITLE
Build fixes for pkvm-6.18

### DIFF
--- a/arch/x86/include/asm/pkvm_image_vars.h
+++ b/arch/x86/include/asm/pkvm_image_vars.h
@@ -11,17 +11,27 @@
  */
 #define PKVM_ALIAS(sym)  pkvm_sym(sym) = sym;
 
+#ifdef CONFIG_PRINTK
 PKVM_ALIAS(_printk);
+PKVM_ALIAS(mem_dump_obj);
+#endif
+
 #ifdef CONFIG_BUG
 PKVM_ALIAS(__warn_printk);
 #endif
-PKVM_ALIAS(___ratelimit);
+
+#ifdef CONFIG_TRACING
 PKVM_ALIAS(__trace_bputs);
 PKVM_ALIAS(__trace_bprintk);
+#endif
+
+#ifdef CONFIG_DYNAMIC_DEBUG_CORE
 PKVM_ALIAS(__dynamic_pr_debug);
-PKVM_ALIAS(mem_dump_obj);
+#endif
+
+PKVM_ALIAS(___ratelimit);
 PKVM_ALIAS(vmalloc_base);
 PKVM_ALIAS(get_cpu_entry_area);
-#endif
+#endif /* CONFIG_PKVM_X86_DEBUG */
 
 #endif /* _ASM_X86_PKVM_IMAGE_VARS_H */

--- a/arch/x86/kvm/Kconfig
+++ b/arch/x86/kvm/Kconfig
@@ -137,7 +137,7 @@ config PKVM_X86
 config PKVM_INTEL
 	bool "pKVM for Intel processors support"
 	depends on KVM_INTEL=y
-	depends on INTEL_IOMMU
+	depends on INTEL_IOMMU && IRQ_REMAP
 	depends on BLK_DEV_FD=n
 	depends on X86_64
 	depends on X86_X2APIC


### PR DESCRIPTION
This PR adds two small fixes to address build failures when:

1. dynamic debug is disabled.
2. interrupt remapping is disabled.